### PR TITLE
Clean up output from test runner

### DIFF
--- a/iwyu_test_util.py
+++ b/iwyu_test_util.py
@@ -109,6 +109,12 @@ def _GetIwyuPath():
   return _IWYU_PATH
 
 
+def _ShellQuote(arg):
+  if ' ' in arg:
+    arg = '"' + arg + '"'
+  return arg
+
+
 def _GetCommandOutput(command):
   p = subprocess.Popen(command,
                        shell=True,
@@ -424,8 +430,11 @@ def TestIwyuOnRelativeFile(test_case, cc_file, cpp_files_to_check,
   iwyu_flags = ['-Xiwyu ' + flag for flag in iwyu_flags]
 
   # TODO(csilvers): verify that has exit-status 0.
-  cmd = '"%s" %s %s %s' % (
-      _GetIwyuPath(), ' '.join(iwyu_flags), ' '.join(clang_flags), cc_file)
+  cmd = '%s %s %s %s' % (
+    _ShellQuote(_GetIwyuPath()),
+    ' '.join(iwyu_flags),
+    ' '.join(clang_flags),
+    cc_file)
   if verbose:
     print('>>> Running %s' % cmd)
   output = _GetCommandOutput(cmd)

--- a/run_iwyu_tests.py
+++ b/run_iwyu_tests.py
@@ -206,14 +206,8 @@ class OneIwyuTest(unittest.TestCase):
     files_to_check = [PosixPath(f) for f in files_to_check]
 
     iwyu_flags = self._iwyu_flags_map.get(filename, None)
-    if iwyu_flags:
-      logging.info('%s: Using iwyu flags %s', filename, str(iwyu_flags))
-
     clang_flags = self._clang_flags_map.get(filename, [])
     clang_flags.extend(self._include_map.get(filename, []))
-    if clang_flags:
-      logging.info('%s: Using clang flags %s', filename, str(clang_flags))
-
     iwyu_test_util.TestIwyuOnRelativeFile(self, filename, files_to_check,
                                           iwyu_flags, clang_flags, verbose=True)
 


### PR DESCRIPTION
Here's a small one with some aesthetics that have been bugging me for a while:

* Only quote the IWYU executable name when necessary
* Remove logging of IWYU and Clang flags, they are already visible on
  the command-line