### PR TITLE
Fix #245: SOCK_STREAM attributed to bits/socket_type.h

### DIFF
--- a/gcc.libc.imp
+++ b/gcc.libc.imp
@@ -72,6 +72,7 @@
   { include: [ "<bits/sockaddr.h>", private, "<sys/un.h>", public ] },
   { include: [ "<bits/socket.h>", private, "<sys/socket.h>", public ] },
   { include: [ "<bits/socket2.h>", private, "<sys/socket.h>", public ] },
+  { include: [ "<bits/socket_type.h>", private, "<sys/socket.h>", public ] },
   { include: [ "<bits/stab.def>", private, "<stab.h>", public ] },
   { include: [ "<bits/stat.h>", private, "<sys/stat.h>", public ] },
   { include: [ "<bits/statfs.h>", private, "<sys/statfs.h>", public ] },

--- a/iwyu_include_picker.cc
+++ b/iwyu_include_picker.cc
@@ -310,6 +310,7 @@ const IncludeMapEntry libc_include_map[] = {
   { "<bits/sockaddr.h>", kPrivate, "<sys/un.h>", kPublic },
   { "<bits/socket.h>", kPrivate, "<sys/socket.h>", kPublic },
   { "<bits/socket2.h>", kPrivate, "<sys/socket.h>", kPublic },
+  { "<bits/socket_type.h>", kPrivate, "<sys/socket.h>", kPublic },
   { "<bits/stab.def>", kPrivate, "<stab.h>", kPublic },
   { "<bits/stat.h>", kPrivate, "<sys/stat.h>", kPublic },
   { "<bits/statfs.h>", kPrivate, "<sys/statfs.h>", kPublic },


### PR DESCRIPTION
Add mapping from bits/socket_type.h -> sys/socket.h.