### PR TITLE
Fix issue #127: macro locations

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -431,17 +431,7 @@ class BaseAstVisitor : public RecursiveASTVisitor<Derived> {
 
   SourceLocation CurrentLoc() const {
     CHECK_(current_ast_node_ && "Call CurrentLoc within Visit* or Traverse*");
-    const SourceLocation loc = current_ast_node_->GetLocation();
-    if (!loc.isValid())
-      return loc;
-    // If the token is formed via macro concatenation, the spelling
-    // location will be in <scratch space>.  Use the instantiation
-    // location instead.
-    const SourceLocation spelling_loc = GetSpellingLoc(loc);
-    if (IsInMacro(loc) && StartsWith(PrintableLoc(spelling_loc), "<scratch "))
-      return GetInstantiationLoc(loc);
-    else
-      return spelling_loc;
+    return current_ast_node_->GetLocation();
   }
 
   string CurrentFilePath() const {
@@ -1380,30 +1370,71 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
     return type;
   }
 
-  // Re-assign uses from macro authors to macro callers when possible.
-  // With macros, it can be very difficult to tell what types are the
-  // responsibility of the macro-caller, and which the macro-author.  e.g.
-  //    #define SIZE_IN_FOOS(ptr)  ( sizeof(*ptr) / sizeof(Foo) )
-  // Here the type of *ptr is the responsibility of the caller, while the
-  // type of Foo is the responsibility of the author, even though the
-  // Exprs for *ptr and Foo are both located inside the macro (the Expr
-  // for ptr is located at the macro-calling site, but not for *ptr).
-  // To help us guess the owner, we use this rule: if the macro-file
-  // intends-to-provide the type, then we keep ownership of the type
-  // at the macro.  Otherwise, we assume it's with the caller.  This
-  // works well as long as the file defining the macro is well-behaved.
-  //   This function should be called with a use-loc that is within
-  // an expanded macro (so the use-loc will point to either inside a
-  // macro definition, or to an argument to a macro call).  If it
-  // points within a macro definition, and that macro-definition file
-  // does not mean to re-export the symbol being used, then we reassign
-  // use of the decl to the macro-caller.
-  SourceLocation GetUseLocationForMacroExpansion(SourceLocation use_loc,
-                                                 const Decl* used_decl) {
-    CHECK_(IsInMacro(use_loc) && "Unexpected non-macro-expansion call");
-    if (!preprocessor_info().PublicHeaderIntendsToProvide(
-            GetFileEntry(use_loc), GetFileEntry(used_decl)))
-      return GetInstantiationLoc(use_loc);
+  // Return any forward-declare of decl earlier in the same file as loc.
+  const NamedDecl* GetForwardDeclareInSameFile(const Decl* decl,
+                                               SourceLocation loc) {
+    set<const NamedDecl*> redecls = GetClassRedecls(DynCastFrom(decl));
+    for (const NamedDecl* redecl : redecls) {
+      if (IsBeforeInSameFile(redecl, loc)) {
+        return redecl;
+      }
+    }
+
+    return nullptr;
+  }
+
+  // Get the canonical use location for a (location, decl) pair.
+  // Decide whether the file expanding the macro or the file defining the macro
+  // should be held responsible for a use.
+  SourceLocation GetCanonicalUseLocation(SourceLocation use_loc,
+                                         const NamedDecl* decl) {
+    // If we're not in a macro, just echo the use location.
+    if (!IsInMacro(use_loc))
+      return use_loc;
+
+    // If we're in a macro, and the macro file forward-declares decl, make sure
+    // we keep that forward-declaration.
+    const NamedDecl* fwd_decl = GetForwardDeclareInSameFile(decl, use_loc);
+    if (fwd_decl) {
+      const FileEntry* used_in = GetFileEntry(use_loc);
+      preprocessor_info().FileInfoFor(used_in)->ReportForwardDeclareUse(
+          use_loc, decl, IsNodeInsideCXXMethodBody(current_ast_node()),
+          nullptr);
+    }
+
+    // Resolve the best use location based on our current knowledge.
+    //
+    // 1) If the macro definition file forward-declares the used decl, that's a
+    //    hint that it wants the expansion location to take responsibility.
+    // 2) If the symbol being used is passed as an argument to the macro, we
+    //    want the expansion location to take responsibility (that thing they
+    //    passed in is something they know about, and the macro doesn't.)
+    // 3) If the use_loc is in <scratch space>, we assume it's formed by macro
+    //    argument concatenation, and attribute responsibility to the expansion
+    //    location.
+    //
+    // Otherwise, the macro file is responsible for including the symbol.
+    SourceLocation expansion_loc = GetInstantiationLoc(use_loc);
+    const char* responsible = "expansion";
+
+    if (fwd_decl != nullptr) {
+      VERRS(5) << "Macro file has a forward-decl attribution hint.\n";
+      use_loc = expansion_loc;
+    } else if (IsInScratchSpace(use_loc)) {
+      VERRS(5) << "Decl was used in <scratch space>, presumably as a result of "
+                  "macro arg concatenation.\n";
+      use_loc = expansion_loc;
+    } else if (GlobalSourceManager()->isMacroArgExpansion(use_loc)) {
+      VERRS(5) << "Use location is a macro arg expansion.\n";
+      use_loc = expansion_loc;
+    } else {
+      responsible = "definition";
+    }
+
+    VERRS(5) << "Attributing " << decl->getNameAsString() << " use to macro "
+             << responsible << " location at " << PrintableLoc(use_loc)
+             << ".\n";
+
     return use_loc;
   }
 
@@ -1621,11 +1652,9 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
     if (CanIgnoreDecl(target_decl))
       return;
 
-    // Figure out the best location to attribute uses inside macros.
-    if (IsInMacro(used_loc))
-      used_loc = GetUseLocationForMacroExpansion(used_loc, target_decl);
+    // Canonicalize the use location and report the use.
+    used_loc = GetCanonicalUseLocation(used_loc, target_decl);
     const FileEntry* used_in = GetFileEntry(used_loc);
-
     preprocessor_info().FileInfoFor(used_in)->ReportFullSymbolUse(
         used_loc, target_decl, IsNodeInsideCXXMethodBody(current_ast_node()),
         comment);
@@ -1694,11 +1723,9 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
     if (CanIgnoreDecl(target_decl))
       return;
 
-    // Figure out the best location to attribute uses inside macros.
-    if (IsInMacro(used_loc))
-      used_loc = GetUseLocationForMacroExpansion(used_loc, target_decl);
+    // Canonicalize the use location and report the use.
+    used_loc = GetCanonicalUseLocation(used_loc, target_decl);
     const FileEntry* used_in = GetFileEntry(used_loc);
-
     preprocessor_info().FileInfoFor(used_in)->ReportForwardDeclareUse(
         used_loc, target_decl, IsNodeInsideCXXMethodBody(current_ast_node()),
         comment);

--- a/iwyu.cc
+++ b/iwyu.cc
@@ -2194,7 +2194,7 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
       if (!CanIgnoreType(dereftype))
         // This reports even if the expr ends up not being a reference, but
         // that's ok (if potentially redundant).
-        ReportTypeUse(GetLocation(arg_expr), dereftype);
+        ReportTypeUse(GetLocation(arg_expr->IgnoreParenImpCasts()), dereftype);
     }
     return true;
   }

--- a/iwyu_location_util.cc
+++ b/iwyu_location_util.cc
@@ -31,6 +31,7 @@ using clang::ConditionalOperator;
 using clang::FunctionDecl;
 using clang::MemberExpr;
 using clang::SourceLocation;
+using clang::UnaryOperator;
 using clang::UnresolvedMemberExpr;
 
 
@@ -142,6 +143,10 @@ SourceLocation GetLocation(const clang::Stmt* stmt) {
   } else if (const ConditionalOperator* conditional_op =
              DynCastFrom(stmt)) {
     return conditional_op->getQuestionLoc();
+  } else if (const UnaryOperator* unary_op = DynCastFrom(stmt)) {
+    // Drill through unary operators and parentheses, to get at the underlying
+    // DeclRefExpr or whatever, e.g. '*(x)' should give the location of 'x'
+    stmt = unary_op->getSubExpr()->IgnoreParenImpCasts();
   }
 
   return stmt->getLocStart();

--- a/iwyu_location_util.cc
+++ b/iwyu_location_util.cc
@@ -167,4 +167,8 @@ SourceLocation GetLocation(const clang::TemplateArgumentLoc* argloc) {
   return argloc->getLocation();
 }
 
+bool IsInScratchSpace(SourceLocation loc) {
+  return PrintableLoc(GetSpellingLoc(loc)) == "<scratch space>";
+}
+
 }  // namespace include_what_you_use

--- a/iwyu_location_util.h
+++ b/iwyu_location_util.h
@@ -82,6 +82,12 @@ inline bool IsBuiltinOrCommandLineFile(const clang::FileEntry* file) {
   return IsBuiltinFile(file) || (!strcmp(file->getName(), "<command line>"));
 }
 
+// When macro args are concatenated e.g. '#define CAT(A, B) A##B', their
+// location ends up outside the source text, in what the compiler calls
+// "<scratch space>".
+// This function returns true if the provided loc is in scratch space.
+bool IsInScratchSpace(clang::SourceLocation loc);
+
 inline string GetFilePath(const clang::FileEntry* file) {
   return (IsBuiltinFile(file) ? "<built-in>" :
           NormalizeFilePath(file->getName()));

--- a/tests/cxx/macro_location-d2.h
+++ b/tests/cxx/macro_location-d2.h
@@ -9,6 +9,12 @@
 
 #include "tests/cxx/macro_location-d1.h"
 
+// The forward-declare is a hint that the use should be attributed
+// to users of the DECLARE_INDIRECT macro, not this file.
+class IndirectClass;
+
+#define DECLARE_INDIRECT(name) IndirectClass name;
+
 #define ARRAYSIZE(x)  ( sizeof(x) / sizeof(*(x)) )
 
 #define NEW_CLASS(name)                         \

--- a/tests/cxx/macro_location.h
+++ b/tests/cxx/macro_location.h
@@ -6,7 +6,7 @@
 // License. See LICENSE.TXT for details.
 //
 //===----------------------------------------------------------------------===//
-
+#include "tests/cxx/indirect.h"
 #include "tests/cxx/macro_location-d2.h"
 #include "tests/cxx/macro_location-d3.h"
 
@@ -23,7 +23,9 @@ NEW_CLASS(Bar);
 USE_CLASS(HClass);
 // This shouldn't cause macro_location-d1.h to need to include us for HClass.
 CREATE_VAR(HClass);
-
+// This should force us to #include a definition of IndirectClass, because it's
+// forward-declared by DECLARE_INDIRECT's file.
+DECLARE_INDIRECT(global_indirect);
 
 /**** IWYU_SUMMARY
 
@@ -35,7 +37,8 @@ tests/cxx/macro_location.h should remove these lines:
 - class Foo;  // lines XX-XX
 
 The full include-list for tests/cxx/macro_location.h:
-#include "tests/cxx/macro_location-d2.h"  // for ARRAYSIZE, CREATE_VAR, NEW_CLASS, USE_CLASS
+#include "tests/cxx/indirect.h"  // for IndirectClass
+#include "tests/cxx/macro_location-d2.h"  // for ARRAYSIZE, CREATE_VAR, DECLARE_INDIRECT, NEW_CLASS, USE_CLASS
 #include "tests/cxx/macro_location-i3.h"  // for Foo
 
 


### PR DESCRIPTION
This is a replacement for PR #189 and I believe it actually works (with test to prove it!)

Background: the challenge is that macro authors want to be able to push #include responsibility onto callers of the macro by introducing a heuristic forward-declare (only used for the purpose of signalling to IWYU that the macro file is not responsible.)

IWYU's prior approach to macro locations was too eager, it committed to the instantiation loc already in `CurrentLoc`, where we didn't really know what the location would be used for.

While working on delaying this decision, I found a bug with locations of unary operators, which confused the location for things like `#define ARRAYSIZE(x) sizeof(x) / sizeof(*(x))` where the second `sizeof` would register as a use, but its location could not be mapped to the macro argument.

Then I instituted the new rules:

- If a use location is known to be part of a macro argument, we attribute it to callers. Anything passed as argument to a macro is the caller's responsibility.
- If a use location is in scratch space, it's the result of concatenation of macro arguments. See above
- If there's a forward declaration of the used decl in the file defining the macro, the macro rejects responsiblity and the caller becomes responsible (this matches what we do for typedefs.)

Unfortunately the last one turned out to be problematic -- if the macro file is part of the IWYU analysis, a "nudging" forward-declare will typically not have any use inside the macro file, and IWYU would suggest that we remove it. Since it was basically just a marker, IWYU would short-circuit itself, and the next IWYU run would attribute the symbol to the macro, causing all sorts of weirdness.

The last commit fixes that problem by reporting the marker fwd-decl as used by the macro's spelling location.

These changes finally made it possible for me to change the macro_location test to also include the forward-declare construct.

@dpunset, please try this out in your codebase. @vsapsai, please review this critically, I'd like to refine it a bit more, but I've worked on it so long I'm basically blind.