### PR TITLE
Naming

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -2440,12 +2440,12 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
     // We also need to do a varargs check, like for other function calls.
     if (CanIgnoreCurrentASTNode())  return true;
     // ... only if this NewExpr involves a constructor call.
-    const Expr* Init = expr->getInitializer();
-    if (const CXXConstructExpr* CCE =
-        dyn_cast_or_null<CXXConstructExpr>(Init)){
-      ReportIfReferenceVararg(CCE->getArgs(),
-                              CCE->getNumArgs(),
-                              CCE->getConstructor());
+    const Expr* initializer = expr->getInitializer();
+    if (const CXXConstructExpr* cce =
+            dyn_cast_or_null<CXXConstructExpr>(initializer)) {
+      ReportIfReferenceVararg(cce->getArgs(),
+                              cce->getNumArgs(),
+                              cce->getConstructor());
     }
     return true;
   }

--- a/iwyu.cc
+++ b/iwyu.cc
@@ -839,10 +839,10 @@ class BaseAstVisitor : public RecursiveASTVisitor<Derived> {
     // implicitly when the variable goes out of scope).  Only when initializing
     // a field of a class does the constructor not have to worry
     // about destruction.  It turns out it's easier to check for that.
-    bool willCallImplicitDestructorOnLeavingScope =
+    bool will_call_implicit_destructor_on_leaving_scope =
         !IsCXXConstructExprInInitializer(current_ast_node()) &&
         !IsCXXConstructExprInNewExpr(current_ast_node());
-    if (willCallImplicitDestructorOnLeavingScope) {
+    if (will_call_implicit_destructor_on_leaving_scope) {
       // Create the destructor if it hasn't been lazily created yet.
       InstantiateImplicitMethods(expr->getConstructor()->getParent());
       if (const CXXDestructorDecl* dtor_decl = GetSiblingDestructorFor(expr)) {

--- a/iwyu.cc
+++ b/iwyu.cc
@@ -700,9 +700,10 @@ class BaseAstVisitor : public RecursiveASTVisitor<Derived> {
     }
 
     // Check the (single) destructor.
-    bool hasImplicitDeclaredDestructor = (!decl->needsImplicitDestructor() &&
-                                          !decl->hasUserDeclaredDestructor());
-    if (hasImplicitDeclaredDestructor) {
+    bool has_implicit_declared_destructor =
+        (!decl->needsImplicitDestructor() &&
+         !decl->hasUserDeclaredDestructor());
+    if (has_implicit_declared_destructor) {
       if (!TraverseImplicitDeclHelper(decl->getDestructor()))
         return false;
     }
@@ -710,9 +711,9 @@ class BaseAstVisitor : public RecursiveASTVisitor<Derived> {
     // Check copy and move assignment operators.
     for (CXXRecordDecl::method_iterator it = decl->method_begin();
          it != decl->method_end(); ++it) {
-      bool isAssignmentOperator = it->isCopyAssignmentOperator() ||
-                                  it->isMoveAssignmentOperator();
-      if (isAssignmentOperator && it->isImplicit()) {
+      bool is_assignment_operator =
+          it->isCopyAssignmentOperator() || it->isMoveAssignmentOperator();
+      if (is_assignment_operator && it->isImplicit()) {
         if (!TraverseImplicitDeclHelper(*it))
           return false;
       }


### PR DESCRIPTION
I realized just recently that the original IWYU convention for variable names is `lowercase_with_underscores`, not `camelCase`. A few atypical names had slipped through, so I thought I'd harmonize.

Ran clang-format on all changes, so indentation sometimes changed slightly.