### PR TITLE
Fix #310: Replace Each with range loops

### DIFF
--- a/iwyu_globals.cc
+++ b/iwyu_globals.cc
@@ -282,9 +282,8 @@ static bool SortByDescendingLength(const HeaderSearchPath& left,
 static vector<HeaderSearchPath> NormalizeHeaderSearchPaths(
     const map<string, HeaderSearchPath::Type>& include_dirs_map) {
   vector<HeaderSearchPath> include_dirs;
-  for (Each<string, HeaderSearchPath::Type>
-           it(&include_dirs_map); !it.AtEnd(); ++it) {
-    include_dirs.push_back(HeaderSearchPath(it->first, it->second));
+  for (const pair<string, HeaderSearchPath::Type>& entry : include_dirs_map) {
+    include_dirs.push_back(HeaderSearchPath(entry.first, entry.second));
   }
 
   sort(include_dirs.begin(), include_dirs.end(), &SortByDescendingLength);
@@ -328,15 +327,16 @@ void InitGlobals(clang::SourceManager* sm,
   function_calls_full_use_cache = new FullUseCache;
   class_members_full_use_cache = new FullUseCache;
 
-  for (Each<HeaderSearchPath> it(&search_paths); !it.AtEnd(); ++it) {
-    const char* path_type_name
-        = (it->path_type == HeaderSearchPath::kSystemPath ? "system" : "user");
-    VERRS(6) << "Search path: " << it->path << " (" << path_type_name << ")\n";
+  for (const HeaderSearchPath& entry : search_paths) {
+    const char* path_type_name =
+        (entry.path_type == HeaderSearchPath::kSystemPath ? "system" : "user");
+    VERRS(6) << "Search path: " << entry.path << " (" << path_type_name
+             << ")\n";
   }
 
   // Add mappings.
-  for (Each<string> it(&GlobalFlags().mapping_files); !it.AtEnd(); ++it) {
-    include_picker->AddMappingsFromFile(*it);
+  for (const string& mapping_file : GlobalFlags().mapping_files) {
+    include_picker->AddMappingsFromFile(mapping_file);
   }
 }
 
@@ -389,8 +389,8 @@ void AddGlobToReportIWYUViolationsFor(const string& glob) {
 
 bool ShouldReportIWYUViolationsFor(const clang::FileEntry* file) {
   const string filepath = GetFilePath(file);
-  for (Each<string> it(&GlobalFlags().check_also); !it.AtEnd(); ++it)
-    if (GlobMatchesPath(it->c_str(), filepath.c_str()))
+  for (const string& glob : GlobalFlags().check_also)
+    if (GlobMatchesPath(glob.c_str(), filepath.c_str()))
       return true;
   return false;
 }

--- a/iwyu_output.h
+++ b/iwyu_output.h
@@ -283,22 +283,23 @@ class IwyuFileInfo {
   }
   set<string> AssociatedQuotedIncludes() const {
     set<string> associated_quoted_includes;
-    for (Each<const IwyuFileInfo*> it(&associated_headers_); !it.AtEnd(); ++it)
-      associated_quoted_includes.insert((*it)->quoted_file_);
+    for (const IwyuFileInfo* associated : associated_headers_)
+      associated_quoted_includes.insert(associated->quoted_file_);
     return associated_quoted_includes;
   }
 
   set<const clang::FileEntry*> AssociatedFileEntries() const {
     set<const clang::FileEntry*> associated_file_entries;
-    for (Each<const IwyuFileInfo*> it(&associated_headers_); !it.AtEnd(); ++it)
-      associated_file_entries.insert((*it)->file_);
+    for (const IwyuFileInfo* associated : associated_headers_)
+      associated_file_entries.insert(associated->file_);
     return associated_file_entries;
   }
 
   set<string> AssociatedDesiredIncludes() const {
     set<string> associated_desired_includes;
-    for (Each<const IwyuFileInfo*> it(&associated_headers_); !it.AtEnd(); ++it)
-      InsertAllInto((*it)->desired_includes(), &associated_desired_includes);
+    for (const IwyuFileInfo* associated : associated_headers_)
+      InsertAllInto(associated->desired_includes(),
+                    &associated_desired_includes);
     return associated_desired_includes;
   }
 

--- a/iwyu_path_util.cc
+++ b/iwyu_path_util.cc
@@ -191,12 +191,12 @@ string ConvertToQuotedInclude(const string& filepath,
   // HeaderSearchPaths is sorted to be longest-first, so this
   // loop will prefer the longest prefix: /usr/include/c++/4.4/foo
   // will be mapped to <foo>, not <c++/4.4/foo>.
-  for (Each<HeaderSearchPath> it(&search_paths); !it.AtEnd(); ++it) {
+  for (const HeaderSearchPath& entry : search_paths) {
     // All header search paths have a trailing "/", so we'll get a perfect
     // quoted include by just stripping the prefix.
 
-    if (StripPathPrefix(&path, it->path)) {
-      if (it->path_type == HeaderSearchPath::kSystemPath)
+    if (StripPathPrefix(&path, entry.path)) {
+      if (entry.path_type == HeaderSearchPath::kSystemPath)
         return "<" + path + ">";
       else
         return "\"" + path + "\"";

--- a/iwyu_stl_util.h
+++ b/iwyu_stl_util.h
@@ -15,14 +15,12 @@
 #include <algorithm>                    // for find
 #include <map>                          // for map, multimap
 #include <set>                          // for set
-#include <utility>                      // for pair
 #include <vector>                       // for vector
 
 namespace include_what_you_use {
 
 using std::map;
 using std::multimap;
-using std::pair;
 using std::set;
 using std::vector;
 
@@ -146,90 +144,6 @@ vector<T> GetUniqueEntries(const vector<T>& v) {
   }
   return retval;
 }
-
-// Utilities for writing concise loops over STL containers.
-//
-//   for (Each<T> it(&some_container); !it.AtEnd(); ++it) {
-//     ... access the current element via *it or it->something ...
-//   }
-//
-//   for (Each<Key, Value> it(&some_map); !it.AtEnd(); ++it) {
-//     ... access the key via it->first ...
-//     ... access the value via it->second ...
-//   }
-//
-// Benefit of Each over concise_iterator.h:
-//
-//   - Only the element type (as opposed to the entire container type)
-//     needs to be specified.
-//   - Safer as it doesn't allow the container to be a temporary object.
-//
-// Disadvantage:
-//
-//   - Slower (AtEnd(), ++, and iterator dereference all involve a
-//     virtual call).
-template <typename T, typename U = void>
-class Each;
-
-template <typename Element>
-class Each<Element, void> {  // implements Each<Element>
- public:
-  template <class Container>
-  explicit Each(const Container* container)
-      : impl_(new Impl<typename Container::const_iterator>(container->begin(),
-                                                           container->end())) {}
-  ~Each() { delete impl_; }
-
-  // Returns true if the iterator points to the end of the container.
-  bool AtEnd() const { return impl_->AtEnd(); }
-
-  // Advances the iterator.
-  void operator++() { impl_->Advance(); }
-
-  // Reads the current element.
-  const Element& operator*() const { return *impl_->Get(); }
-  const Element* operator->() const { return impl_->Get(); }
-
- private:
-  class ImplBase {
-   public:
-    virtual ~ImplBase() {}
-
-    virtual bool AtEnd() const = 0;
-    virtual void Advance() = 0;
-    virtual const Element* Get() const = 0;
-  };
-
-  template <typename Iter>
-  class Impl : public ImplBase {
-   public:
-    Impl(Iter begin, Iter end)
-        : current_(begin),
-          end_(end) {}
-
-    bool AtEnd() const override { return current_ == end_; }
-    void Advance() override { ++current_; }
-    const Element* Get() const override { return &(*current_); }
-
-   private:
-    Iter current_;
-    const Iter end_;
-  };
-
-  Each(const Each&);  // No implementation.
-  void operator=(const Each&);  // No implementation.
-
-  ImplBase* const impl_;
-};
-
-// Each<Key, Value> is just a short-hand for Each<pair<const Key, Value> >.
-template <typename Key, typename Value>
-class Each : public Each<pair<const Key, Value> > {
- public:
-  template <class Container>
-  explicit Each(const Container* container)
-      : Each<pair<const Key, Value> >(container) {}
-};
 
 }  // namespace include_what_you_use
 


### PR DESCRIPTION
I worked through this just to see how it would pan out.

Some observations:

- Resulting code feels cleaner to me overall
- Map iteration almost always needs `auto` to avoid stuff like `pair<string, pair<string, string> >` as a value type

The diff is pretty huge. I kept it as separate commits to make it easier to review, but I thought I'd squash it before merging.

Let me know what you think.