### PR TITLE
Improve macro use-attribution heuristics

### DIFF
--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -119,6 +119,7 @@ using clang::VarDecl;
 using llvm::ArrayRef;
 using llvm::PointerUnion;
 using llvm::cast;
+using llvm::dyn_cast;
 using llvm::dyn_cast_or_null;
 using llvm::errs;
 using llvm::isa;
@@ -895,10 +896,15 @@ bool IsFriendDecl(const Decl* decl) {
   return decl->getFriendObjectKind() != Decl::FOK_None;
 }
 
-bool IsForwardDecl(const clang::TagDecl* decl) {
-  return (isa<RecordDecl>(decl) &&   // not an enum
-          !decl->isCompleteDefinition() && !IsFriendDecl(decl) &&
-          !decl->isEmbeddedInDeclarator());
+bool IsForwardDecl(const NamedDecl* decl) {
+  if (const auto* record_decl = dyn_cast<RecordDecl>(decl)) {
+    return (!record_decl->getName().empty() &&
+            !record_decl->isCompleteDefinition() &&
+            !record_decl->isEmbeddedInDeclarator() &&
+            !IsFriendDecl(record_decl));
+  }
+
+  return false;
 }
 
 // Two possibilities: it's written as a nested class (that is, with a

--- a/iwyu_ast_util.h
+++ b/iwyu_ast_util.h
@@ -589,11 +589,11 @@ bool IsDefaultNewOrDelete(const clang::FunctionDecl* decl,
 // Returns true if this decl is part of a friend decl.
 bool IsFriendDecl(const clang::Decl* decl);
 
-// Returns true if a Record-decl looks like a forward-declaration of a
+// Returns true if a named decl looks like a forward-declaration of a
 // class (rather than a definition, a friend declaration, or an 'in
 // place' declaration like 'struct Foo' in 'void MyFunc(struct Foo*);'
 // Always returns false for enums.
-bool IsForwardDecl(const clang::TagDecl* decl);
+bool IsForwardDecl(const clang::NamedDecl* decl);
 
 // Returns true if this decl is defined inside another class/struct.
 // Unlike IsNestedClassAsWritten(), which works on an ASTNode, this

--- a/tests/cxx/macro_location-d4.h
+++ b/tests/cxx/macro_location-d4.h
@@ -1,0 +1,40 @@
+//===--- macro_location-d4.h - test input file for iwyu -------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// This file contains negative cases for the forward-declares used for
+// use-attribution hints when expanding macros.
+
+#include "tests/cxx/macro_location-i5.h" // for UNNAMED_TYPE_IN_MACRO
+
+// A class declared in this file and used via a macro defined in this file
+// should not be seen by IWYU in files expanding the macro.
+class Logger {
+ public:
+  void Log(int level, const char* msg);
+};
+
+// A forward-declaration inside a macro should not count as a use-attribution
+// hint and should not be seen by IWYU in files expanding other macros.
+#define UNRELATED_FORWARD_DECLARE class Logger;
+
+#define LOG_INFO(x) \
+  Logger().Log(0, x);
+
+// A class declared and used in this macro should not be seen by IWYU in files
+// expanding the macro. This is similar to USE_CLASS in macro_location-d2.h, but
+// doesn't involve macro arg concatentation.
+// (And yes, this code is broken in so many ways, it's only to put the test case
+// in a vaguely real-life scenario)
+#define DECLARE_AND_USE_CLASS(y)     \
+  class ScopedLogger {               \
+   public:                           \
+    ScopedLogger() { LOG_INFO(y); }  \
+    ~ScopedLogger() { LOG_INFO(y); } \
+  };                                 \
+  ScopedLogger lll;

--- a/tests/cxx/macro_location-i5.h
+++ b/tests/cxx/macro_location-i5.h
@@ -1,0 +1,27 @@
+//===--- macro_location-i5.h - test input file for iwyu -------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// This file contains negative cases for the forward-declares used for
+// use-attribution hints when expanding macros.
+
+// An unnamed type inside a macro should not be seen by IWYU in files expanding
+// the macro.
+//
+// The below test code is absolute nonsense, it's reduced from the definition of
+// READ_ONCE in the Linux kernel:
+// http://lxr.free-electrons.com/source/tools/include/linux/compiler.h#L112
+#define UNNAMED_TYPE_IN_MACRO(value) \
+  char nonsense() {                  \
+    union {                          \
+      int v;                         \
+      char c[1];                     \
+    } u;                             \
+    u.v = value;                     \
+    return u.c[0];                   \
+  }

--- a/tests/cxx/macro_location.h
+++ b/tests/cxx/macro_location.h
@@ -9,6 +9,7 @@
 #include "tests/cxx/indirect.h"
 #include "tests/cxx/macro_location-d2.h"
 #include "tests/cxx/macro_location-d3.h"
+#include "tests/cxx/macro_location-d4.h"
 
 class Foo;
 static Foo *foo = 0;
@@ -37,11 +38,23 @@ CONCAT(Concat, FwdDeclClass) *global_concat_ptr;
 // IWYU: ConcatClass is...*macro_location-i4.h
 CONCAT(Concat, Class) global_concat;
 
+// Make sure types defined and used only within a macro definition file
+// aren't attributed to the macro expansion loc.
+
+// IWYU: UNNAMED_TYPE_IN_MACRO is...*macro_location-i5.h
+UNNAMED_TYPE_IN_MACRO(500);
+
+void func() {
+  LOG_INFO("hello");
+  DECLARE_AND_USE_CLASS("hello again");
+}
+
 /**** IWYU_SUMMARY
 
 tests/cxx/macro_location.h should add these lines:
 #include "tests/cxx/macro_location-i3.h"
 #include "tests/cxx/macro_location-i4.h"
+#include "tests/cxx/macro_location-i5.h"
 
 tests/cxx/macro_location.h should remove these lines:
 - #include "tests/cxx/macro_location-d3.h"  // lines XX-XX
@@ -50,8 +63,10 @@ tests/cxx/macro_location.h should remove these lines:
 The full include-list for tests/cxx/macro_location.h:
 #include "tests/cxx/indirect.h"  // for IndirectClass
 #include "tests/cxx/macro_location-d2.h"  // for ARRAYSIZE, CREATE_VAR, DECLARE_INDIRECT, NEW_CLASS, USE_CLASS
+#include "tests/cxx/macro_location-d4.h"  // for DECLARE_AND_USE_CLASS, LOG_INFO
 #include "tests/cxx/macro_location-i3.h"  // for Foo
 #include "tests/cxx/macro_location-i4.h"  // for ConcatClass, ConcatFwdDeclClass (ptr only)
+#include "tests/cxx/macro_location-i5.h"  // for UNNAMED_TYPE_IN_MACRO
 
 
 ***** IWYU_SUMMARY */


### PR DESCRIPTION
Bugs #334, #335 and #338 were all caused by the new macro location
rule that considers a forward-decl in the macro definition file a
hint that uses of the declared type inside a macro are attributed
to the macro's expansion location.

Several different kinds of declarations were mis-characterized as
forward decls.

This patch improves IsForwardDecl to better detect this, and
simplifies the heuristic rule so that any forward-declaration
outside of a macro in the same file as the macro definition will
count as a use-attribution hint.

This deprecates #342.