### PR TITLE
Update to reflect changes in LLVM.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,7 +133,6 @@ target_link_libraries(include-what-you-use
   LLVMScalarOpts
   LLVMInstCombine
   LLVMTransformUtils
-  LLVMipa
   LLVMTarget # Analysis, MC, Core, Support
   LLVMAnalysis # Core, Support
   LLVMOption # Support


### PR DESCRIPTION
LLVM r245318 removed IPA library, folding the code into the main
Analysis library.