### PR TITLE
Install mapping files in share/include-what-you-use

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,3 +180,7 @@ endif()
 
 install(TARGETS include-what-you-use RUNTIME DESTINATION bin)
 install(PROGRAMS fix_includes.py iwyu_tool.py DESTINATION bin)
+
+# Install mapping files
+file(GLOB MAPPING_FILES *.imp)
+install(FILES ${MAPPING_FILES} DESTINATION share/include-what-you-use)


### PR DESCRIPTION
Make mapping files  available for users who doesn't build include-what-you-use themselves.