### PR TITLE
Update to reflect getOptionalExplicitTemplateArgs changes in Clang.

### DIFF
--- a/iwyu_ast_util.h
+++ b/iwyu_ast_util.h
@@ -798,9 +798,8 @@ const clang::FunctionType* GetCalleeFunctionType(clang::CallExpr* expr);
 bool IsCastToReferenceType(const clang::CastExpr* expr);
 
 // Returns the list of explicit template args for all exprs that support
-// such a concept (declrefexpr, memberexpr), and NULL if none is present.
-const clang::ASTTemplateArgumentListInfo* GetExplicitTplArgs(
-    const clang::Expr* expr);
+// such a concept (declrefexpr, memberexpr), and empty list if none is present.
+clang::TemplateArgumentListInfo GetExplicitTplArgs(const clang::Expr* expr);
 
 }  // namespace include_what_you_use
 


### PR DESCRIPTION
Clang r256359 removed `getOptionalExplicitTemplateArgs` on various Expr
subclasses. Use
  `void copyTemplateArgumentsInto(TemplateArgumentListInfo &List) const`
instead.

`const ASTTemplateKWAndArgsInfo *getTemplateKWAndArgsInfo() const` doesn't look
like appropriate replacement because it checks only `HasTemplateKWAndArgsInfo`
and we'll need to do `hasExplicitTemplateArgs()` checks ourselves.