### PR TITLE
Remove CanonicalizeFilePath and add NormalizeFolderPath

### DIFF
--- a/iwyu_globals.cc
+++ b/iwyu_globals.cc
@@ -300,7 +300,7 @@ static vector<HeaderSearchPath> ComputeHeaderSearchPaths(
            it = header_search->system_dir_begin();
        it != header_search->system_dir_end(); ++it) {
     if (const DirectoryEntry* entry = it->getDir()) {
-      const string path = CanonicalizeHeaderSearchPath(entry->getName());
+      const string path = NormalizeFolderPath(entry->getName());
       search_path_map[path] = HeaderSearchPath::kSystemPath;
     }
   }
@@ -311,7 +311,7 @@ static vector<HeaderSearchPath> ComputeHeaderSearchPaths(
       // search_dir_begin()/end() includes both system and user paths.
       // If it's a system path, it's already in the map, so everything
       // new is a user path.  The insert only 'takes' for new entries.
-      const string path = CanonicalizeHeaderSearchPath(entry->getName());
+      const string path = NormalizeFolderPath(entry->getName());
       search_path_map.insert(make_pair(path, HeaderSearchPath::kUserPath));
     }
   }
@@ -386,7 +386,7 @@ FullUseCache* ClassMembersFullUseCache() {
 
 void AddGlobToReportIWYUViolationsFor(const string& glob) {
   CHECK_(commandline_flags && "Call ParseIwyuCommandlineFlags() before this");
-  commandline_flags->check_also.insert(CanonicalizeFilePath(glob));
+  commandline_flags->check_also.insert(NormalizeFilePath(glob));
 }
 
 bool ShouldReportIWYUViolationsFor(const clang::FileEntry* file) {

--- a/iwyu_path_util.cc
+++ b/iwyu_path_util.cc
@@ -9,6 +9,7 @@
 
 #include "iwyu_path_util.h"
 
+#include <algorithm>                    // for std::replace
 #include <stddef.h>
 #include <string.h>                     // for strlen
 #include <system_error>
@@ -80,39 +81,12 @@ string Basename(const string& path) {
   return path;
 }
 
-string CanonicalizeFilePath(const string& path) {
-  string result = path;
-
-#ifdef _WIN32
-  // Canonicalise directory separators (forward slashes considered canonical.)
-  for (size_t i = 0; i < result.size(); ++i) {
-    if (result[i] == '\\')
-      result[i] = '/';
-  }
-#endif
-
-  // We may also want to collapse ../ here.
-
-  return result;
-}
-
-string CanonicalizeHeaderSearchPath(const string& path) {
-  string result = CanonicalizeFilePath(path);
-
-  // We want a trailing slash on all header search paths, because it makes it
-  // much easier to find the longest common path prefix.
-  if (!EndsWith(result, "/"))
-    result += "/";
-
-  return result;
-}
-
 string GetCanonicalName(string file_path) {
   // Get rid of any <> and "" in case file_path is really an #include line.
   StripLeft(&file_path, "\"") || StripLeft(&file_path, "<");
   StripRight(&file_path, "\"") || StripRight(&file_path, ">");
 
-  file_path = CanonicalizeFilePath(file_path);
+  file_path = NormalizeFilePath(file_path);
 
   bool stripped_ext = StripRight(&file_path, ".h")
       || StripRight(&file_path, ".hpp")
@@ -146,9 +120,25 @@ string GetCanonicalName(string file_path) {
 }
 
 string NormalizeFilePath(const string& path) {
-  string result = CanonicalizeFilePath(path);
-  while (StripLeft(&result, "./")) {
-  }
+  llvm::SmallString<128> llvmPath(path.c_str());
+  string result;
+  if (llvm::sys::path::remove_dots(llvmPath))
+      result = llvmPath.str();
+  else
+      result = path; // When nothing changed don't convert again.
+#ifdef _WIN32
+  // Canonicalize directory separators (forward slashes considered canonical.)
+  std::replace(result.begin(), result.end(), '\\', '/');
+#endif
+
+  return result;
+}
+
+string NormalizeFolderPath(const string& path) {
+  string result = NormalizeFilePath(path);
+  // Ensure trailing slash.
+  if (!result.empty() && result.back() != '/')
+      result += "/";
   return result;
 }
 

--- a/iwyu_path_util.h
+++ b/iwyu_path_util.h
@@ -43,21 +43,18 @@ bool IsHeaderFile(string path);
 // else return the input path.
 string Basename(const string& path);
 
-// On Microsoft platforms, convert \ to /.
-string CanonicalizeFilePath(const string& path);
-
-// Canonicalize slashes and ensure trailing slash.
-string CanonicalizeHeaderSearchPath(const string& path);
-
 // Removes enclosing <> or "", then strips uninteresting suffixes from
 // the file name. Replaces "/internal/" with "/public/" and
-// "/include/" with "/src".  "Canonicalize" the path on Microsoft
-// platforms.
+// "/include/" with "/src".  Normalize the file path.
 string GetCanonicalName(string file_path);
 
-// "Canonicals" the name on Microsoft platforms, then recursively
+// Replaces "\" by "/" (Microsoft platform paths), then recursively
 // removes all "./" prefixes.
 string NormalizeFilePath(const string& path);
+
+// Normalizes like NormalizeFilePath and ensures trailing slash.
+// Hence use only for folders!
+string NormalizeFolderPath(const string& path);
 
 // Is path absolute?
 bool IsAbsolutePath(const string& path);


### PR DESCRIPTION
As discussed in #276 (https://github.com/include-what-you-use/include-what-you-use/pull/276#discussion_r63248447, https://github.com/include-what-you-use/include-what-you-use/pull/276/files#r63247740) the `CanonicalizeFilePath` is redundant and `NormalizeFilePath` should be used. Additionally we also need a function that adds the trailing slash to paths so compares for path suffixes are done correctly. This is now `NormalizeFolderPath`