### PR TITLE
Adjust badinc test for improved Clang behavior

### DIFF
--- a/tests/cxx/badinc.cc
+++ b/tests/cxx/badinc.cc
@@ -1765,6 +1765,8 @@ int main() {
   const std::vector<float>::const_iterator float_constit = float_vector.begin();
   // IWYU: std::vector<.*>::const_iterator is...*<vector>
   (void)(float_it == float_constit);
+  // IWYU: std::vector<.*>::const_iterator is...*<vector>
+  (void)(float_constit == float_it);
   // IWYU: std::vector is...*<vector>
   // IWYU: std::vector<.*>::const_iterator is...*<vector>
   std::vector<float>::const_iterator float_forit;

--- a/tests/cxx/badinc.cc
+++ b/tests/cxx/badinc.cc
@@ -1763,7 +1763,7 @@ int main() {
   // IWYU: std::vector is...*<vector>
   // IWYU: std::vector<.*>::const_iterator is...*<vector>
   const std::vector<float>::const_iterator float_constit = float_vector.begin();
-  // IWYU: std::vector is...*<vector>
+  // IWYU: std::vector<.*>::const_iterator is...*<vector>
   (void)(float_it == float_constit);
   // IWYU: std::vector is...*<vector>
   // IWYU: std::vector<.*>::const_iterator is...*<vector>
@@ -1785,8 +1785,8 @@ int main() {
            // IWYU: std::vector is...*<vector>
            float_reverse_it = float_vector.rbegin();
        // IWYU: std::vector is...*<vector>
+       // IWYU: std::vector<.*>::reverse_iterator is...*<vector>
        float_reverse_it != float_vector.rbegin();
-       // IWYU: std::vector is...*<vector>
        // IWYU: std::vector<.*>::reverse_iterator is...*<vector>
        ++float_reverse_it) ;
   // IWYU: std::vector is...*<vector>
@@ -1798,8 +1798,8 @@ int main() {
            // IWYU: std::vector is...*<vector>
            float_const_reverse_it = float_vector.rbegin();
        // IWYU: std::vector is...*<vector>
+       // IWYU: std::vector<.*>::const_reverse_iterator is...*<vector>
        float_const_reverse_it != float_vector.rend();
-       // IWYU: std::vector is...*<vector>
        // IWYU: std::vector<.*>::const_reverse_iterator is...*<vector>
        ++float_const_reverse_it) ;
 

--- a/tests/cxx/badinc.cc
+++ b/tests/cxx/badinc.cc
@@ -1763,8 +1763,10 @@ int main() {
   // IWYU: std::vector is...*<vector>
   // IWYU: std::vector<.*>::const_iterator is...*<vector>
   const std::vector<float>::const_iterator float_constit = float_vector.begin();
+  // IWYU: std::vector is...*<vector>
   // IWYU: std::vector<.*>::const_iterator is...*<vector>
   (void)(float_it == float_constit);
+  // IWYU: std::vector is...*<vector>
   // IWYU: std::vector<.*>::const_iterator is...*<vector>
   (void)(float_constit == float_it);
   // IWYU: std::vector is...*<vector>
@@ -1789,6 +1791,7 @@ int main() {
        // IWYU: std::vector is...*<vector>
        // IWYU: std::vector<.*>::reverse_iterator is...*<vector>
        float_reverse_it != float_vector.rbegin();
+       // IWYU: std::vector is...*<vector>
        // IWYU: std::vector<.*>::reverse_iterator is...*<vector>
        ++float_reverse_it) ;
   // IWYU: std::vector is...*<vector>
@@ -1802,6 +1805,7 @@ int main() {
        // IWYU: std::vector is...*<vector>
        // IWYU: std::vector<.*>::const_reverse_iterator is...*<vector>
        float_const_reverse_it != float_vector.rend();
+       // IWYU: std::vector is...*<vector>
        // IWYU: std::vector<.*>::const_reverse_iterator is...*<vector>
        ++float_const_reverse_it) ;
 


### PR DESCRIPTION
badinc.cc would have several intentional misattributions for iterators to
<vector>. Clang changed in r289250 to better preserve type sugar, which caused
these tests to produce more correct diagnostics. Test assertions were now
protecting broken behavior, and failing.

Adjust assertions to reflect goodness.