### PR TITLE
Fix #210: Avoid mis-stripping of same path prefix

### DIFF
--- a/iwyu_globals.cc
+++ b/iwyu_globals.cc
@@ -297,7 +297,7 @@ static vector<HeaderSearchPath> ComputeHeaderSearchPaths(
            it = header_search->system_dir_begin();
        it != header_search->system_dir_end(); ++it) {
     if (const DirectoryEntry* entry = it->getDir()) {
-      const string path = CanonicalizeFilePath(entry->getName());
+      const string path = CanonicalizeHeaderSearchPath(entry->getName());
       search_path_map[path] = HeaderSearchPath::kSystemPath;
     }
   }
@@ -308,7 +308,7 @@ static vector<HeaderSearchPath> ComputeHeaderSearchPaths(
       // search_dir_begin()/end() includes both system and user paths.
       // If it's a system path, it's already in the map, so everything
       // new is a user path.  The insert only 'takes' for new entries.
-      const string path = CanonicalizeFilePath(entry->getName());
+      const string path = CanonicalizeHeaderSearchPath(entry->getName());
       search_path_map.insert(make_pair(path, HeaderSearchPath::kUserPath));
     }
   }
@@ -406,11 +406,12 @@ void InitGlobalsAndFlagsForTesting() {
 
   // Use a reasonable default for the -I flags.
   map<string, HeaderSearchPath::Type> search_path_map;
-  search_path_map["/usr/include"] = HeaderSearchPath::kSystemPath;
-  search_path_map["/usr/include/c++/4.3"] = HeaderSearchPath::kSystemPath;
-  search_path_map["/usr/include/c++/4.2"] = HeaderSearchPath::kSystemPath;
-  search_path_map["."] = HeaderSearchPath::kUserPath;
-  search_path_map["/usr/src/linux-headers-2.6.24-gg23/include"] = HeaderSearchPath::kSystemPath;
+  search_path_map["/usr/include/"] = HeaderSearchPath::kSystemPath;
+  search_path_map["/usr/include/c++/4.3/"] = HeaderSearchPath::kSystemPath;
+  search_path_map["/usr/include/c++/4.2/"] = HeaderSearchPath::kSystemPath;
+  search_path_map["./"] = HeaderSearchPath::kUserPath;
+  search_path_map["/usr/src/linux-headers-2.6.24-gg23/include/"] =
+      HeaderSearchPath::kSystemPath;
 
   SetHeaderSearchPaths(NormalizeHeaderSearchPaths(search_path_map));
 }

--- a/iwyu_globals.cc
+++ b/iwyu_globals.cc
@@ -283,7 +283,6 @@ static vector<HeaderSearchPath> NormalizeHeaderSearchPaths(
     include_dirs.push_back(HeaderSearchPath(it->first, it->second));
   }
 
-
   sort(include_dirs.begin(), include_dirs.end(), &SortByDescendingLength);
   return include_dirs;
 }

--- a/iwyu_path_util.cc
+++ b/iwyu_path_util.cc
@@ -96,6 +96,17 @@ string CanonicalizeFilePath(const string& path) {
   return result;
 }
 
+string CanonicalizeHeaderSearchPath(const string& path) {
+  string result = CanonicalizeFilePath(path);
+
+  // We want a trailing slash on all header search paths, because it makes it
+  // much easier to find the longest common path prefix.
+  if (!EndsWith(result, "/"))
+    result += "/";
+
+  return result;
+}
+
 string GetCanonicalName(string file_path) {
   // Get rid of any <> and "" in case file_path is really an #include line.
   StripLeft(&file_path, "\"") || StripLeft(&file_path, "<");
@@ -177,8 +188,9 @@ string ConvertToQuotedInclude(const string& filepath) {
   // loop will prefer the longest prefix: /usr/include/c++/4.4/foo
   // will be mapped to <foo>, not <c++/4.4/foo>.
   for (Each<HeaderSearchPath> it(&search_paths); !it.AtEnd(); ++it) {
+    // All header search paths have a trailing "/", so we'll get a perfect
+    // quoted include by just stripping the prefix.
     if (StripLeft(&path, it->path)) {
-      StripLeft(&path, "/");
       if (it->path_type == HeaderSearchPath::kSystemPath)
         return "<" + path + ">";
       else

--- a/iwyu_path_util.cc
+++ b/iwyu_path_util.cc
@@ -84,7 +84,7 @@ string CanonicalizeFilePath(const string& path) {
   string result = path;
 
 #ifdef _WIN32
-  // canonicalise directory separators (forward slashes considered canonical)
+  // Canonicalise directory separators (forward slashes considered canonical.)
   for (size_t i = 0; i < result.size(); ++i) {
     if (result[i] == '\\')
       result[i] = '/';
@@ -197,7 +197,6 @@ string ConvertToQuotedInclude(const string& filepath) {
         return "\"" + path + "\"";
     }
   }
-
 
   // Case 2: Uses the implicit "-I." entry on the search path.  Always local.
   return "\"" + path + "\"";

--- a/iwyu_path_util.h
+++ b/iwyu_path_util.h
@@ -46,6 +46,9 @@ string Basename(const string& path);
 // On Microsoft platforms, convert \ to /.
 string CanonicalizeFilePath(const string& path);
 
+// Canonicalize slashes and ensure trailing slash.
+string CanonicalizeHeaderSearchPath(const string& path);
+
 // Removes enclosing <> or "", then strips uninteresting suffixes from
 // the file name. Replaces "/internal/" with "/public/" and
 // "/include/" with "/src".  "Canonicalize" the path on Microsoft


### PR DESCRIPTION
If two paths in the header search set shared the same prefix, IWYU would
sometimes pick the wrong one and produce an invalid quoted include. For
example:

Header search path: /a/foo, /a/foobar
File path: /a/foobar/header.h

This would yield "bar/header.h", as "/a/foo" was considered a basename of
the file path.

We fix this by ensuring all search path entries end with "/".

I didn't add a test for this, because an end-to-end test would be almost
nonsensical. Once we get the unit test suite up and running, I'd like to
add a test for this there instead.