### PR TITLE
Remove incorrect test case assumption on desugared types

### DIFF
--- a/tests/cxx/derived_function_tpl_args.cc
+++ b/tests/cxx/derived_function_tpl_args.cc
@@ -70,8 +70,6 @@ int main() {
   Fn(lc);
   Fn(lc_ptr);
   FnWithPtr(lc_ptr);
-  // TODO(csilvers): this is wrong. Figure out how to resugar in this case too.
-  // IWYU: IndirectClass is...*derived_function_tpl_args-i1.h
   FnWithReference(lc);
   FnWithReference(lc_ptr);
 


### PR DESCRIPTION
Clang r289250 caused more type sugar to remain in the AST. That, in turn, caused
derived_function_tpl_args to fail, because we had a compensating assertion
(marked with a TODO indicating that it was undesirable.)

Now that type sugar survives, we won't see a need for IndirectClass
here. Rather, the use will be attributed to the LocalClass typedef, which exists
in the same file. No diagnostic expected.

(Fixes part of the tracking bug #384)