### PR TITLE
Add support for using declarations

### DIFF
--- a/iwyu_test_util.py
+++ b/iwyu_test_util.py
@@ -69,7 +69,8 @@ def _Which(program, paths):
 
 def _GetIwyuPath(iwyu_paths):
   """Returns the path to IWYU or raises IOError if it cannot be found."""
-  iwyu_path = _Which('include-what-you-use', iwyu_paths)
+  #iwyu_path = _Which('include-what-you-use', iwyu_paths)
+  iwyu_path = "/home/chris/src/build/llvm/_target/gcc/bin/include-what-you-use"
   if iwyu_path:
       return iwyu_path
 

--- a/using_overload.cc
+++ b/using_overload.cc
@@ -1,0 +1,30 @@
+//===--- using_overload.cc - test input file for iwyu ---------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include <vector>
+#include <list>
+
+void use_overload() {  
+  std::vector<int> a(10);
+  std::vector<int> b(11);
+  using std::swap;
+  swap(a, b);
+}
+
+/**** IWYU_SUMMARY
+
+tests/cxx/using_overload.cc should add these lines:
+
+tests/cxx/using_overload.cc should remove these lines:
+- #include <list>  // lines XX-XX
+
+The full include-list for tests/cxx/using_overload.cc:
+#include <vector>  // for swap, vector
+
+***** IWYU_SUMMARY */

--- a/using_specialization.cc
+++ b/using_specialization.cc
@@ -1,0 +1,31 @@
+//===--- using_specialization.cc - test input file for iwyu ---------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+namespace ns {
+  #include "template_specialization-i1.h"
+  #include "template_specialization-i2.h"
+}
+
+void use_non_specialization() {
+  using ns::Foo;
+  Foo<float> f;
+}
+
+/**** IWYU_SUMMARY
+
+tests/cxx/using_specialization.cc should add these lines:
+
+tests/cxx/using_specialization.cc should remove these lines:
+- #include "template_specialization-i2.h"  // lines XX-XX
+
+The full include-list for tests/cxx/using_specialization.cc:
+#include "template_specialization-i1.h"  // for Foo
+
+***** IWYU_SUMMARY */
+


### PR DESCRIPTION
Add support for using declarations such that "using std::swap;" does not cause all std::swap headers to be included.

This was caused by the fact that IWYU marks all function references as requiring a full include (ie:  not forward declarable).  This makes sense for normal functions but not in the context of using declarations.

This change alters the logic as follows;

- Change adding all references of a using declaration from immediate to deferred
- Detect when something is accessed though a using declaration and add it as forward
declarable.
- If a using declaration is never referenced, arbitrarily add one of the symbols it
is referencing so that we don't remove all headers it refers to and break compilation.

The change also adds two tests to try to catch the problem.  The tests fail prior to the change and pass after the change.

Resolves issue #174 