### PR TITLE
Add --no_comments arg to suppress why-comments

### DIFF
--- a/iwyu_globals.cc
+++ b/iwyu_globals.cc
@@ -90,7 +90,8 @@ static void PrintHelp(const char* extra_msg) {
          "   --max_line_length: maximum line length for includes.\n"
          "        Note that this only affects comments and alignment thereof,\n"
          "        the maximum line length can still be exceeded with long\n"
-         "        file names (default: 80)."
+         "        file names (default: 80).\n"
+         "   --no_comments: do not add 'why' comments.\n"
          "   --verbose=<level>: the higher the level, the more output.\n"
          "\n"
          "In addition to IWYU-specific options you can specify the following\n"
@@ -160,7 +161,8 @@ CommandlineFlags::CommandlineFlags()
       no_default_mappings(false),
       max_line_length(80),
       prefix_header_include_policy(CommandlineFlags::kAdd),
-      pch_in_code(false) {
+      pch_in_code(false),
+      no_comments(false) {
 }
 
 int CommandlineFlags::ParseArgv(int argc, char** argv) {
@@ -175,6 +177,7 @@ int CommandlineFlags::ParseArgv(int argc, char** argv) {
     {"prefix_header_includes", required_argument, NULL, 'x'},
     {"pch_in_code", no_argument, NULL, 'h'},
     {"max_line_length", optional_argument, NULL, 'l'},
+    {"no_comments", optional_argument, NULL, 'o'},
     {0, 0, 0, 0}
   };
   static const char shortopts[] = "d::p:v:c:m:n";
@@ -187,6 +190,7 @@ int CommandlineFlags::ParseArgv(int argc, char** argv) {
       case 'v': verbose = atoi(optarg); break;
       case 'm': mapping_files.push_back(optarg); break;
       case 'n': no_default_mappings = true; break;
+      case 'o': no_comments = true; break;
       case 'x':
         if (strcmp(optarg, "add") == 0) {
           prefix_header_include_policy = CommandlineFlags::kAdd;

--- a/iwyu_globals.h
+++ b/iwyu_globals.h
@@ -101,6 +101,7 @@ struct CommandlineFlags {
   // Policy regarding files included via -include option.  No short option.
   PrefixHeaderIncludePolicy prefix_header_include_policy;
   bool pch_in_code;  // Treat the first seen include as a PCH. No short option.
+  bool no_comments;  // Disable 'why' comments. No short option.
 };
 
 const CommandlineFlags& GlobalFlags();

--- a/iwyu_output.cc
+++ b/iwyu_output.cc
@@ -1724,6 +1724,11 @@ vector<string> GetSymbolsSortedByFrequency(const map<string, int>& m) {
 OutputLine PrintableIncludeOrForwardDeclareLine(
     const OneIncludeOrForwardDeclareLine& line,
     const set<string>& associated_quoted_includes) {
+  // If we don't want any comments, always use the line as-is.
+  if (GlobalFlags().no_comments) {
+    return OutputLine(line.line());
+  }
+
   // Print the line number where we saw this forward-declare or
   // #include, as a comment, if we don't have anything better to show.
   // (For instance, when we want to delete this line.)
@@ -1859,6 +1864,8 @@ size_t PrintableDiffs(const string& filename,
   }
 
   // Compute max width of lines with comments so we can align them nicely.
+  // This is not strictly necessary if comments have been disabled,
+  // but it won't have any effect in that case anyway.
   size_t line_length = 0;
   size_t max_line_length = GlobalFlags().max_line_length;
 

--- a/run_iwyu_tests.py
+++ b/run_iwyu_tests.py
@@ -75,6 +75,7 @@ class OneIwyuTest(unittest.TestCase):
       'non_transitive_include.cc': [self.CheckAlsoExtension('-d*.h'),
                                     '--transitive_includes_only'],
       'no_h_includes_cc.cc': [self.CheckAlsoExtension('.c')],
+      'no_comments.cc': ['--no_comments'],
       'overloaded_class.cc': [self.CheckAlsoExtension('-i1.h')],
       'pch_in_code.cc': ['--pch_in_code', '--prefix_header_includes=remove'],
       'prefix_header_attribution.cc': ['--prefix_header_includes=remove'],

--- a/tests/cxx/no_comments.cc
+++ b/tests/cxx/no_comments.cc
@@ -1,0 +1,29 @@
+//===--- no_comments.cc - test input file for iwyu ------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// Test that passing the --no_comments switch to IWYU suppresses both
+// '// lines NN-NN' and '// for symbol' comments.
+
+#include "tests/cxx/direct.h"
+
+// IWYU: IndirectClass is...*indirect.h
+IndirectClass global;
+
+/**** IWYU_SUMMARY
+
+tests/cxx/no_comments.cc should add these lines:
+#include "tests/cxx/indirect.h"
+
+tests/cxx/no_comments.cc should remove these lines:
+- #include "tests/cxx/direct.h"
+
+The full include-list for tests/cxx/no_comments.cc:
+#include "tests/cxx/indirect.h"
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
We've run IWYU continuously on a large code base for about a year, and applied its changes without `fix_includes.py` (developers apply changes manually and mindfully.)

We see the `// for` comments rotting pretty fast and the relatively usesless `// lines` comments being pasted into source code. This now creates new maintenance overhead for us, so I'd like to be able to disable the why-comments.