### PR TITLE
Allow size_t from multiple headers.

### DIFF
--- a/gcc.symbols.imp
+++ b/gcc.symbols.imp
@@ -93,6 +93,11 @@
   { symbol: [ "useconds_t", private, "<unistd.h>", public ] },
   # glob.h seems to define size_t if necessary, but it should come from stddef.
   { symbol: [ "size_t", private, "<stddef.h>", public ] },
+  { symbol: [ "size_t", private, "<stdio.h>", public ] },
+  { symbol: [ "size_t", private, "<stdlib.h>", public ] },
+  { symbol: [ "size_t", private, "<string.h>", public ] },
+  { symbol: [ "size_t", private, "<time.h>", public ] },
+  { symbol: [ "size_t", private, "<wchar.h>", public ] },
   # Macros that can be defined in more than one file, don't have the
   # same __foo_defined guard that other types do, so the grep above
   # doesn't discover them.  Until I figure out a better way, I just

--- a/iwyu_include_picker.cc
+++ b/iwyu_include_picker.cc
@@ -171,7 +171,14 @@ const IncludeMapEntry libc_symbol_map[] = {
   { "useconds_t", kPrivate, "<sys/types.h>", kPublic },
   { "useconds_t", kPrivate, "<unistd.h>", kPublic },
   // glob.h seems to define size_t if necessary, but it should come from stddef.
-  { "size_t", kPrivate, "<stddef.h>", kPublic },
+  // It is unspecified if the cname headers provide ::size_t.
+  // <locale.h> is the one header which defines NULL but not size_t.
+  { "size_t", kPrivate, "<stddef.h>", kPublic },  // 'canonical' location for size_t
+  { "size_t", kPrivate, "<stdio.h>", kPublic },
+  { "size_t", kPrivate, "<stdlib.h>", kPublic },
+  { "size_t", kPrivate, "<string.h>", kPublic },
+  { "size_t", kPrivate, "<time.h>", kPublic },
+  { "size_t", kPrivate, "<wchar.h>", kPublic },
   // Macros that can be defined in more than one file, don't have the
   // same __foo_defined guard that other types do, so the grep above
   // doesn't discover them.  Until I figure out a better way, I just

--- a/tests/cxx/badinc-inl.h
+++ b/tests/cxx/badinc-inl.h
@@ -10,7 +10,7 @@
 #ifndef DEVTOOLS_MAINTENANCE_INCLUDE_WHAT_YOU_USE_BADINC_INL_H_
 #define DEVTOOLS_MAINTENANCE_INCLUDE_WHAT_YOU_USE_BADINC_INL_H_
 
-#include <time.h>   // one way to get NULL
+#include <locale.h>   // the way to get NULL without size_t
 #include "tests/cxx/badinc-private.h"
 #include "tests/cxx/badinc-private2.h"
 

--- a/tests/cxx/badinc.cc
+++ b/tests/cxx/badinc.cc
@@ -68,7 +68,8 @@
 #include UNUSED_INC
 // The following ilne is not needed, but use a 'keep' pragma anyway.
 #include <setjmp.h>   // IWYU pragma: keep
-#include <cwchar>     // for NULL (though we get NULL via badinc.h's stdio.h).
+#include <clocale>    // for NULL (though we get NULL via badinc.h's stdio.h).
+                      // clocale is chosen as it provides NULL but not size_t.
 #include <algorithm>  // try #including the same file twice
 #include <algorithm>  // ...and then 3 times
 
@@ -1067,7 +1068,7 @@ class CC_TemplateClass {
   typedef I1_TemplateClass<A> i1_typedef;
 
   // Let's throw in per-class operator new/delete.
-  // IWYU: size_t is...*<stddef.h>
+  // IWYU: size_t is...*((<stddef.h>)|(stdio.h)|(stdlib.h)|(string.h)|(time.h)|(wchar.h))
   void* operator new(size_t size) {
     B b;
     (void)b;
@@ -1980,7 +1981,7 @@ tests/cxx/badinc.cc should remove these lines:
 - #include <math.h>  // lines XX-XX
 - #include <algorithm>  // lines XX-XX
 - #include <algorithm>  // lines XX-XX
-- #include <cwchar>  // lines XX-XX
+- #include <clocale>  // lines XX-XX
 - #include <locale>  // lines XX-XX
 - #include "tests/cxx/badinc-d2.h"  // lines XX-XX
 - class Cc_ForwardDeclare_Function::I2_Class;  // lines XX-XX
@@ -1993,7 +1994,7 @@ The full include-list for tests/cxx/badinc.cc:
 #include <ctype.h>  // for isascii
 #include <setjmp.h>
 #include <stdarg.h>  // for va_list
-#include <stddef.h>  // for offsetof, size_t
+#include <stddef.h>  // for offsetof
 #include <stdlib.h>  // for rand
 #include <algorithm>  // for find
 #include <fstream>  // for fstream


### PR DESCRIPTION
According to the C language specification, size_t is defined by all
of stddef.h, stdio.h, stdlib.h, string.h, time.h, and wchar.h. Allow
size_t to be provided by any of these.

The tests must be updated to reflect this change. Currently cstdlib
and time.h are being used to obtain NULL, but these also now provide
size_t, which interferes with tests for size_t. Fortunately, locale.h
provides NULL but not size_t.