### PR TITLE
Don't classify anonymous types as fwd-decls

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -1374,6 +1374,9 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
                                                SourceLocation loc) {
     set<const NamedDecl*> redecls = GetClassRedecls(DynCastFrom(decl));
     for (const NamedDecl* redecl : redecls) {
+      // Anonymous types can't be forward-decls.
+      if (redecl->getName().empty())
+        continue;
       if (IsBeforeInSameFile(redecl, loc)) {
         return redecl;
       }

--- a/tests/cxx/macro_location-i3.h
+++ b/tests/cxx/macro_location-i3.h
@@ -10,3 +10,22 @@
 #define DECLARE_FRIEND(cls)  friend class cls
 
 class Foo {};
+
+
+// Reduced example from the Linux kernel:
+// http://lxr.free-electrons.com/source/tools/include/linux/compiler.h#L112
+//
+// (The below test code is absolute nonsense, but it triggers the same IWYU
+// behavior as the actual READ_ONCE macro.)
+//
+// This makes sure we don't treat anonymous type declarations as forward-decls
+// in the context of macro use locations.
+#define ANONYMOUS_TYPE_IN_MACRO(value) \
+  char nonsense() {                    \
+    union {                            \
+      int v;                           \
+      char c[1];                       \
+    } u;                               \
+    u.v = value;                       \
+    return u.c[0];                     \
+  }

--- a/tests/cxx/macro_location.h
+++ b/tests/cxx/macro_location.h
@@ -37,6 +37,9 @@ CONCAT(Concat, FwdDeclClass) *global_concat_ptr;
 // IWYU: ConcatClass is...*macro_location-i4.h
 CONCAT(Concat, Class) global_concat;
 
+// IWYU: ANONYMOUS_TYPE_IN_MACRO is...*macro_location-i3.h
+ANONYMOUS_TYPE_IN_MACRO(500);
+
 /**** IWYU_SUMMARY
 
 tests/cxx/macro_location.h should add these lines:
@@ -50,7 +53,7 @@ tests/cxx/macro_location.h should remove these lines:
 The full include-list for tests/cxx/macro_location.h:
 #include "tests/cxx/indirect.h"  // for IndirectClass
 #include "tests/cxx/macro_location-d2.h"  // for ARRAYSIZE, CREATE_VAR, DECLARE_INDIRECT, NEW_CLASS, USE_CLASS
-#include "tests/cxx/macro_location-i3.h"  // for Foo
+#include "tests/cxx/macro_location-i3.h"  // for ANONYMOUS_TYPE_IN_MACRO, Foo
 #include "tests/cxx/macro_location-i4.h"  // for ConcatClass, ConcatFwdDeclClass (ptr only)
 
 


### PR DESCRIPTION
When looking for forward-decl hints in macro definition files, avoid
anonymous types.

This fixes #334.

Additional note: there should be other cases where this can break. I think the real fix is to find any declarations outside of the macro definition range, but I'm not entirely sure how to do that, so this is a good start.