### PR TITLE
Fix #254: Treat global :: qualifier as namespace

### DIFF
--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -231,9 +231,13 @@ bool IsNamespaceQualifiedNode(const ASTNode* ast_node) {
   if (ast_node == NULL)
     return false;
   const ElaboratedType* elaborated_type = ast_node->GetAs<ElaboratedType>();
-  return (elaborated_type && elaborated_type->getQualifier()
-          && elaborated_type->getQualifier()->getKind() ==
-          NestedNameSpecifier::Namespace);
+  if (elaborated_type == NULL)
+    return false;
+  const NestedNameSpecifier* qualifier = elaborated_type->getQualifier();
+  if (qualifier == NULL)
+    return false;
+  return (qualifier->getKind() == NestedNameSpecifier::Global ||
+          qualifier->getKind() == NestedNameSpecifier::Namespace);
 }
 
 bool IsNodeInsideCXXMethodBody(const ASTNode* ast_node) {

--- a/tests/cxx/elaborated_type.cc
+++ b/tests/cxx/elaborated_type.cc
@@ -19,6 +19,8 @@
 #include "tests/cxx/elaborated_type_enum1.h"  // for ElaborationEnum1
 #include "tests/cxx/elaborated_type_enum2.h"  // for ElaborationEnum2
 
+class GlobalClass;
+
 // Make sure both elaborated and bare enums require the full type.
 void bare_enum(ElaborationEnum1 e);
 void elaborated_enum(enum ElaborationEnum2 e);
@@ -43,10 +45,14 @@ void bare_union(ElaborationUnion* u);
 void elaborated_union(union UnknownElaborationUnion* u);
 
 // Namespace-qualified types must be forward-declared even
-// if they are represented as elaborated types in Clang's AST. 
+// if they are represented as elaborated types in Clang's AST,
+// and the same goes for ::global-qualified types.
 #include "tests/cxx/elaborated_type_namespace.h"
 
 void namespace_qualified(Elaboration::Class* c);
+void global_qualified(::GlobalClass* c);
+void namespace_qualified_elab(class Elaboration::Class* c);
+void global_qualified_elab(class ::GlobalClass* c);
 
 // We can use elaborated types for templates, too, but
 // they must also be forward-declared.
@@ -71,6 +77,7 @@ The full include-list for tests/cxx/elaborated_type.cc:
 #include "tests/cxx/elaborated_type_enum1.h"  // for ElaborationEnum1
 #include "tests/cxx/elaborated_type_enum2.h"  // for ElaborationEnum2
 class ElaborationClass;
+class GlobalClass;  // lines XX-XX
 namespace Elaboration { class Class; }
 namespace Elaboration { template <typename T, typename U> struct Template; }
 struct ElaborationStruct;


### PR DESCRIPTION
This forces forward-declarations for e.g.

  class Bar;
  class Foo {
    friend class ::Bar;
  };

Without the global qualifier, class Bar would be an elaborated type, and
require no forward declaration.

With the qualifier, however, it needs to be explicitly forward-declared.