### PR TITLE
Fix handling template creation as an array.

### DIFF
--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -1027,6 +1027,14 @@ const Type* GetTypeOf(const Expr* expr) {
   return expr->getType().getTypePtr();
 }
 
+const Type* GetTypeOf(const CXXConstructExpr* expr) {
+  const Type* type = expr->getType().getTypePtr();
+  if (const clang::ArrayType* array_type = type->getAsArrayTypeUnsafe()) {
+    type = array_type->getElementType().getTypePtr();
+  }
+  return type;
+}
+
 const Type* GetTypeOf(const ValueDecl* decl) {
   return decl->getType().getTypePtr();
 }

--- a/iwyu_ast_util.h
+++ b/iwyu_ast_util.h
@@ -650,6 +650,8 @@ bool DeclsAreInSameClass(const clang::Decl* decl1, const clang::Decl* decl2);
 // --- Utilities for Type.
 
 const clang::Type* GetTypeOf(const clang::Expr* expr);
+// Returns the type of the constructed class.
+const clang::Type* GetTypeOf(const clang::CXXConstructExpr* expr);
 // Returns the type of the given variable, function, or enum declaration.
 const clang::Type* GetTypeOf(const clang::ValueDecl* decl);
 // ...or class, struct, union, enum, typedef, or template type.


### PR DESCRIPTION
It fixes case in `tests/cxx/badinc.cc` when for

    new I1_TemplateClass<I2_Class, I1_Struct>[kI1ConstInt]

we erroneously don't need full declaration for `I1_Struct`.

Clang r283406 improved handling array creation which caused us to see
not template type but array type. The fix is to take element type in
this case.

Another attempted approach is

    GetTypeOf(constructor_expr->getConstructor()->getParent());

But it doesn't work because in this case we receive not template type
but instantiated RecordType that has no template arguments. For example,
with mentioned code we get type like

    RecordType 0x7fb7ccc251f0 'class I1_TemplateClass<class EmptyClass, struct Fail_Struct>'
    `-ClassTemplateSpecialization 0x7fb7ccc250f0 'I1_TemplateClass'

instead of desired

    TemplateSpecializationType 0x7fb7ccc253f0 'I1_TemplateClass<class EmptyClass, struct Fail_Struct>' sugar I1_TemplateClass
    |-TemplateArgument type 'class EmptyClass'
    |-TemplateArgument type 'struct Fail_Struct'
    `-RecordType 0x7fb7ccc251f0 'class I1_TemplateClass<class EmptyClass, struct Fail_Struct>'
      `-ClassTemplateSpecialization 0x7fb7ccc250f0 'I1_TemplateClass'