### PR TITLE
Clean up third-party license listing

### DIFF
--- a/LICENSE.TXT
+++ b/LICENSE.TXT
@@ -61,9 +61,4 @@ licenses, and/or restrictions:
 
 Program             Directory
 -------             ---------
-Autoconf            llvm/autoconf
-                    llvm/projects/ModuleMaker/autoconf
-                    llvm/projects/sample/autoconf
-CellSPU backend     llvm/lib/Target/CellSPU/README.txt
-Google Test         llvm/utils/unittest/googletest
-OpenBSD regex       llvm/lib/Support/{reg*, COPYRIGHT.regex}
+getopt_port         include-what-you-use/iwyu_getopt.*


### PR DESCRIPTION
The only third-party package we use is an adapted copy of kimgr's
getopt_port, so mention that.

This is a fix for https://github.com/include-what-you-use/include-what-you-use.org/issues/1, filed in the wrong project.