### PR TITLE
Terminology: as-typed -> as-written

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -3088,7 +3088,7 @@ class InstantiatedTemplateVisitor
     const Type* class_type = GetTypeOf(expr);
     if (CanIgnoreType(class_type))  return true;
 
-    // If the ctor type is a SubstTemplateTypeParmType, get the type-as-typed.
+    // If the ctor type is a SubstTemplateTypeParmType, get the type-as-written.
     const Type* actual_type = ResugarType(class_type);
     CHECK_(actual_type && "If !CanIgnoreType(), we should be resugar-able");
     ReportTypeUse(caller_loc(), actual_type);

--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -508,7 +508,7 @@ static const Type* GetTemplateArgAsType(const TemplateArgument& tpl_arg) {
 // VarDecl 'vector<int(*)(const MyClass&)> x', it would return
 // (vector<int(*)(const MyClass&)>, int(*)(const MyClass&),
 // int(const MyClass&), int, const MyClass&, MyClass).  Note that
-// this function only returns types-as-typed, so it does *not* return
+// this function only returns types-as-written, so it does *not* return
 // alloc<int(*)(const MyClass&)>, even though it's part of vector.
 class TypeEnumerator : public RecursiveASTVisitor<TypeEnumerator> {
  public:
@@ -666,7 +666,7 @@ set<FunctionDecl*> GetLateParsedFunctionDecls(TranslationUnitDecl* decl) {
 // contains the original map elements plus mapping for the components.
 // This is because when a type is 'owned' by the template
 // instantiator, all parts of the type are owned.  We only consider
-// type-components as typed.
+// type-components as written.
 static map<const Type*, const Type*> ResugarTypeComponents(
     const map<const Type*, const Type*>& resugar_map) {
   map<const Type*, const Type*> retval = resugar_map;

--- a/iwyu_include_picker.cc
+++ b/iwyu_include_picker.cc
@@ -1007,7 +1007,7 @@ void IncludePicker::AddDirectInclude(const string& includer_filepath,
 
   quoted_includes_to_quoted_includers_[quoted_includee].insert(quoted_includer);
   const pair<string, string> key(includer_filepath, includee_filepath);
-  includer_and_includee_to_include_as_typed_[key] = quoted_include_as_written;
+  includer_and_includee_to_include_as_written_[key] = quoted_include_as_written;
 
   // Mark the clang fake-file "<built-in>" as private, so we never try
   // to map anything to it.
@@ -1265,7 +1265,7 @@ string IncludePicker::MaybeGetIncludeNameAsWritten(
     const string& includer_filepath, const string& includee_filepath) const {
   const pair<string, string> key(includer_filepath, includee_filepath);
   // I want to use GetOrDefault here, but it has trouble deducing tpl args.
-  const string* value = FindInMap(&includer_and_includee_to_include_as_typed_,
+  const string* value = FindInMap(&includer_and_includee_to_include_as_written_,
                                   key);
   return value ? *value : "";
 }
@@ -1323,17 +1323,17 @@ vector<string> IncludePicker::GetCandidateHeadersForFilepathIncludedFrom(
   // We'll have called ConvertToQuotedInclude on members of retval,
   // but sometimes we can do better -- if included_filepath is in
   // retval, the iwyu-preprocessor may have stored the quoted-include
-  // as typed in including_filepath.  This is better to use than
+  // as written in including_filepath.  This is better to use than
   // ConvertToQuotedInclude because it avoids trouble when the same
   // file is accessible via different include search-paths, or is
   // accessed via a symlink.
-  const string& quoted_include_as_typed
+  const string& quoted_include_as_written
       = MaybeGetIncludeNameAsWritten(including_filepath, included_filepath);
-  if (!quoted_include_as_typed.empty()) {
+  if (!quoted_include_as_written.empty()) {
     vector<string>::iterator it = std::find(retval.begin(), retval.end(),
                                             quoted_includee);
     if (it != retval.end())
-      *it = quoted_include_as_typed;
+      *it = quoted_include_as_written;
   }
   return retval;
 }

--- a/iwyu_include_picker.h
+++ b/iwyu_include_picker.h
@@ -203,7 +203,7 @@ class IncludePicker {
   vector<string> GetPublicValues(const IncludeMap& m, const string& key) const;
 
   // Given an includer-pathname and includee-pathname, return the
-  // quoted-include of the includee, as typed in the includer, or
+  // quoted-include of the includee, as written in the includer, or
   // "" if it's not found for some reason.
   string MaybeGetIncludeNameAsWritten(const string& includer_filepath,
                                       const string& includee_filepath) const;
@@ -231,7 +231,8 @@ class IncludePicker {
   // include-as-written (including <>'s or ""'s) that the includer
   // used to refer to the includee.  We use this to return includes as
   // they were written in the source, when possible.
-  map<pair<string, string>, string> includer_and_includee_to_include_as_typed_;
+  map<pair<string, string>, string>
+      includer_and_includee_to_include_as_written_;
 
   // Maps from a quoted filepath pattern to the set of files that used
   // a pragma declaring it as a friend.  That is, if foo/bar/x.h has a

--- a/iwyu_lexer_utils.cc
+++ b/iwyu_lexer_utils.cc
@@ -69,8 +69,9 @@ SourceLocation GetLocationAfter(
   return start_loc.getLocWithOffset(needle_loc - data + needle.length());
 }
 
-string GetIncludeNameAsTyped(SourceLocation include_loc,
-                             const CharacterDataGetterInterface& data_getter) {
+string GetIncludeNameAsWritten(
+    SourceLocation include_loc,
+    const CharacterDataGetterInterface& data_getter) {
   const string data = GetSourceTextUntilEndOfLine(include_loc, data_getter);
   if (data.empty())
     return data;

--- a/iwyu_lexer_utils.h
+++ b/iwyu_lexer_utils.h
@@ -57,12 +57,12 @@ clang::SourceLocation GetLocationAfter(
     clang::SourceLocation start_loc, const string& needle,
     const CharacterDataGetterInterface& data_getter);
 
-// Returns the include-name as typed, including <>'s and ""'s.
+// Returns the include-name as written, including <>'s and ""'s.
 // Resolved computed includes first, so given
 //    #define INC  <stdio.h>
 //    #include INC
 // If include_loc points to the second INC, we'll return '<stdio.h>'.
-string GetIncludeNameAsTyped(
+string GetIncludeNameAsWritten(
     clang::SourceLocation include_loc,
     const CharacterDataGetterInterface& data_getter);
 

--- a/iwyu_preprocessor.h
+++ b/iwyu_preprocessor.h
@@ -243,12 +243,12 @@ class IwyuPreprocessorInfo : public clang::PPCallbacks,
   // #include from iwyu removal.
   void MaybeProtectInclude(clang::SourceLocation includer_loc,
                            const clang::FileEntry* includee,
-                           const string& include_name_as_typed);
+                           const string& include_name_as_written);
 
   // Called whenever an #include is seen in the preprocessor output.
   void AddDirectInclude(clang::SourceLocation includer_loc,
                         const clang::FileEntry* includee,
-                        const string& include_name_as_typed);
+                        const string& include_name_as_written);
 
   // Report a "begin_exports"/"end_exports" pragma pair.
   // begin_line is first line, end_line is just after the last line.
@@ -304,7 +304,7 @@ class IwyuPreprocessorInfo : public clang::PPCallbacks,
   // which we don't have.  Luckily, a vector works just as well.
   vector<clang::Token> macros_called_from_macros_;
 
-  // This maps from the include-name as typed in the program
+  // This maps from the include-name as written in the program
   // (including <>'s or ""'s) to the FileEntry we loaded for that
   // #include.
   map<string, const clang::FileEntry*> include_to_fileentry_map_;

--- a/more_tests/iwyu_lexer_utils_test.cc
+++ b/more_tests/iwyu_lexer_utils_test.cc
@@ -240,31 +240,31 @@ TEST(GetLocationAfter, BeginAfterStartOfText) {
             GetSourceTextUntilEndOfLine(after_loc, data_getter));
 }
 
-TEST(GetIncludeNameAsTyped, SystemInclude) {
+TEST(GetIncludeNameAsWritten, SystemInclude) {
   const char text[] = "#include <stdio.h>\n";
   StringCharacterDataGetter data_getter(text);
   SourceLocation begin_loc = data_getter.BeginningOfString();
   SourceLocation inc_loc = CreateSourceLocationFromOffset(begin_loc, 9);
   EXPECT_EQ("<stdio.h>",
-            GetIncludeNameAsTyped(inc_loc, data_getter));
+            GetIncludeNameAsWritten(inc_loc, data_getter));
 }
 
-TEST(GetIncludeNameAsTyped, NonsysytemInclude) {
+TEST(GetIncludeNameAsWritten, NonsysytemInclude) {
   const char text[] = "#include \"ads/util.h\"\n";
   StringCharacterDataGetter data_getter(text);
   SourceLocation begin_loc = data_getter.BeginningOfString();
   SourceLocation inc_loc = CreateSourceLocationFromOffset(begin_loc, 9);
   EXPECT_EQ("\"ads/util.h\"",
-            GetIncludeNameAsTyped(inc_loc, data_getter));
+            GetIncludeNameAsWritten(inc_loc, data_getter));
 }
 
-TEST(GetIncludeNameAsTyped, WithComments) {
+TEST(GetIncludeNameAsWritten, WithComments) {
   const char text[] = "#include <stdio.h>  // for printf\n";
   StringCharacterDataGetter data_getter(text);
   SourceLocation begin_loc = data_getter.BeginningOfString();
   SourceLocation inc_loc = CreateSourceLocationFromOffset(begin_loc, 9);
   EXPECT_EQ("<stdio.h>",
-            GetIncludeNameAsTyped(inc_loc, data_getter));
+            GetIncludeNameAsWritten(inc_loc, data_getter));
 }
 
 }  // namespace


### PR DESCRIPTION
Clang uses mostly "as-written" in its APIs. Follow that convention
more consistently.

Sparked by Eugene's comment on the recent clang-tidy patches.