### PR TITLE
Handle CK_ZeroToOCLQueue cast kind

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -2030,6 +2030,7 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
       case clang::CK_ReinterpretMemberPointer:
       case clang::CK_BuiltinFnToFnPtr:
       case clang::CK_ZeroToOCLEvent: // OpenCL event_t is a built-in type.
+      case clang::CK_ZeroToOCLQueue: // OpenCL queue_t is a built-in type.
       case clang::CK_IntToOCLSampler: // OpenCL sampler_t is a built-in type.
       case clang::CK_AddressSpaceConversion:  // Address spaces are associated
                                               // with pointers, so no need for


### PR DESCRIPTION
Added in Clang in r290431, and handled here to silence warning.