### PR TITLE
Update to reflect changes in Clang.

### DIFF
--- a/run_iwyu_tests.py
+++ b/run_iwyu_tests.py
@@ -81,7 +81,8 @@ class OneIwyuTest(unittest.TestCase):
     clang_flags_map = {
       'alias_template.cc': ['-std=c++11'],
       'auto_type_within_template.cc': ['-std=c++11'],
-      'catch.cc': ['-Xclang', '-fcxx-exceptions', '-Xclang', '-fexceptions'],
+      # MSVC targets need to explicitly enable exceptions, so we do it for all.
+      'catch.cc': ['-fcxx-exceptions', '-fexceptions'],
       'clmode.cc': ['--driver-mode=cl', '/C', '/Os', '/W2'],
       'conversion_ctor.cc': ['-std=c++11'],
       'deleted_implicit.cc' : ['-std=c++11'],

--- a/run_iwyu_tests.py
+++ b/run_iwyu_tests.py
@@ -81,6 +81,7 @@ class OneIwyuTest(unittest.TestCase):
     clang_flags_map = {
       'alias_template.cc': ['-std=c++11'],
       'auto_type_within_template.cc': ['-std=c++11'],
+      'catch.cc': ['-Xclang', '-fcxx-exceptions', '-Xclang', '-fexceptions'],
       'clmode.cc': ['--driver-mode=cl', '/C', '/Os', '/W2'],
       'conversion_ctor.cc': ['-std=c++11'],
       'deleted_implicit.cc' : ['-std=c++11'],


### PR DESCRIPTION
Clang r242176 disables exceptions by default for MSVC. They can be
re-enabled by passing `Xclang -fcxx-exceptions -Xclang -fexceptions` on
the command-line.

This patch does that for the only test that uses try/catch.