### PR TITLE
Clang in cl-mode now supports -fsyntax-only.

### DIFF
--- a/iwyu_driver.cc
+++ b/iwyu_driver.cc
@@ -179,11 +179,7 @@ CompilerInstance* CreateCompilerInstance(int argc, const char **argv) {
   // FIXME: This is a hack to try to force the driver to do something we can
   // recognize. We need to extend the driver library to support this use model
   // (basically, exactly one input, and the operation mode is hard wired).
-  driver.ParseDriverMode(args);
-  if (driver.IsCLMode())
-    args.push_back("/Zs");
-  else
-    args.push_back("-fsyntax-only");
+  args.push_back("-fsyntax-only");
 
   unique_ptr<Compilation> compilation(driver.BuildCompilation(args));
   if (!compilation)

--- a/run_iwyu_tests.py
+++ b/run_iwyu_tests.py
@@ -81,7 +81,7 @@ class OneIwyuTest(unittest.TestCase):
     clang_flags_map = {
       'alias_template.cc': ['-std=c++11'],
       'auto_type_within_template.cc': ['-std=c++11'],
-      'clmode.cc': ['--driver-mode=cl', '/C', '/Os', '/W2'],
+      'clmode.cc': ['--driver-mode=cl', '/GF', '/Os', '/W2'],
       'conversion_ctor.cc': ['-std=c++11'],
       'deleted_implicit.cc' : ['-std=c++11'],
       'lambda_fwd_decl.cc': ['-std=c++11'],


### PR DESCRIPTION
Per http://lists.cs.uiuc.edu/pipermail/cfe-commits/Week-of-Mon-20150413/127452.html.

Remove special-casing with /Zs.
Adjust test not to pass invalid args (/C now requires /P)
