### PR TITLE
Fix #232: Pick up revision from Git instead of SVN

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,15 +63,15 @@ else()
   message(STATUS "IWYU in-tree configuration")
 endif()
 
-# Pick up SVN revision so we can report it
-# in version information.
-include(FindSubversion)
-if( Subversion_FOUND AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.svn" )
-  Subversion_WC_INFO(${CMAKE_CURRENT_SOURCE_DIR} IWYU)
+# Pick up Git revision so we can report it in version information.
+include(FindGit)
+if( GIT_FOUND )
+  execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse --short HEAD
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    OUTPUT_VARIABLE IWYU_GIT_REV
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
 endif()
-add_definitions(
-  -DIWYU_SVN_REVISION="${IWYU_WC_REVISION}"
-)
+add_definitions(-DIWYU_GIT_REV="${IWYU_GIT_REV}")
 
 add_executable(include-what-you-use
   iwyu.cc

--- a/Makefile
+++ b/Makefile
@@ -35,11 +35,11 @@ ifneq (,$(filter $(HOST_OS), Cygwin MingW))
   LIBS += -lshlwapi
 endif
 
-# Provide SVN revision for version string like in clang/lib/Basic/Makefile.
-IWYU_SVN_REVISION := $(strip \
+# Provide Git revision for version string like in clang/lib/Basic/Makefile.
+IWYU_GIT_REV := $(strip \
         $(shell $(LLVM_SRC_ROOT)/utils/GetSourceVersion $(PROJ_SRC_DIR)))
 
-CPP.Defines += -DIWYU_SVN_REVISION='"$(IWYU_SVN_REVISION)"'
+CPP.Defines += -DIWYU_GIT_REV='"$(IWYU_GIT_REV)"'
 
 check-iwyu:: all
 	./run_iwyu_tests.py

--- a/iwyu_globals.cc
+++ b/iwyu_globals.cc
@@ -103,10 +103,10 @@ static void PrintHelp(const char* extra_msg) {
 
 static void PrintVersion() {
   llvm::outs() << "include-what-you-use " << IWYU_VERSION_STRING;
-  // IWYU_SVN_REVISION should be provided by build system.
-  string iwyu_svn_revision = IWYU_SVN_REVISION;
-  if (!iwyu_svn_revision.empty()) {
-    llvm::outs() << " (" << iwyu_svn_revision << ")";
+  // IWYU_GIT_REV should be provided by build system.
+  string iwyu_rev = IWYU_GIT_REV;
+  if (!iwyu_rev.empty()) {
+    llvm::outs() << " (git:" << iwyu_rev << ")";
   }
   llvm::outs() << " based on " << clang::getClangFullVersion()
                << "\n";


### PR DESCRIPTION
Let me know what you think. Example output:

    $ include-what-you-use.exe --version
    include-what-you-use 0.5 (20c4f5f) based on clang version 3.8.0 (trunk 248605)
