### PR TITLE
Fix #256: Enable bigobjs for MSYS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,11 @@ add_executable(include-what-you-use
   iwyu_verrs.cc
 )
 
+if( MINGW )
+  # Work around 'too many sections' error with MINGW/GCC
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wa,-mbig-obj")
+endif()
+
 if( MSVC )
   # Disable warnings for IWYU, and disable exceptions in MSVC's STL.
   add_definitions(


### PR DESCRIPTION
iwyu.cc is now big enough that it causes a 'too many sections' error with MSYS GCC.

As hypothesized here [1], GCC has a signed 16-bit table for the number of sections in an object file. The switch `-Wa,-mbig-obj` will bump it to 32 bits.

[1] http://stackoverflow.com/questions/16596876/