### PR TITLE
Assume override keyword support.

### DIFF
--- a/iwyu_preprocessor.h
+++ b/iwyu_preprocessor.h
@@ -170,26 +170,25 @@ class IwyuPreprocessorInfo : public clang::PPCallbacks,
   virtual void MacroExpands(const clang::Token& id,
                             const clang::MacroDefinition& definition,
                             clang::SourceRange range,
-                            const clang::MacroArgs* args) IWYU_OVERRIDE;
-  virtual void MacroDefined(
-      const clang::Token& id,
-      const clang::MacroDirective* directive) IWYU_OVERRIDE;
+                            const clang::MacroArgs* args) override;
+  virtual void MacroDefined(const clang::Token& id,
+                            const clang::MacroDirective* directive) override;
   // Not needed for iwyu:
   // virtual void MacroUndefined(const clang::Token&, const clang::MacroInfo*);
 
   virtual void If(clang::SourceLocation loc,
                   clang::SourceRange condition_range,
-                  ConditionValueKind condition_value) IWYU_OVERRIDE;
+                  ConditionValueKind condition_value) override;
   virtual void Elif(clang::SourceLocation loc,
                     clang::SourceRange condition_range,
                     ConditionValueKind condition_value,
-                    clang::SourceLocation if_loc) IWYU_OVERRIDE;
+                    clang::SourceLocation if_loc) override;
   virtual void Ifdef(clang::SourceLocation loc,
                      const clang::Token& id,
-                     const clang::MacroDefinition& definition) IWYU_OVERRIDE;
+                     const clang::MacroDefinition& definition) override;
   virtual void Ifndef(clang::SourceLocation loc,
                       const clang::Token& id,
-                      const clang::MacroDefinition& definition) IWYU_OVERRIDE;
+                      const clang::MacroDefinition& definition) override;
   // Not needed for iwyu:
   // virtual void Else();
   // virtual void Endif();
@@ -202,15 +201,15 @@ class IwyuPreprocessorInfo : public clang::PPCallbacks,
                                  const clang::FileEntry* file,
                                  llvm::StringRef search_path,
                                  llvm::StringRef relative_path,
-                                 const clang::Module* imported) IWYU_OVERRIDE;
+                                 const clang::Module* imported) override;
 
   virtual void FileChanged(clang::SourceLocation loc, FileChangeReason reason,
                            clang::SrcMgr::CharacteristicKind file_type,
-                           clang::FileID PrevFID) IWYU_OVERRIDE;
+                           clang::FileID PrevFID) override;
   virtual void FileSkipped(
       const clang::FileEntry& file,
       const clang::Token &filename,
-      clang::SrcMgr::CharacteristicKind file_type) IWYU_OVERRIDE;
+      clang::SrcMgr::CharacteristicKind file_type) override;
   // FileChanged is actually a multi-plexer for 4 different callbacks.
   void FileChanged_EnterFile(clang::SourceLocation file_beginning);
   void FileChanged_ExitToFile(clang::SourceLocation include_loc,
@@ -222,7 +221,7 @@ class IwyuPreprocessorInfo : public clang::PPCallbacks,
   // Clang doc: The handler shall return true if it has pushed any
   // tokens to be read using e.g. EnterToken or EnterTokenStream.
   virtual bool HandleComment(clang::Preprocessor& pp,
-                             clang::SourceRange comment_range) IWYU_OVERRIDE;
+                             clang::SourceRange comment_range) override;
 
  private:
   // Returns true if includee is considered part of the main

--- a/port.h
+++ b/port.h
@@ -15,20 +15,6 @@
 #include <iostream>
 #include "llvm/Support/Compiler.h"
 
-// Portable stub for Clang's __has_feature.
-#ifndef __has_feature
-# define __has_feature(x) 0
-#endif
-
-// Portable override keyword.
-// Use to mark virtual methods as overriding a base class method,
-// compiler will complain if method does not exist in base class.
-#if (defined(_MSC_VER) || __has_feature(cxx_override_control))
-#define IWYU_OVERRIDE override
-#else
-#define IWYU_OVERRIDE
-#endif
-
 // Count of statically allocated array.
 #define IWYU_ARRAYSIZE(arr) sizeof(arr) / sizeof(*arr)
 


### PR DESCRIPTION
We're past the time where `override` is not a supported keyword across all compilers necessary to compile LLVM.

This patch retires `IWYU_OVERRIDE` and just uses the keyword outright.