### PR TITLE
Automatically reexport enums in call-expressions

### DIFF
--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -70,6 +70,7 @@ using clang::DependentTemplateName;
 using clang::DependentTemplateSpecializationType;
 using clang::ElaboratedType;
 using clang::EnumDecl;
+using clang::EnumType;
 using clang::ExplicitCastExpr;
 using clang::Expr;
 using clang::ExprWithCleanups;
@@ -377,6 +378,13 @@ bool IsMemberOfATypedef(const ASTNode* ast_node) {
     if (nns->getAsType() && isa<TypedefType>(nns->getAsType()))
       return true;
   }
+  return false;
+}
+
+bool IsUnscopedEnum(const DeclRefExpr* expr) {
+  if (const EnumType* enum_type = DynCastFrom(GetTypeOf(expr->getDecl())))
+    return !enum_type->getDecl()->isScoped();
+
   return false;
 }
 

--- a/iwyu_ast_util.h
+++ b/iwyu_ast_util.h
@@ -36,6 +36,7 @@ class CXXRecordDecl;
 class CallExpr;
 class CastExpr;
 class ClassTemplateDecl;
+class DeclRefExpr;
 class Expr;
 class FunctionDecl;
 class NamedDecl;
@@ -413,6 +414,10 @@ const clang::NestedNameSpecifier* GetQualifier(const ASTNode* ast_node);
 // MyTypedef::a, or MyTypedef::subclass::a, etc.  Note it does
 // *not* return true if the ast_node itself is a typedef.
 bool IsMemberOfATypedef(const ASTNode* ast_node);
+
+// Return true if expr refers to an enumerator whose type is a unscoped,
+// pre-C++11, enum decl.
+bool IsUnscopedEnum(const clang::DeclRefExpr* expr);
 
 // Returns the decl-context of the deepest decl in the ast-chain.
 const clang::DeclContext* GetDeclContext(const ASTNode* ast_node);

--- a/run_iwyu_tests.py
+++ b/run_iwyu_tests.py
@@ -126,6 +126,7 @@ class OneIwyuTest(unittest.TestCase):
       'double_include.cc': ['.'],
       'elaborated_struct.c': ['.'],
       'elaborated_type.cc': ['.'],
+      'enum_reexport.cc': ['.'],
       'external_including_internal.cc': ['.'],
       'forward_declare_in_macro.cc': ['.'],
       'fullinfo_for_templates.cc': ['.'],

--- a/tests/cxx/enum_reexport.cc
+++ b/tests/cxx/enum_reexport.cc
@@ -1,0 +1,41 @@
+//===--- enum_reexport.cc - test input file for iwyu ----------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// Tests that IWYU ignores uses of enumerators as part of call-expressions.
+// The motivation is that unscoped enums are not forward-declarable, so
+// the file declaring the function being called must already include
+// the enum definition.
+//
+// This is only strictly true for pre-C++11 unscoped enums, but idiomatically
+// they come in two flavors: enums nested in a class and free enums in global
+// scope. The logic above is valid for both.
+
+#include "tests/cxx/enum_reexport_func.h"
+
+
+void TestNestedEnum() {
+  FreeFunction(Unscoped::V1);
+
+  Class c;
+  c.Method(Unscoped::V2);
+}
+
+void TestGlobalEnum() {
+  FreeFunction(UE_V1);
+
+  Class c;
+  c.Method(UE_V3);
+}
+
+
+/**** IWYU_SUMMARY
+
+(tests/cxx/enum_reexport.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/enum_reexport_enum.h
+++ b/tests/cxx/enum_reexport_enum.h
@@ -1,0 +1,25 @@
+//===--- enum_reexport_enum.h - test input file for iwyu ------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// Enum nested in class.
+class Unscoped {
+public:
+  enum Enum {
+    V1,
+    V2,
+    V3
+  };
+};
+
+// Global enum.
+enum UnscopedEnum {
+  UE_V1,
+  UE_V2,
+  UE_V3
+};

--- a/tests/cxx/enum_reexport_func.h
+++ b/tests/cxx/enum_reexport_func.h
@@ -1,0 +1,22 @@
+//===--- enum_reexport_func.h - test input file for iwyu ------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/enum_reexport_enum.h"
+
+// Declare a couple of free functions taking enums both nested and globally
+// scoped.
+void FreeFunction(Unscoped::Enum);
+void FreeFunction(UnscopedEnum);
+
+// Declare a class with methods taking enums, both nested and globally scoped.
+class Class {
+public:
+  void Method(Unscoped::Enum);
+  void Method(UnscopedEnum);
+};


### PR DESCRIPTION
When an enum is used in a call-expression, the target of that
call-expression must have included the enum definition to be able to
declare its prototype.

Since we already depend on the callee itself, the enum must be
indirectly available and we can ignore its use in this context.

Commentary: This is a tentative fix for #244. I've moved code around most of the code base until I found this to be the cleanest cut to ignore uses of enumerators in call-expressions. Let me know what you think. 

@ThosRTanner, it'd be great if you could test this on your Qt example.
