### PR TITLE
Silence CMake CMP0048 warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,10 @@
 cmake_minimum_required(VERSION 2.8)
 
+if( POLICY CMP0048 )
+  # Silence CMP0048 warning about missing project VERSION.
+  cmake_policy(SET CMP0048 NEW)
+endif()
+
 project(include-what-you-use)
 
 if( CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR )


### PR DESCRIPTION
Whenever I run `cmake` I see the following warning:

    CMake Warning (dev) at tools/clang/tools/include-what-you-use/CMakeLists.txt:3 (project):
      Policy CMP0048 is not set: project() command manages VERSION variables.
      Run "cmake --help-policy CMP0048" for policy details.  Use the cmake_policy
      command to set the policy and suppress this warning.

      The following variable(s) would be set to empty:

        PROJECT_VERSION
        PROJECT_VERSION_MAJOR
        PROJECT_VERSION_MINOR
        PROJECT_VERSION_PATCH
    This warning is for project developers.  Use -Wno-dev to suppress it.

It doesn't look particularly useful to us, so I just picked up whatever LLVM's base `CMakeLists.txt` was doing.