### PR TITLE
Pick up more sugar for function arguments

### DIFF
--- a/tests/cxx/derived_function_tpl_args.cc
+++ b/tests/cxx/derived_function_tpl_args.cc
@@ -65,8 +65,6 @@ int main() {
   typedef IndirectClass LocalClass;
   LocalClass lc;
   LocalClass* lc_ptr = 0;
-  // TODO(csilvers): this is wrong. Figure out how to resugar in this case too.
-  // IWYU: IndirectClass is...*derived_function_tpl_args-i1.h
   Fn(lc);
   Fn(lc_ptr);
   FnWithPtr(lc_ptr);


### PR DESCRIPTION
Type sugar (typedefs, more specifically) were previously lost for
arguments passed by value.

Introduce a new helper function to glean sugared type info from
ImplicitCastExpr nodes in the AST, as present in later revs of Clang.

Fixes a TODO in derived_function_tpl_args.