### PR TITLE
Fix 262: Don't fail the build if checked out via SVN

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,11 +65,14 @@ endif()
 
 # Pick up Git revision so we can report it in version information.
 include(FindGit)
-if( GIT_FOUND )
+if( GIT_FOUND AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git" )
   execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse --short HEAD
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     OUTPUT_VARIABLE IWYU_GIT_REV
     OUTPUT_STRIP_TRAILING_WHITESPACE)
+else()
+  message(STATUS "Warning: IWYU Git version info not found, DO NOT release "
+                 "from this build tree!")
 endif()
 add_definitions(-DIWYU_GIT_REV="${IWYU_GIT_REV}")
 


### PR DESCRIPTION
Based on @JVApen's patch, this should allow, but discourage, SVN checkouts.