### PR TITLE
Part of fix for the issue #166.  Follow typedef chains in templates.

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -1475,6 +1475,37 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
     return true;
   }
 
+  // Returns the first type that is not a typedef in a template.  For example,
+  // for template
+  //
+  //   template<typename T> class Foo {
+  //     typedef T value_type;
+  //     typedef value_type& reference;
+  //   };
+  //
+  // for type 'reference' it will return type T with which Foo was instantiated.
+  const Type* DesugarDependentTypedef(const TypedefType* typedef_type) {
+    const DeclContext* parent
+        = typedef_type->getDecl()->getLexicalDeclContext();
+    if (const ClassTemplateSpecializationDecl* template_parent
+        = DynCastFrom(parent)) {
+      return DesugarDependentTypedef(typedef_type, template_parent);
+    }
+    return typedef_type;
+  }
+
+  const Type* DesugarDependentTypedef(
+      const TypedefType* typedef_type, const RecordDecl* parent) {
+    const Type* underlying_type
+        = typedef_type->getDecl()->getUnderlyingType().getTypePtr();
+    if (const TypedefType* underlying_typedef = DynCastFrom(underlying_type)) {
+      if (underlying_typedef->getDecl()->getLexicalDeclContext() == parent) {
+        return DesugarDependentTypedef(underlying_typedef, parent);
+      }
+    }
+    return underlying_type;
+  }
+
   set<const Type*> GetCallerResponsibleTypesForTypedef(
       const TypedefDecl* decl) {
     set<const Type*> retval;
@@ -2086,6 +2117,9 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
         = expr->isArrow() ? RemovePointerFromType(base_type) : base_type;
     if (CanIgnoreType(base_type) && CanIgnoreType(deref_base_type))
       return true;
+    if (const TypedefType* typedef_type = DynCastFrom(deref_base_type)) {
+      deref_base_type = DesugarDependentTypedef(typedef_type);
+    }
     // Technically, we should say the type is being used at the
     // location of base_expr.  That may be a different file than us in
     // cases like MACRO.b().  However, while one can imagine

--- a/tests/cxx/typedef_chain_class.h
+++ b/tests/cxx/typedef_chain_class.h
@@ -1,0 +1,21 @@
+//===--- typedef_chain_class.h - test input file for iwyu -----------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// Simple class to use in typedef chains.  Similar to IndirectClass but without
+// concerns if it is a direct include or indirect.
+
+#ifndef DEVTOOLS_MAINTENANCE_INCLUDE_WHAT_YOU_USE_TESTS_TYPEDEF_CHAIN_CLASS_H_
+#define DEVTOOLS_MAINTENANCE_INCLUDE_WHAT_YOU_USE_TESTS_TYPEDEF_CHAIN_CLASS_H_
+
+class TypedefChainClass {
+ public:
+  void Method() const { };
+};
+
+#endif  // DEVTOOLS_MAINTENANCE_INCLUDE_WHAT_YOU_USE_TESTS_TYPEDEF_CHAIN_CLASS_H_

--- a/tests/cxx/typedef_chain_in_template-d1.h
+++ b/tests/cxx/typedef_chain_in_template-d1.h
@@ -1,0 +1,22 @@
+//===--- typedef_chain_in_template-d1.h - test input file for iwyu --------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// This header mimics std::vector in libstdc++.
+
+#include "tests/cxx/typedef_chain_in_template-i1.h"
+
+template<typename T>
+class ContainerAsLibstdcpp {
+ public:
+  typedef T value_type;
+  typedef typename TypedefWrapper<T>::reference reference;
+  reference GetContent() { return content_; }
+ private:
+  value_type content_;
+};

--- a/tests/cxx/typedef_chain_in_template-d2.h
+++ b/tests/cxx/typedef_chain_in_template-d2.h
@@ -1,0 +1,20 @@
+//===--- typedef_chain_in_template-d2.h - test input file for iwyu --------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// This header mimics std::vector in libc++.
+
+template<typename T>
+class ContainerAsLibcpp {
+ public:
+  typedef T value_type;
+  typedef value_type& reference;
+  reference GetContent() { return content_; }
+ private:
+  value_type content_;
+};

--- a/tests/cxx/typedef_chain_in_template-d3.h
+++ b/tests/cxx/typedef_chain_in_template-d3.h
@@ -1,0 +1,21 @@
+//===--- typedef_chain_in_template-d3.h - test input file for iwyu --------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// Container that tests typedef chains shorter than in libc++.
+
+template<typename T>
+class ContainerShortTypedefChain {
+ private:
+  T content_;
+ public:
+  T& GetContent1() { return content_; }
+
+  typedef T& reference;
+  reference GetContent2() { return content_; }
+};

--- a/tests/cxx/typedef_chain_in_template-d4.h
+++ b/tests/cxx/typedef_chain_in_template-d4.h
@@ -1,0 +1,25 @@
+//===--- typedef_chain_in_template-d4.h - test input file for iwyu --------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// Container that tests typedef chains longer than in libc++.
+
+template<typename T>
+class ContainerLongTypedefChain {
+ public:
+  typedef T value_type;
+  typedef value_type& reference;
+  typedef reference& reference_reference;
+  reference_reference GetContent1() { return content_; }
+
+  typedef reference reference2;
+  typedef reference2 reference3;
+  reference3 GetContent2() { return content_; }
+ private:
+  value_type content_;
+};

--- a/tests/cxx/typedef_chain_in_template-i1.h
+++ b/tests/cxx/typedef_chain_in_template-i1.h
@@ -1,0 +1,16 @@
+//===--- typedef_chain_in_template-i1.h - test input file for iwyu --------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// This header mimics ext/alloc_traits.h in libstdc++.
+
+template<typename T>
+struct TypedefWrapper {
+  typedef T value_type;
+  typedef value_type& reference;
+};

--- a/tests/cxx/typedef_chain_in_template.cc
+++ b/tests/cxx/typedef_chain_in_template.cc
@@ -1,0 +1,61 @@
+//===--- typedef_chain_in_template.cc - test input file for iwyu ----------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// Tests that if template declares a typedef depending on template argument,
+// IWYU follows the typedef chain and uses underlying type that is not a
+// typedef depending on template argument.  Usually such typedefs are template
+// implementation details and template clients should not use these typedefs
+// directly.
+
+#include "tests/cxx/typedef_chain_in_template-d1.h"
+#include "tests/cxx/typedef_chain_in_template-d2.h"
+#include "tests/cxx/typedef_chain_in_template-d3.h"
+#include "tests/cxx/typedef_chain_in_template-d4.h"
+#include "tests/cxx/typedef_chain_class.h"
+// Unused include to trigger IWYU summary telling what symbols are used from
+// every file.
+#include "tests/cxx/direct.h"
+
+void UsageAsWithLibstdcpp() {
+  ContainerAsLibstdcpp<TypedefChainClass> c;
+  c.GetContent().Method();
+}
+
+void UsageAsWithLibcpp() {
+  ContainerAsLibcpp<TypedefChainClass> c;
+  c.GetContent().Method();
+}
+
+void UsageWithShorterTypedefChain() {
+  ContainerShortTypedefChain<TypedefChainClass> c;
+  c.GetContent1().Method();
+  c.GetContent2().Method();
+}
+
+void UsageWithLongerTypedefChain() {
+  ContainerLongTypedefChain<TypedefChainClass> c;
+  c.GetContent1().Method();
+  c.GetContent2().Method();
+}
+
+/**** IWYU_SUMMARY
+
+tests/cxx/typedef_chain_in_template.cc should add these lines:
+
+tests/cxx/typedef_chain_in_template.cc should remove these lines:
+- #include "tests/cxx/direct.h"  // lines XX-XX
+
+The full include-list for tests/cxx/typedef_chain_in_template.cc:
+#include "tests/cxx/typedef_chain_class.h"  // for TypedefChainClass
+#include "tests/cxx/typedef_chain_in_template-d1.h"  // for ContainerAsLibstdcpp
+#include "tests/cxx/typedef_chain_in_template-d2.h"  // for ContainerAsLibcpp
+#include "tests/cxx/typedef_chain_in_template-d3.h"  // for ContainerShortTypedefChain
+#include "tests/cxx/typedef_chain_in_template-d4.h"  // for ContainerLongTypedefChain
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/typedef_chain_no_follow-d1.h
+++ b/tests/cxx/typedef_chain_no_follow-d1.h
@@ -1,0 +1,12 @@
+//===--- typedef_chain_no_follow-d1.h - test input file for iwyu ----------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/typedef_chain_class.h"
+
+typedef TypedefChainClass TypedefChainTypedef;

--- a/tests/cxx/typedef_chain_no_follow-d2.h
+++ b/tests/cxx/typedef_chain_no_follow-d2.h
@@ -1,0 +1,21 @@
+//===--- typedef_chain_no_follow-d2.h - test input file for iwyu ----------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// Declares typedef inside a class.
+
+#include "tests/cxx/typedef_chain_class.h"
+
+class NonContainer1 {
+ public:
+  typedef TypedefChainClass value_type;
+  typedef value_type& reference;
+
+  value_type tcc_;
+  reference GetTypedefChainClass() { return tcc_; }
+};

--- a/tests/cxx/typedef_chain_no_follow-d3.h
+++ b/tests/cxx/typedef_chain_no_follow-d3.h
@@ -1,0 +1,23 @@
+//===--- typedef_chain_no_follow-d3.h - test input file for iwyu ----------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// Declares typedef inside a template, typedef does not depend on template
+// argument.
+
+#include "tests/cxx/typedef_chain_class.h"
+
+template<typename T>
+class NonContainer2 {
+ public:
+  typedef TypedefChainClass value_type;
+  typedef value_type& reference;
+
+  value_type tcc_;
+  reference GetTypedefChainClass() { return tcc_; }
+};

--- a/tests/cxx/typedef_chain_no_follow.cc
+++ b/tests/cxx/typedef_chain_no_follow.cc
@@ -1,0 +1,52 @@
+//===--- typedef_chain_no_follow.cc - test input file for iwyu ------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// Tests cases when IWYU should not follow typedef chain and should not suggest
+// to include a file for underlying typedef type.
+
+#include "tests/cxx/typedef_chain_no_follow-d1.h"
+#include "tests/cxx/typedef_chain_no_follow-d2.h"
+#include "tests/cxx/typedef_chain_no_follow-d3.h"
+// Unused include to trigger IWYU summary telling what symbols are used from
+// every file.
+#include "tests/cxx/direct.h"
+
+void TypedefDeclaredInGlobalNamespace() {
+  TypedefChainTypedef tct;
+  tct.Method();
+}
+
+// Tests how we handle a typedef declared in a class.  Main purpose is to make
+// sure we handle typedefs in templates the same way as typedefs in classes
+// when typedef does not depend on template argument.
+void TypedefDeclaredInClass() {
+  NonContainer1 nc;
+  nc.GetTypedefChainClass().Method();
+}
+
+// Tests that we don't follow typedef chain and don't suggest to use
+// TypedefChainClass directly.
+void TypedefDeclaredInTemplate() {
+  NonContainer2<int> nc;
+  nc.GetTypedefChainClass().Method();
+}
+
+/**** IWYU_SUMMARY
+
+tests/cxx/typedef_chain_no_follow.cc should add these lines:
+
+tests/cxx/typedef_chain_no_follow.cc should remove these lines:
+- #include "tests/cxx/direct.h"  // lines XX-XX
+
+The full include-list for tests/cxx/typedef_chain_no_follow.cc:
+#include "tests/cxx/typedef_chain_no_follow-d1.h"  // for TypedefChainTypedef
+#include "tests/cxx/typedef_chain_no_follow-d2.h"  // for NonContainer1, NonContainer1::value_type
+#include "tests/cxx/typedef_chain_no_follow-d3.h"  // for NonContainer2, NonContainer2::value_type
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
First of all, it doesn't fix the issue #166 completely. Now IWYU suggests to include `<memory>  // for allocator_traits<>::value_type` instead of `<ext/alloc_traits.h>  // for __alloc_traits<>::value_type`. But I believe it is the movement in the right direction.

I want to mention that in this change I didn't try to handle alias templates and nested templates. Another issue is that most likely `VisitMemberExpr` is not the only place that should use `GetFirstNonTemplateTypedef`. My plan is to investigate if `GetCallerResponsibleTypesForTypedef` should use it, todos look quite promising.

Also I wasn't able to come up with a test case that executes lines
```c++
if (underlying_typedef->getDecl()->getLexicalDeclContext() == parent) {
  return GetFirstNonTemplateTypedef(underlying_typedef, parent);
}
```
Looks like Clang doesn't allow such cases but I prefer to keep this code to not rely on current Clang implementation and because its intention is correct.

In the process of fixing the issue I've discovered the following cases:
```c++
// tests/cxx/issue166_extra_test-i1.h
#ifndef DEVTOOLS_MAINTENANCE_INCLUDE_WHAT_YOU_USE_TESTS_ISSUE166_EXTRA_TEST_I1_H_
#define DEVTOOLS_MAINTENANCE_INCLUDE_WHAT_YOU_USE_TESTS_ISSUE166_EXTRA_TEST_I1_H_

template<typename T>
class Container {
 public:
  typedef T value;
  typedef value& reference;

  value content_;
  reference getContent() { return content_; }
};

#endif  // DEVTOOLS_MAINTENANCE_INCLUDE_WHAT_YOU_USE_TESTS_ISSUE166_EXTRA_TEST_I1_H_
```
```c++
// tests/cxx/issue166_extra_test-d1.h
#include "tests/cxx/issue166_extra_test-i1.h"

template<typename T>
class NonContainer {
 public:
  typedef Container<T> value;
  typedef value& reference;

  value container_;
  reference getContainer() { return container_; }
};
```
```c++
// tests/cxx/issue166_extra_test.cc
#include "tests/cxx/issue166_extra_test-d1.h"
#include "tests/cxx/indirect.h"

void usage() {
  NonContainer<IndirectClass> nc;
  nc.getContainer().getContent().Method();
}
```
```c++
// tests/cxx/issue166_extra_test2.cc
#include "tests/cxx/issue166_extra_test-i1.h"
#include "tests/cxx/indirect.h"

void usage() {
  Container<IndirectClass> c;
}
```

`tests/cxx/issue166_extra_test.cc` is not that serious, it merely suggest to add `#include "tests/cxx/issue166_extra_test-i1.h"  // for Container`. `tests/cxx/issue166_extra_test2.cc` on the other hand suggests to replace `#include "tests/cxx/indirect.h"` with a forward declaration which breaks the compilation. I think it is almost identical to the issue #169 and can be fixed by applying `GetFirstNonTemplateTypedef` in the right place.