### PR TITLE
Handle internal headers guarded by macro and x-macros (fix issue #109).

### DIFF
--- a/iwyu_output.cc
+++ b/iwyu_output.cc
@@ -602,6 +602,10 @@ void IwyuFileInfo::ReportMacroUse(clang::SourceLocation use_loc,
   LogSymbolUse("Marked full-info use of macro", symbol_uses_.back());
 }
 
+void IwyuFileInfo::ReportDefinedMacroUse(const clang::FileEntry* used_in) {
+  macro_users_.insert(used_in);
+}
+
 void IwyuFileInfo::ReportIncludeFileUse(const clang::FileEntry* included_file,
                                         const string& quoted_include) {
   symbol_uses_.push_back(OneUse("", included_file, quoted_include,

--- a/iwyu_output.cc
+++ b/iwyu_output.cc
@@ -609,6 +609,10 @@ void IwyuFileInfo::ReportIncludeFileUse(const clang::FileEntry* included_file,
   LogSymbolUse("Marked use of include-file", symbol_uses_.back());
 }
 
+void IwyuFileInfo::ReportIncludedFileMacroUse(const FileEntry* included_file) {
+  kept_includes_.insert(included_file);
+}
+
 void IwyuFileInfo::ReportPragmaKeep(const clang::FileEntry* included_file) {
   kept_includes_.insert(included_file);
 }

--- a/iwyu_output.cc
+++ b/iwyu_output.cc
@@ -609,11 +609,7 @@ void IwyuFileInfo::ReportIncludeFileUse(const clang::FileEntry* included_file,
   LogSymbolUse("Marked use of include-file", symbol_uses_.back());
 }
 
-void IwyuFileInfo::ReportIncludedFileMacroUse(const FileEntry* included_file) {
-  kept_includes_.insert(included_file);
-}
-
-void IwyuFileInfo::ReportPragmaKeep(const clang::FileEntry* included_file) {
+void IwyuFileInfo::ReportKnownDesiredFile(const FileEntry* included_file) {
   kept_includes_.insert(included_file);
 }
 

--- a/iwyu_output.h
+++ b/iwyu_output.h
@@ -235,9 +235,13 @@ class IwyuFileInfo {
                            const string& symbol);
   // TODO(dsturtevant): Can we determine in_cxx_method_body? Do we care?
 
+  // Called when using a macro in this file.
   void ReportMacroUse(clang::SourceLocation use_loc,
                       clang::SourceLocation dfn_loc,
                       const string& symbol);
+
+  // Called when somebody uses a macro defined in this file.
+  void ReportDefinedMacroUse(const clang::FileEntry* used_in);
 
   // We only allow forward-declaring of decls, not arbitrary symbols.
   void ReportForwardDeclareUse(clang::SourceLocation use_loc,
@@ -264,6 +268,11 @@ class IwyuFileInfo {
   // This is used only in iwyu_preprocessor.cc.  TODO(csilvers): revamp?
   const set<const clang::FileEntry*>& direct_includes_as_fileentries() const {
     return direct_includes_as_fileentries_;
+  }
+
+  // This is used only in iwyu_preprocessor.cc.
+  const set<const clang::FileEntry*>& macro_users() const {
+    return macro_users_;
   }
 
   // Resolve and pending analysis that needs to occur between AST traversal
@@ -348,6 +357,9 @@ class IwyuFileInfo {
   // Holds files forced to be kept.  For example, files included with the
   // "IWYU pragma: keep" comment and x-macros.
   set<const clang::FileEntry*> kept_includes_;
+
+  // Holds files using macros defined in this file.
+  set<const clang::FileEntry*> macro_users_;
 
   // What we will recommend the #includes to be.
   set<string> desired_includes_;

--- a/iwyu_output.h
+++ b/iwyu_output.h
@@ -256,11 +256,10 @@ class IwyuFileInfo {
   void ReportIncludeFileUse(const clang::FileEntry* included_file,
                             const string& quoted_include);
 
-  void ReportIncludedFileMacroUse(const clang::FileEntry* included_file);
-
-  // This is used when we see an "IWYU pragma: keep" comment
-  // on an include line.
-  void ReportPragmaKeep(const clang::FileEntry* included_file);
+  // This is used when we see a file we want to keep not due to symbol-use
+  // reasons.  For example, it can be #included with an "IWYU pragma: keep"
+  // comment or it can be a x-macro.
+  void ReportKnownDesiredFile(const clang::FileEntry* included_file);
 
   // This is used only in iwyu_preprocessor.cc.  TODO(csilvers): revamp?
   const set<const clang::FileEntry*>& direct_includes_as_fileentries() const {

--- a/iwyu_output.h
+++ b/iwyu_output.h
@@ -256,6 +256,8 @@ class IwyuFileInfo {
   void ReportIncludeFileUse(const clang::FileEntry* included_file,
                             const string& quoted_include);
 
+  void ReportIncludedFileMacroUse(const clang::FileEntry* included_file);
+
   // This is used when we see an "IWYU pragma: keep" comment
   // on an include line.
   void ReportPragmaKeep(const clang::FileEntry* included_file);
@@ -344,7 +346,8 @@ class IwyuFileInfo {
   set<const clang::FileEntry*> direct_includes_as_fileentries_;
   set<const clang::NamedDecl*> direct_forward_declares_;
 
-  // Holds any files included with the "IWYU pragma: keep" comment.
+  // Holds files forced to be kept.  For example, files included with the
+  // "IWYU pragma: keep" comment and x-macros.
   set<const clang::FileEntry*> kept_includes_;
 
   // What we will recommend the #includes to be.

--- a/iwyu_preprocessor.cc
+++ b/iwyu_preprocessor.cc
@@ -754,7 +754,8 @@ void IwyuPreprocessorInfo::FileChanged_ExitToFile(
   }
 
   // Check macros defined by includer.  Requires file preprocessing to be
-  // finished to know all direct includes.
+  // finished to know all direct includes.  Note that direct includes don't
+  // contain #include_next and it is desirable in this case.
   bool should_report_violations = ShouldReportIWYUViolationsFor(exiting_from);
   IwyuFileInfo *file_info = GetFromFileInfoMap(exiting_from);
   std::list<const FileEntry*> direct_macro_use_includees;
@@ -766,19 +767,19 @@ void IwyuPreprocessorInfo::FileChanged_ExitToFile(
                                       direct_macro_use_includees.end()));
   for (const FileEntry* macro_use_includee : direct_macro_use_includees) {
     if (should_report_violations) {
-      file_info->ReportKnownDesiredFile(macro_use_includee);
       ERRSYM(exiting_from) << "Keep #include " << macro_use_includee->getName()
                            << " in " << exiting_from->getName()
                            << " because used macro is defined by includer.\n";
+      file_info->ReportKnownDesiredFile(macro_use_includee);
     } else {
       string private_include =
           ConvertToQuotedInclude(GetFilePath(macro_use_includee));
       string public_include = ConvertToQuotedInclude(GetFilePath(exiting_from));
-      MutableGlobalIncludePicker()->AddMapping(private_include, public_include);
-      MutableGlobalIncludePicker()->MarkIncludeAsPrivate(private_include);
       ERRSYM(exiting_from) << "Mark " << public_include
                            << " as public header for " << private_include
                            << " because used macro is defined by includer.\n";
+      MutableGlobalIncludePicker()->AddMapping(private_include, public_include);
+      MutableGlobalIncludePicker()->MarkIncludeAsPrivate(private_include);
     }
   }
 }

--- a/iwyu_preprocessor.h
+++ b/iwyu_preprocessor.h
@@ -213,7 +213,7 @@ class IwyuPreprocessorInfo : public clang::PPCallbacks,
   // FileChanged is actually a multi-plexer for 4 different callbacks.
   void FileChanged_EnterFile(clang::SourceLocation file_beginning);
   void FileChanged_ExitToFile(clang::SourceLocation include_loc,
-                              clang::FileID exiting_from);
+                              const clang::FileEntry* exiting_from);
   void FileChanged_RenameFile(clang::SourceLocation new_file);
   void FileChanged_SystemHeaderPragma(clang::SourceLocation loc);
 

--- a/run_iwyu_tests.py
+++ b/run_iwyu_tests.py
@@ -98,6 +98,7 @@ class OneIwyuTest(unittest.TestCase):
       'deleted_implicit.cc' : ['-std=c++11'],
       'lambda_fwd_decl.cc': ['-std=c++11'],
       'lateparsed_template.cc': ['-fdelayed-template-parsing'],
+      'macro_defined_by_includer.cc': ['-DCOMMAND_LINE_TYPE=double'],
       'ms_inline_asm.cc': ['-fms-extensions'],
       'prefix_header_attribution.cc': [
           self.Include('prefix_header_attribution-d1.h')],

--- a/run_iwyu_tests.py
+++ b/run_iwyu_tests.py
@@ -98,7 +98,8 @@ class OneIwyuTest(unittest.TestCase):
       'deleted_implicit.cc' : ['-std=c++11'],
       'lambda_fwd_decl.cc': ['-std=c++11'],
       'lateparsed_template.cc': ['-fdelayed-template-parsing'],
-      'macro_defined_by_includer.cc': ['-DCOMMAND_LINE_TYPE=double'],
+      'macro_defined_by_includer.cc': [
+          '-std=c++11', '-DCOMMAND_LINE_TYPE=double'],
       'ms_inline_asm.cc': ['-fms-extensions'],
       'prefix_header_attribution.cc': [
           self.Include('prefix_header_attribution-d1.h')],

--- a/tests/cxx/macro_defined_by_includer-d1.h
+++ b/tests/cxx/macro_defined_by_includer-d1.h
@@ -1,0 +1,12 @@
+//===--- macro_defined_by_includer-d1.h - test input file for iwyu --------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// Header file to provide extra level of inclusion indirection.
+
+#include "tests/cxx/macro_defined_by_includer-i1.h"

--- a/tests/cxx/macro_defined_by_includer-d2.h
+++ b/tests/cxx/macro_defined_by_includer-d2.h
@@ -1,0 +1,12 @@
+//===--- macro_defined_by_includer-d2.h - test input file for iwyu --------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// Header file to provide extra level of inclusion indirection.
+
+#include "tests/cxx/macro_defined_by_includer-i2.h"

--- a/tests/cxx/macro_defined_by_includer-d2.h
+++ b/tests/cxx/macro_defined_by_includer-d2.h
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-// Header file to provide extra level of inclusion indirection.
+// Tests case when file using macro is included from file defining macro but
+// the macro user is first encountered as include in another file.
 
+#define DIRECT_INCLUDE_GUARD_2
 #include "tests/cxx/macro_defined_by_includer-i2.h"
+#include "tests/cxx/macro_defined_by_includer-g2.h"

--- a/tests/cxx/macro_defined_by_includer-d3.h
+++ b/tests/cxx/macro_defined_by_includer-d3.h
@@ -1,0 +1,14 @@
+//===--- macro_defined_by_includer-d3.h - test input file for iwyu --------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// Tests nested guarded includes.  Covers the case when "public" mapping for
+// some private include can be in fact private.
+
+#define DIRECT_INCLUDE_GUARD_3
+#include "tests/cxx/macro_defined_by_includer-g3.h"

--- a/tests/cxx/macro_defined_by_includer-d4.h
+++ b/tests/cxx/macro_defined_by_includer-d4.h
@@ -1,4 +1,4 @@
-//===--- macro_defined_by_includer-i2.h - test input file for iwyu --------===//
+//===--- macro_defined_by_includer-d4.h - test input file for iwyu --------===//
 //
 //                     The LLVM Compiler Infrastructure
 //
@@ -7,4 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "tests/cxx/macro_defined_by_includer-g2.h"
+// Header file to provide extra level of inclusion indirection.
+
+#include "tests/cxx/macro_defined_by_includer-i3.h"

--- a/tests/cxx/macro_defined_by_includer-g1.h
+++ b/tests/cxx/macro_defined_by_includer-g1.h
@@ -1,0 +1,14 @@
+//===--- macro_defined_by_includer-g1.h - test input file for iwyu --------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef DIRECT_INCLUDE_GUARD_1
+  #error Do not include directly
+#else
+  class GuardedInclude1 {};
+#endif

--- a/tests/cxx/macro_defined_by_includer-g2.h
+++ b/tests/cxx/macro_defined_by_includer-g2.h
@@ -7,8 +7,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef DEVTOOLS_MAINTENANCE_INCLUDE_WHAT_YOU_USE_TESTS_MACRO_DEFINED_BY_INCLUDER_D2_H_
+#define DEVTOOLS_MAINTENANCE_INCLUDE_WHAT_YOU_USE_TESTS_MACRO_DEFINED_BY_INCLUDER_D2_H_
+
 #ifndef DIRECT_INCLUDE_GUARD_2
   #error Do not include directly
 #else
   class GuardedInclude2 {};
 #endif
+
+#endif  // DEVTOOLS_MAINTENANCE_INCLUDE_WHAT_YOU_USE_TESTS_MACRO_DEFINED_BY_INCLUDER_D2_H_

--- a/tests/cxx/macro_defined_by_includer-g2.h
+++ b/tests/cxx/macro_defined_by_includer-g2.h
@@ -1,0 +1,14 @@
+//===--- macro_defined_by_includer-g2.h - test input file for iwyu --------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef DIRECT_INCLUDE_GUARD_2
+  #error Do not include directly
+#else
+  class GuardedInclude2 {};
+#endif

--- a/tests/cxx/macro_defined_by_includer-g3.h
+++ b/tests/cxx/macro_defined_by_includer-g3.h
@@ -1,0 +1,17 @@
+//===--- macro_defined_by_includer-g3.h - test input file for iwyu --------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#define DIRECT_INCLUDE_GUARD_4
+#include "tests/cxx/macro_defined_by_includer-g4.h"
+
+#ifndef DIRECT_INCLUDE_GUARD_3
+  #error Do not include directly
+#else
+  class GuardedInclude3 {};
+#endif

--- a/tests/cxx/macro_defined_by_includer-g4.h
+++ b/tests/cxx/macro_defined_by_includer-g4.h
@@ -1,4 +1,4 @@
-//===--- macro_defined_by_includer-i2.h - test input file for iwyu --------===//
+//===--- macro_defined_by_includer-g4.h - test input file for iwyu --------===//
 //
 //                     The LLVM Compiler Infrastructure
 //
@@ -7,4 +7,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "tests/cxx/macro_defined_by_includer-g2.h"
+#ifndef DIRECT_INCLUDE_GUARD_4
+  #error Do not include directly
+#else
+  class GuardedInclude4 {};
+#endif

--- a/tests/cxx/macro_defined_by_includer-g5.h
+++ b/tests/cxx/macro_defined_by_includer-g5.h
@@ -1,4 +1,4 @@
-//===--- macro_defined_by_includer-i2.h - test input file for iwyu --------===//
+//===--- macro_defined_by_includer-g5.h - test input file for iwyu --------===//
 //
 //                     The LLVM Compiler Infrastructure
 //
@@ -7,4 +7,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "tests/cxx/macro_defined_by_includer-g2.h"
+#ifndef DIRECT_INCLUDE_GUARD_5
+  #error Do not include directly
+#else
+  class GuardedInclude5 {};
+#endif

--- a/tests/cxx/macro_defined_by_includer-i1.h
+++ b/tests/cxx/macro_defined_by_includer-i1.h
@@ -1,0 +1,11 @@
+//===--- macro_defined_by_includer-i1.h - test input file for iwyu --------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#define DIRECT_INCLUDE_GUARD_1
+#include "tests/cxx/macro_defined_by_includer-g1.h"

--- a/tests/cxx/macro_defined_by_includer-i2.h
+++ b/tests/cxx/macro_defined_by_includer-i2.h
@@ -1,0 +1,14 @@
+//===--- macro_defined_by_includer-i2.h - test input file for iwyu --------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// Header file to test including file that uses x-macro.
+
+#define TYPE char
+#include "tests/cxx/macro_defined_by_includer-xmacro.h"
+#undef TYPE

--- a/tests/cxx/macro_defined_by_includer-i3.h
+++ b/tests/cxx/macro_defined_by_includer-i3.h
@@ -1,4 +1,4 @@
-//===--- macro_defined_by_includer-i2.h - test input file for iwyu --------===//
+//===--- macro_defined_by_includer-i3.h - test input file for iwyu --------===//
 //
 //                     The LLVM Compiler Infrastructure
 //
@@ -7,4 +7,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "tests/cxx/macro_defined_by_includer-g2.h"
+// Header file to test including file that uses x-macro.
+
+#define TYPE char
+#include "tests/cxx/macro_defined_by_includer-xmacro.h"
+#undef TYPE

--- a/tests/cxx/macro_defined_by_includer-xmacro.h
+++ b/tests/cxx/macro_defined_by_includer-xmacro.h
@@ -1,0 +1,12 @@
+//===--- macro_defined_by_includer-xmacro.h - test input file for iwyu ----===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// File containing X-macro templates.
+
+void f(TYPE const t) {}

--- a/tests/cxx/macro_defined_by_includer.cc
+++ b/tests/cxx/macro_defined_by_includer.cc
@@ -1,0 +1,71 @@
+//===--- macro_defined_by_includer.cc - test input file for iwyu ----------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// Tests a few macro patterns:
+// * internal headers guarded by macro defined in designated header;
+// * x-macros.
+//
+// Usually you include a file with a macro and use that macro.  But in these
+// macro patterns macro is defined by includer and includee doesn't know where
+// the macro comes from.
+
+
+// Test guarded includes.
+#include "tests/cxx/macro_defined_by_includer-d1.h"
+// IWYU: GuardedInclude1 is...*macro_defined_by_includer-i1.h
+GuardedInclude1 g1;
+
+#define DIRECT_INCLUDE_GUARD_2
+#include "tests/cxx/macro_defined_by_includer-g2.h"
+GuardedInclude2 g2;
+
+
+// Test x-macros.
+#include "tests/cxx/macro_defined_by_includer-d2.h"
+
+#define TYPE int
+#include "tests/cxx/macro_defined_by_includer-xmacro.h"
+#undef TYPE
+
+// For x-macros we keep all includes even if its content isn't used.
+#define TYPE double
+#include "tests/cxx/macro_defined_by_includer-xmacro.h"
+#undef TYPE
+
+int main() {
+  // IWYU: f is...*macro_defined_by_includer-i2.h
+  f(3);
+  // IWYU: f is...*macro_defined_by_includer-i2.h
+  f('a');
+}
+
+
+// Test macro defined on command line.  Make sure that detecting file defining
+// macro works without actual file on disk.
+COMMAND_LINE_TYPE x;
+
+
+/**** IWYU_SUMMARY
+
+tests/cxx/macro_defined_by_includer.cc should add these lines:
+#include "tests/cxx/macro_defined_by_includer-i1.h"
+#include "tests/cxx/macro_defined_by_includer-i2.h"
+
+tests/cxx/macro_defined_by_includer.cc should remove these lines:
+- #include "tests/cxx/macro_defined_by_includer-d1.h"  // lines XX-XX
+- #include "tests/cxx/macro_defined_by_includer-d2.h"  // lines XX-XX
+
+The full include-list for tests/cxx/macro_defined_by_includer.cc:
+#include "tests/cxx/macro_defined_by_includer-g2.h"  // for GuardedInclude2
+#include "tests/cxx/macro_defined_by_includer-i1.h"  // for GuardedInclude1
+#include "tests/cxx/macro_defined_by_includer-i2.h"  // for f
+#include "tests/cxx/macro_defined_by_includer-xmacro.h"  // lines XX-XX
+#include "tests/cxx/macro_defined_by_includer-xmacro.h"  // lines XX-XX
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/macro_defined_by_includer.cc
+++ b/tests/cxx/macro_defined_by_includer.cc
@@ -58,6 +58,14 @@ int main() {
 COMMAND_LINE_TYPE x;
 
 
+// Clang internal <limits.h> defines LLONG_MIN and #include_next system
+// <limits.h> which on Mac OS X uses LLONG_MIN.
+//
+// Test that we don't create a mapping between those 2 <limits.h> and don't try
+// to mark system <limits.h> as private.
+#include <limits.h>
+
+
 /**** IWYU_SUMMARY
 
 tests/cxx/macro_defined_by_includer.cc should add these lines:
@@ -65,6 +73,7 @@ tests/cxx/macro_defined_by_includer.cc should add these lines:
 #include "tests/cxx/macro_defined_by_includer-i3.h"
 
 tests/cxx/macro_defined_by_includer.cc should remove these lines:
+- #include <limits.h>  // lines XX-XX
 - #include "tests/cxx/macro_defined_by_includer-d1.h"  // lines XX-XX
 - #include "tests/cxx/macro_defined_by_includer-d4.h"  // lines XX-XX
 

--- a/tests/cxx/macro_defined_by_includer.cc
+++ b/tests/cxx/macro_defined_by_includer.cc
@@ -21,13 +21,20 @@
 // IWYU: GuardedInclude1 is...*macro_defined_by_includer-i1.h
 GuardedInclude1 g1;
 
-#define DIRECT_INCLUDE_GUARD_2
-#include "tests/cxx/macro_defined_by_includer-g2.h"
+#include "tests/cxx/macro_defined_by_includer-d2.h"
 GuardedInclude2 g2;
+
+#include "tests/cxx/macro_defined_by_includer-d3.h"
+GuardedInclude3 g3;
+GuardedInclude4 g4;
+
+#define DIRECT_INCLUDE_GUARD_5
+#include "tests/cxx/macro_defined_by_includer-g5.h"
+GuardedInclude5 g5;
 
 
 // Test x-macros.
-#include "tests/cxx/macro_defined_by_includer-d2.h"
+#include "tests/cxx/macro_defined_by_includer-d4.h"
 
 #define TYPE int
 #include "tests/cxx/macro_defined_by_includer-xmacro.h"
@@ -39,9 +46,9 @@ GuardedInclude2 g2;
 #undef TYPE
 
 int main() {
-  // IWYU: f is...*macro_defined_by_includer-i2.h
+  // IWYU: f is...*macro_defined_by_includer-i3.h
   f(3);
-  // IWYU: f is...*macro_defined_by_includer-i2.h
+  // IWYU: f is...*macro_defined_by_includer-i3.h
   f('a');
 }
 
@@ -55,16 +62,18 @@ COMMAND_LINE_TYPE x;
 
 tests/cxx/macro_defined_by_includer.cc should add these lines:
 #include "tests/cxx/macro_defined_by_includer-i1.h"
-#include "tests/cxx/macro_defined_by_includer-i2.h"
+#include "tests/cxx/macro_defined_by_includer-i3.h"
 
 tests/cxx/macro_defined_by_includer.cc should remove these lines:
 - #include "tests/cxx/macro_defined_by_includer-d1.h"  // lines XX-XX
-- #include "tests/cxx/macro_defined_by_includer-d2.h"  // lines XX-XX
+- #include "tests/cxx/macro_defined_by_includer-d4.h"  // lines XX-XX
 
 The full include-list for tests/cxx/macro_defined_by_includer.cc:
-#include "tests/cxx/macro_defined_by_includer-g2.h"  // for GuardedInclude2
+#include "tests/cxx/macro_defined_by_includer-d2.h"  // for GuardedInclude2
+#include "tests/cxx/macro_defined_by_includer-d3.h"  // for GuardedInclude3, GuardedInclude4
+#include "tests/cxx/macro_defined_by_includer-g5.h"  // for GuardedInclude5
 #include "tests/cxx/macro_defined_by_includer-i1.h"  // for GuardedInclude1
-#include "tests/cxx/macro_defined_by_includer-i2.h"  // for f
+#include "tests/cxx/macro_defined_by_includer-i3.h"  // for f
 #include "tests/cxx/macro_defined_by_includer-xmacro.h"  // lines XX-XX
 #include "tests/cxx/macro_defined_by_includer-xmacro.h"  // lines XX-XX
 


### PR DESCRIPTION
I've made a few trade-offs in implementation which I'd like to explain more.

First, code doesn't distinguish between guarded internal headers and
headers with x-macros. They are handled the same way. But in tests both
patterns are tested. It is done not to cover all code paths but to test
include-what-you-use from user's perspective.

Also I check if file defining macro is immediate includer. I decided not
to check if it includes file using the macro transitively until we have
such real-life use cases. Current implementation is strict in order to
avoid unexpected results.

For some cases I am reusing mechanism that keeps files included with the
"IWYU pragma: keep" comment. The downside is that it keeps all lines
including this file which might be not entirely correct for x-macros.
Though x-macros are close to pure textual includes and we cannot reason
about textual includes.

I also didn't include a few test cases because I think they don't
represent real-life use cases. These test cases are:
* when associated header is included by non-associated header;
* when file defining macro and file using macro are both included by the
  third file.