### PR TITLE
Recognize nested classes in friend declarations

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -3795,12 +3795,12 @@ class IwyuAstConsumer
       current_ast_node()->set_in_forward_declare_context(true);
       if (compiler()->getLangOpts().CPlusPlus) {
         // In C++, if we're already elaborated ('class Foo x') but not
-        // namespace-qualified ('class ns::Foo x') there's no need even to
-        // forward-declare.
+        // a qualified name ('class ns::Foo x', 'class Class::Nested x') there's
+        // no need even to forward-declare.
         // Note that enums are never forward-declarable, so elaborated enums are
-        // short-circuited in CanForwardDeclareType.
+        // already short-circuited in CanForwardDeclareType.
         const ASTNode* parent = current_ast_node()->parent();
-        if (!IsElaborationNode(parent) || IsNamespaceQualifiedNode(parent))
+        if (!IsElaborationNode(parent) || IsQualifiedNameNode(parent))
           ReportDeclForwardDeclareUse(CurrentLoc(), type->getDecl());
       } else {
         // In C, all struct references are elaborated, so we really never need

--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -227,17 +227,13 @@ bool IsElaborationNode(const ASTNode* ast_node) {
   return elaborated_type && elaborated_type->getKeyword() != clang::ETK_None;
 }
 
-bool IsNamespaceQualifiedNode(const ASTNode* ast_node) {
+bool IsQualifiedNameNode(const ASTNode* ast_node) {
   if (ast_node == nullptr)
     return false;
   const ElaboratedType* elaborated_type = ast_node->GetAs<ElaboratedType>();
   if (elaborated_type == nullptr)
     return false;
-  const NestedNameSpecifier* qualifier = elaborated_type->getQualifier();
-  if (qualifier == nullptr)
-    return false;
-  return (qualifier->getKind() == NestedNameSpecifier::Global ||
-          qualifier->getKind() == NestedNameSpecifier::Namespace);
+  return elaborated_type->getQualifier() != nullptr;
 }
 
 bool IsNodeInsideCXXMethodBody(const ASTNode* ast_node) {

--- a/iwyu_ast_util.h
+++ b/iwyu_ast_util.h
@@ -375,9 +375,9 @@ class CurrentASTNodeUpdater {
 // uses ElaboratedType for namespaces ('ns::Foo myvar').
 bool IsElaborationNode(const ASTNode* ast_node);
 
-// See if a given ast_node is a namespace-qualified ElaboratedType
-// node. (E.g. 'class ns::Foo myyvar'.)
-bool IsNamespaceQualifiedNode(const ASTNode* ast_node);
+// See if a given ast_node is a qualified name part of an ElaboratedType
+// node (e.g. 'class ns::Foo x', 'class ::Global x' or 'class Outer::Inner x'.)
+bool IsQualifiedNameNode(const ASTNode* ast_node);
 
 // Return true if the given ast_node is inside a C++ method body.  Do
 // this by walking up the AST tree until you find a CXXMethodDecl,


### PR DESCRIPTION
Fragments such as this:

    friend class Container<T>::Iterator;

would not be recognized as needing a forward-declaration, so IWYU
would suggest removing forward-decls of Iterator.

This patch changes this and expands the test suite for nested classes
to cover containing class templates and friend declarations.

Fixes issue #331.