### PR TITLE
Fix #216: Allow user to specify IWYU path to test

### DIFF
--- a/docs/InstructionsForDevelopers.md
+++ b/docs/InstructionsForDevelopers.md
@@ -18,7 +18,19 @@ To run the IWYU tests, run
 
     python run_iwyu_tests.py
 
-It runs one test for each `.cc` file in the `tests/` directory.  (We have additional tests in `more_tests/`, but have not yet gotten the testing framework set up for those tests.)  The output can be a bit hard to read, but if a test fails, the reason why will be listed after the `ERROR:root:Test failed for xxx` line.
+It runs one test for each `.cc` file in the `tests/` directory.  (We have additional tests in `more_tests/`, but have not yet gotten the testing framework set up for those tests.) The test runner searches for IWYU in the system `PATH` by default.
+
+The output can be a bit hard to read, but if a test fails, the reason why will be listed after the `ERROR:root:Test failed for xxx` line.
+
+You can select individual tests by listing their filename without extension as arguments
+
+    python run_iwyu_tests.py array macro_location
+
+If you don't want to modify your `PATH` you can specify which IWYU executable to use for testing
+
+    python run_iwyu_tests.py -- ./include-what-you-use
+
+(put any test names before '--' and the IWYU path after.)
 
 When fixing `fix_includes.py`, add a test case to `fix_includes_test.py` and run
 

--- a/iwyu_test_util.py
+++ b/iwyu_test_util.py
@@ -67,15 +67,7 @@ def _Which(program, paths):
     return None
 
 
-def _GetIwyuPath(iwyu_paths):
-  """Returns the path to IWYU or raises IOError if it cannot be found."""
-  iwyu_path = _Which('include-what-you-use', iwyu_paths)
-  if iwyu_path:
-      return iwyu_path
-
-  raise IOError('Failed to locate IWYU.\nSearched\n %s' % '\n '.join(iwyu_paths))
-
-
+_IWYU_PATH = None
 _SYSTEM_PATHS = [p.strip('"') for p in os.environ["PATH"].split(os.pathsep)]
 _IWYU_PATHS = [
     '../../../../Debug+Asserts/bin',
@@ -94,7 +86,27 @@ _IWYU_PATHS = [
     '../../../../../build/bin/MinSizeRel',
     '../../../../../build/bin/RelWithDebInfo',
     ]
-_IWYU_PATH = _GetIwyuPath(_IWYU_PATHS + _SYSTEM_PATHS)
+
+
+def SetIwyuPath(iwyu_path):
+  """Set the path to the IWYU executable under test.
+  """
+  global _IWYU_PATH
+  _IWYU_PATH = iwyu_path
+
+
+def _GetIwyuPath():
+  """Returns the path to IWYU or raises IOError if it cannot be found."""
+  global _IWYU_PATH
+
+  if not _IWYU_PATH:
+    iwyu_paths = _IWYU_PATHS + _SYSTEM_PATHS
+    _IWYU_PATH = _Which('include-what-you-use', iwyu_paths)
+    if not _IWYU_PATH:
+      raise IOError('Failed to locate IWYU.\nSearched\n %s' %
+                    '\n '.join(iwyu_paths))
+
+  return _IWYU_PATH
 
 
 def _GetCommandOutput(command):
@@ -404,7 +416,7 @@ def TestIwyuOnRelativeFile(test_case, cc_file, cpp_files_to_check,
 
   # TODO(csilvers): verify that has exit-status 0.
   cmd = '%s %s %s %s' % (
-      _IWYU_PATH, ' '.join(iwyu_flags), ' '.join(clang_flags), cc_file)
+      _GetIwyuPath(), ' '.join(iwyu_flags), ' '.join(clang_flags), cc_file)
   if verbose:
     print('>>> Running %s' % cmd)
   output = _GetCommandOutput(cmd)

--- a/run_iwyu_tests.py
+++ b/run_iwyu_tests.py
@@ -30,6 +30,15 @@ def PosixPath(path):
     return path.replace('\\', '/')
 
 
+def Partition(l, delimiter):
+  try:
+    delim_index = l.index(delimiter)
+  except ValueError:
+    return l, []
+
+  return l[:delim_index], l[delim_index+1:]
+
+
 class OneIwyuTest(unittest.TestCase):
   """Superclass for tests.  A subclass per test-file is created at runtime."""
 
@@ -167,6 +176,10 @@ def RegisterFilesForTesting(rootdir, pattern):
 
 
 if __name__ == '__main__':
+  unittest_args, additional_args = Partition(sys.argv, '--')
+  if additional_args:
+    iwyu_test_util.SetIwyuPath(additional_args[0])
+
   RegisterFilesForTesting('tests/cxx', '*.cc')
   RegisterFilesForTesting('tests/c', '*.c')
-  unittest.main()
+  unittest.main(argv=unittest_args)


### PR DESCRIPTION
Add an optional command-line argument to run_iwyu_tests.py, to specify
which IWYU binary to test with. Usage example:

  $ ./run_iwyu_tests.py -- ./include-what-you-use

The '--' delimiter is used to separate args going to Python's unittest
from the new arg used by the test runner.