### PR TITLE
Add better build target for unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,7 +110,7 @@ else()
 endif()
 
 # Clang dependencies.
-target_link_libraries(include-what-you-use
+list(APPEND IWYU_LINK_LIBS
   clangFrontend
   clangSerialization
   clangDriver
@@ -124,7 +124,7 @@ target_link_libraries(include-what-you-use
 )
 
 # LLVM dependencies.
-target_link_libraries(include-what-you-use
+list(APPEND IWYU_LINK_LIBS
   LLVMX86AsmParser # MC, MCParser, Support, X86CodeGen, X86Desc, X86Info
   LLVMX86CodeGen # Analysis, AsmPrinter, CodeGen, Core, MC, Support, Target, 
                  # X86AsmPrinter, X86Desc, X86Info, X86Utils
@@ -151,12 +151,12 @@ target_link_libraries(include-what-you-use
 
 # Platform dependencies.
 if( WIN32 )
-  target_link_libraries(include-what-you-use
+  list(APPEND IWYU_LINK_LIBS
     shlwapi
   )
 elseif( UNIX )
   include(FindCurses)
-  target_link_libraries(include-what-you-use
+  list(APPEND IWYU_LINK_LIBS
     pthread
     z
     ${CURSES_LIBRARIES}
@@ -167,6 +167,8 @@ else()
     "Unknown system: ${CMAKE_SYSTEM_NAME}. "
     "No platform link-dependencies added.")
 endif()
+
+target_link_libraries(include-what-you-use ${IWYU_LINK_LIBS})
 
 install(TARGETS include-what-you-use RUNTIME DESTINATION bin)
 install(PROGRAMS fix_includes.py iwyu_tool.py DESTINATION bin)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,8 +73,7 @@ if( GIT_FOUND )
 endif()
 add_definitions(-DIWYU_GIT_REV="${IWYU_GIT_REV}")
 
-add_executable(include-what-you-use
-  iwyu.cc
+add_library(IWYU_OBJECTS OBJECT
   iwyu_ast_util.cc
   iwyu_cache.cc
   iwyu_driver.cc
@@ -87,6 +86,11 @@ add_executable(include-what-you-use
   iwyu_path_util.cc
   iwyu_preprocessor.cc
   iwyu_verrs.cc
+)
+
+add_executable(include-what-you-use
+  iwyu.cc
+  $<TARGET_OBJECTS:IWYU_OBJECTS>
 )
 
 if( MSVC )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ if( CMAKE_SOURCE_DIR STREQUAL IWYU_SOURCE_DIR )
 
   if( DEFINED IWYU_LLVM_INCLUDE_PATH AND DEFINED IWYU_LLVM_LIB_PATH )
     # User provided include/lib paths, fall through
-  elseif ( DEFINED IWYU_LLVM_ROOT_PATH )
+  elseif( DEFINED IWYU_LLVM_ROOT_PATH )
     # Synthesize include/lib relative to a root.
     set(IWYU_LLVM_INCLUDE_PATH ${IWYU_LLVM_ROOT_PATH}/include)
     set(IWYU_LLVM_LIB_PATH ${IWYU_LLVM_ROOT_PATH}/lib)
@@ -174,3 +174,5 @@ target_link_libraries(include-what-you-use ${IWYU_LINK_LIBS})
 
 install(TARGETS include-what-you-use RUNTIME DESTINATION bin)
 install(PROGRAMS fix_includes.py iwyu_tool.py DESTINATION bin)
+
+add_subdirectory(more_tests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,9 @@ cmake_minimum_required(VERSION 2.8)
 
 project(include-what-you-use)
 
-if( CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR )
+set(IWYU_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+
+if( CMAKE_SOURCE_DIR STREQUAL IWYU_SOURCE_DIR )
   message(STATUS "IWYU out-of-tree configuration")
 
   if( DEFINED LLVM_PATH )

--- a/more_tests/CMakeLists.txt
+++ b/more_tests/CMakeLists.txt
@@ -1,0 +1,53 @@
+# This build leans on three variables from the parent project:
+#
+# - IWYU_SOURCE_DIR -- the source root directory of IWYU
+# - IWYU_OBJECTS -- an OBJECT library of all IWYU object files
+# - IWYU_LINK_LIBS -- a list of all IWYU link dependencies
+#
+# In an out-of-tree build, it needs to know where to find GTest, and so
+# accepts IWYU_GTEST_INCLUDE_PATH and IWYU_GTEST_LIB_PATH. These are optional
+# as GTest may be installed in a system root already.
+
+function(warn_optional VARNAME)
+  message(WARNING
+    "${VARNAME} not provided, assuming GTest is available on default "
+    "search path.")
+endfunction(warn_optional)
+
+if( CMAKE_SOURCE_DIR STREQUAL IWYU_SOURCE_DIR )
+  # Out-of-tree build.
+  if( DEFINED IWYU_GTEST_INCLUDE_PATH )
+    include_directories(${IWYU_GTEST_INCLUDE_PATH})
+  else()
+    warn_optional("IWYU_GTEST_INCLUDE_PATH")
+  endif()
+
+  if( DEFINED IWYU_GTEST_LIB_PATH )
+    link_directories(${IWYU_GTEST_LIB_PATH})
+  else()
+    warn_optional("IWYU_GTEST_LIB_PATH")
+  endif()
+else()
+  # In-tree build, pick up GTest from LLVM.
+  include_directories(${LLVM_MAIN_SRC_DIR}/utils/unittest/googletest/include)
+endif()
+
+# Configure GTest.
+add_definitions(-DGTEST_HAS_RTTI=0)
+
+# Need to be able to find the IWYU headers.
+include_directories(${IWYU_SOURCE_DIR})
+
+add_executable(include-what-you-use-tests
+  $<TARGET_OBJECTS:IWYU_OBJECTS>
+  # iwyu_include_picker_test.cc
+  # iwyu_lexer_utils_test.cc
+  # iwyu_output_test.cc
+  # iwyu_string_util_test.cc
+  test_main.cc
+)
+
+target_link_libraries(include-what-you-use-tests
+  gtest
+  ${IWYU_LINK_LIBS}
+)

--- a/more_tests/CMakeLists.txt
+++ b/more_tests/CMakeLists.txt
@@ -40,7 +40,7 @@ include_directories(${IWYU_SOURCE_DIR})
 
 add_executable(include-what-you-use-tests
   $<TARGET_OBJECTS:IWYU_OBJECTS>
-  # iwyu_include_picker_test.cc
+  iwyu_include_picker_test.cc
   iwyu_lexer_utils_test.cc
   # iwyu_output_test.cc
   iwyu_string_util_test.cc

--- a/more_tests/CMakeLists.txt
+++ b/more_tests/CMakeLists.txt
@@ -43,7 +43,7 @@ add_executable(include-what-you-use-tests
   # iwyu_include_picker_test.cc
   # iwyu_lexer_utils_test.cc
   # iwyu_output_test.cc
-  # iwyu_string_util_test.cc
+  iwyu_string_util_test.cc
   test_main.cc
 )
 

--- a/more_tests/CMakeLists.txt
+++ b/more_tests/CMakeLists.txt
@@ -41,7 +41,7 @@ include_directories(${IWYU_SOURCE_DIR})
 add_executable(include-what-you-use-tests
   $<TARGET_OBJECTS:IWYU_OBJECTS>
   # iwyu_include_picker_test.cc
-  # iwyu_lexer_utils_test.cc
+  iwyu_lexer_utils_test.cc
   # iwyu_output_test.cc
   iwyu_string_util_test.cc
   test_main.cc

--- a/more_tests/iwyu_string_util_test.cc
+++ b/more_tests/iwyu_string_util_test.cc
@@ -9,13 +9,11 @@
 
 
 // Tests for the iwyu_string_util module.
-
 #include "iwyu_string_util.h"
 
 #include <string>
-
-
-// TODO(dsturtevant): using string for MOE.
+#include <vector>
+#include "gtest/gtest.h"
 
 namespace iwyu = include_what_you_use;
 using iwyu::SplitOnWhiteSpace;
@@ -25,9 +23,9 @@ using iwyu::StripWhiteSpaceRight;
 using iwyu::StripWhiteSpace;
 
 #define TEST_OPERATION(op, in, expected_out) { \
-  string str = in; \
+  std::string str = in; \
   op(&str); \
-  EXPECT_EQ(string(expected_out), str); \
+  EXPECT_EQ(std::string(expected_out), str); \
 }
 
 TEST(IwyuStringUtilTest, StripWhiteSpaceLeft) {
@@ -56,67 +54,62 @@ TEST(IwyuStringUtilTest, StripWhiteSpace) {
 }
 
 TEST(IwyuStringUtilTest, SplitOnWhiteSpace) {
-  string in = "this is a test";
-  vector<string> out = SplitOnWhiteSpace(in, 0);
+  std::string in = "this is a test";
+  std::vector<std::string> out = SplitOnWhiteSpace(in, 0);
   ASSERT_EQ(4, out.size());
-  EXPECT_EQ(string("this"), out[0]);
-  EXPECT_EQ(string("is"), out[1]);
-  EXPECT_EQ(string("a"), out[2]);
-  EXPECT_EQ(string("test"), out[3]);
+  EXPECT_EQ(std::string("this"), out[0]);
+  EXPECT_EQ(std::string("is"), out[1]);
+  EXPECT_EQ(std::string("a"), out[2]);
+  EXPECT_EQ(std::string("test"), out[3]);
 
   in = "this is a test";
   out = SplitOnWhiteSpace(in, 2);
   ASSERT_EQ(2, out.size());
-  EXPECT_EQ(string("this"), out[0]);
-  EXPECT_EQ(string("is"), out[1]);
+  EXPECT_EQ(std::string("this"), out[0]);
+  EXPECT_EQ(std::string("is"), out[1]);
 
   in = "this is\ta    test";
   out = SplitOnWhiteSpace(in, 0);
   ASSERT_EQ(4, out.size());
-  EXPECT_EQ(string("this"), out[0]);
-  EXPECT_EQ(string("is"), out[1]);
-  EXPECT_EQ(string("a"), out[2]);
-  EXPECT_EQ(string("test"), out[3]);
+  EXPECT_EQ(std::string("this"), out[0]);
+  EXPECT_EQ(std::string("is"), out[1]);
+  EXPECT_EQ(std::string("a"), out[2]);
+  EXPECT_EQ(std::string("test"), out[3]);
 
   in = " this is a test ";
   out = SplitOnWhiteSpace(in, 0);
   ASSERT_EQ(4, out.size());
-  EXPECT_EQ(string("this"), out[0]);
-  EXPECT_EQ(string("is"), out[1]);
-  EXPECT_EQ(string("a"), out[2]);
-  EXPECT_EQ(string("test"), out[3]);
+  EXPECT_EQ(std::string("this"), out[0]);
+  EXPECT_EQ(std::string("is"), out[1]);
+  EXPECT_EQ(std::string("a"), out[2]);
+  EXPECT_EQ(std::string("test"), out[3]);
 }
 
 TEST(IwyuStringUtilTest, SplitOnWhiteSpacePreservingQuotes) {
-  string in = "this is <a test>";
-  vector<string> out = SplitOnWhiteSpacePreservingQuotes(in, 0);
+  std::string in = "this is <a test>";
+  std::vector<std::string> out = SplitOnWhiteSpacePreservingQuotes(in, 0);
   ASSERT_EQ(3, out.size());
-  EXPECT_EQ(string("this"), out[0]);
-  EXPECT_EQ(string("is"), out[1]);
-  EXPECT_EQ(string("<a test>"), out[2]);
+  EXPECT_EQ(std::string("this"), out[0]);
+  EXPECT_EQ(std::string("is"), out[1]);
+  EXPECT_EQ(std::string("<a test>"), out[2]);
 
   in = "this <is a> test";
   out = SplitOnWhiteSpacePreservingQuotes(in, 2);
   ASSERT_EQ(2, out.size());
-  EXPECT_EQ(string("this"), out[0]);
-  EXPECT_EQ(string("<is a>"), out[1]);
+  EXPECT_EQ(std::string("this"), out[0]);
+  EXPECT_EQ(std::string("<is a>"), out[1]);
 
   in = "\"this is\"\ta    test";
   out = SplitOnWhiteSpacePreservingQuotes(in, 0);
   ASSERT_EQ(3, out.size());
-  EXPECT_EQ(string("\"this is\""), out[0]);
-  EXPECT_EQ(string("a"), out[1]);
-  EXPECT_EQ(string("test"), out[2]);
+  EXPECT_EQ(std::string("\"this is\""), out[0]);
+  EXPECT_EQ(std::string("a"), out[1]);
+  EXPECT_EQ(std::string("test"), out[2]);
 
   in = " this is \"a test\" ";
   out = SplitOnWhiteSpacePreservingQuotes(in, 0);
   ASSERT_EQ(3, out.size());
-  EXPECT_EQ(string("this"), out[0]);
-  EXPECT_EQ(string("is"), out[1]);
-  EXPECT_EQ(string("\"a test\""), out[2]);
-}
-
-int main(int argc, char** argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
+  EXPECT_EQ(std::string("this"), out[0]);
+  EXPECT_EQ(std::string("is"), out[1]);
+  EXPECT_EQ(std::string("\"a test\""), out[2]);
 }

--- a/more_tests/test_main.cc
+++ b/more_tests/test_main.cc
@@ -1,8 +1,31 @@
 #include "iwyu_globals.h"
 #include "gtest/gtest.h"
 
+#if defined(_WIN32)
+#include <windows.h>
+#if defined(_MSC_VER)
+#include <crtdbg.h>
+#endif  // _MSC_VER
+#endif  // _WIN32
+
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);
   include_what_you_use::InitGlobalsAndFlagsForTesting();
+
+#if defined(_WIN32)
+  // Windows reports critical errors using GUI prompts by default,
+  // force it not to.
+  ::SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX);
+#if defined(_MSC_VER)
+  ::_set_error_mode(_OUT_TO_STDERR);
+  _CrtSetReportMode(_CRT_WARN, _CRTDBG_MODE_FILE | _CRTDBG_MODE_DEBUG);
+  _CrtSetReportFile(_CRT_WARN, _CRTDBG_FILE_STDERR);
+  _CrtSetReportMode(_CRT_ERROR, _CRTDBG_MODE_FILE | _CRTDBG_MODE_DEBUG);
+  _CrtSetReportFile(_CRT_ERROR, _CRTDBG_FILE_STDERR);
+  _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE | _CRTDBG_MODE_DEBUG);
+  _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
+#endif  // _MSC_VER
+#endif  // _WIN32
+
   return RUN_ALL_TESTS();
 }

--- a/more_tests/test_main.cc
+++ b/more_tests/test_main.cc
@@ -1,0 +1,8 @@
+#include "iwyu_globals.h"
+#include "gtest/gtest.h"
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  include_what_you_use::InitGlobalsAndFlagsForTesting();
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Supersedes PR #237.
- Put IWYU sources in an OBJECT library
- Build an intermediate list of target link deps
- Add build target for unit tests
- Port iwyu_string_util_test.cc (tests succeed)
- Port iwyu_lexer_utils_test.cc (tests succeed)
- Port iwyu_include_picker_test.cc (tests fail)

I haven't managed to port iwyu_output.cc here yet, it's quite a lot of work due to code changes over the years.
