### PR TITLE
Fix #109: synthesize mappings from #error directives

### DIFF
--- a/iwyu_lexer_utils.h
+++ b/iwyu_lexer_utils.h
@@ -82,6 +82,12 @@ vector<clang::Token> FindArgumentsToDefined(
 string GetTokenText(const clang::Token& token,
                     const CharacterDataGetterInterface& character_data_getter);
 
+// Given a location at the beginning of a file, enumerate all #error directives
+// and return their messages.
+std::vector<std::string> FindErrorDirectives(
+    clang::SourceLocation file_begin,
+    const CharacterDataGetterInterface& data_getter);
+
 }  // namespace include_what_you_use
 
 #endif  // DEVTOOLS_MAINTENANCE_INCLUDE_WHAT_YOU_USE_IWYU_LEXER_UTILS_H_

--- a/iwyu_preprocessor.h
+++ b/iwyu_preprocessor.h
@@ -265,6 +265,9 @@ class IwyuPreprocessorInfo : public clang::PPCallbacks,
   // Process @headername directives in a file.
   void ProcessHeadernameDirectivesInFile(clang::SourceLocation file_beginning);
 
+  // Process #error directives pointing to another header.
+  void ProcessErrorDirectivesInFile(clang::SourceLocation file_beginning);
+
   // Checks whether it's OK to use the given macro defined in file defined_in.
   void ReportMacroUse(const string& name,
                       clang::SourceLocation usage_location,

--- a/tests/cxx/hash_error-glib-private.h
+++ b/tests/cxx/hash_error-glib-private.h
@@ -1,0 +1,14 @@
+//===--- hash_error-glib-private.h - test input file for iwyu -------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#if !defined(IWYU_HASH_ERROR_GLIB_PUBLIC_INCLUDED)
+#error "Only <tests/cxx/hash_error-glib-public.h> can be included directly."
+#endif
+
+int glib_symbol;

--- a/tests/cxx/hash_error-glib-public.h
+++ b/tests/cxx/hash_error-glib-public.h
@@ -1,0 +1,12 @@
+//===--- hash_error-glib-private.h - test input file for iwyu -------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#define IWYU_HASH_ERROR_GLIB_PUBLIC_INCLUDED
+#include "tests/cxx/hash_error-glib-private.h"
+#undef IWYU_HASH_ERROR_GLIB_PUBLIC_INCLUDED

--- a/tests/cxx/hash_error-glibc1-private.h
+++ b/tests/cxx/hash_error-glibc1-private.h
@@ -1,0 +1,14 @@
+//===--- hash_error-glibc1-private.h - test input file for iwyu -----------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#if !defined(IWYU_HASH_ERROR_GLIBC1_PUBLIC_INCLUDED)
+#error "Never use "tests/cxx/hash_error-glibc1-private.h" directly; include <tests/cxx/hash_error-glibc1-public.h> instead."
+#endif
+
+int glibc1_symbol;

--- a/tests/cxx/hash_error-glibc1-public.h
+++ b/tests/cxx/hash_error-glibc1-public.h
@@ -1,0 +1,14 @@
+//===--- hash_error-glibc1-public.h - test input file for iwyu ------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// Test for auto-mapping based on #error messages in private headers.
+
+#define IWYU_HASH_ERROR_GLIBC1_PUBLIC_INCLUDED
+#include "tests/cxx/hash_error-glibc1-private.h"
+#undef IWYU_HASH_ERROR_GLIBC1_PUBLIC_INCLUDED

--- a/tests/cxx/hash_error-glibc2-private.h
+++ b/tests/cxx/hash_error-glibc2-private.h
@@ -1,0 +1,14 @@
+//===--- hash_error-glibc2-private.h - test input file for iwyu -----------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#if !defined(IWYU_HASH_ERROR_GLIBC2_PUBLIC_INCLUDED)
+#error "Never include "tests/cxx/hash_error-glibc2-private.h" directly; use <tests/cxx/hash_error-glibc2-public.h> instead."
+#endif
+
+int glibc2_symbol;

--- a/tests/cxx/hash_error-glibc2-public.h
+++ b/tests/cxx/hash_error-glibc2-public.h
@@ -1,0 +1,14 @@
+//===--- hash_error-glibc2-public.h - test input file for iwyu ------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// Test for auto-mapping based on #error messages in private headers.
+
+#define IWYU_HASH_ERROR_GLIBC2_PUBLIC_INCLUDED
+#include "tests/cxx/hash_error-glibc2-private.h"
+#undef IWYU_HASH_ERROR_GLIBC2_PUBLIC_INCLUDED

--- a/tests/cxx/hash_error-nomap.h
+++ b/tests/cxx/hash_error-nomap.h
@@ -1,0 +1,15 @@
+//===--- hash_error-nomap.h - test input file for iwyu --------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifdef IWYU_THIS_SHOULD_NEVER_BE_DEFINED
+#error "This is just some random #error"
+#endif
+
+int nomap_symbol;
+

--- a/tests/cxx/hash_error.cc
+++ b/tests/cxx/hash_error.cc
@@ -1,0 +1,40 @@
+//===--- hash_error.cc - test input file for iwyu -------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// Tests automatic mapping based on known #error directives in private headers.
+//
+// GNU libc has the following two conventions:
+// #error "Never include <private> directly; use <public> instead."
+// #error "Never use <private> directly; include <public> instead."
+//
+// The glib library has the following convention:
+// #error "Only <public> can be included directly."
+//
+// Use angled includes to match typical style for these library includes.
+
+#include <tests/cxx/hash_error-glibc1-public.h>
+#include <tests/cxx/hash_error-glibc2-public.h>
+#include <tests/cxx/hash_error-glib-public.h>
+#include "tests/cxx/hash_error-nomap.h"  // unused
+
+static int total = glibc1_symbol + glibc2_symbol + glib_symbol;
+
+
+/**** IWYU_SUMMARY
+tests/cxx/hash_error.cc should add these lines:
+
+tests/cxx/hash_error.cc should remove these lines:
+- #include "tests/cxx/hash_error-nomap.h"  // lines XX-XX
+
+The full include-list for tests/cxx/hash_error.cc:
+#include <tests/cxx/hash_error-glib-public.h>  // for glib_symbol
+#include <tests/cxx/hash_error-glibc1-public.h>  // for glibc1_symbol
+#include <tests/cxx/hash_error-glibc2-public.h>  // for glibc2_symbol
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
cc @sylvestre 

Like with `@headername`, we now parse header files to find known `#error`
directives for GNU libc and the glib library.

These `#error` directives are phrased in a way that we can construct
mappings from private to public headers automatically, instead of
maintaining manual mappings.

I've tested this for `glib`, which I happened to have installed on my FreeBSD rig, but I don't have an environment with `glibc`, so it would be nice to revert the recent `socket_types.h` mapping and re-run the repro case from #245.