### PR TITLE
Update to reflect changes in Clang

### DIFF
--- a/iwyu_driver.cc
+++ b/iwyu_driver.cc
@@ -207,7 +207,7 @@ CompilerInstance* CreateCompilerInstance(int argc, const char **argv) {
   const ArgStringList &cc_arguments = command.getArguments();
   const char** args_start = const_cast<const char**>(cc_arguments.data());
   const char** args_end = args_start + cc_arguments.size();
-  unique_ptr<CompilerInvocation> invocation(new CompilerInvocation);
+  std::shared_ptr<CompilerInvocation> invocation(new CompilerInvocation);
   CompilerInvocation::CreateFromArgs(*invocation,
                                      args_start, args_end, diagnostics);
   invocation->getFrontendOpts().DisableFree = false;
@@ -238,7 +238,7 @@ CompilerInstance* CreateCompilerInstance(int argc, const char **argv) {
   // Create a compiler instance to handle the actual work.
   // The caller will be responsible for freeing this.
   CompilerInstance* compiler = new CompilerInstance;
-  compiler->setInvocation(invocation.release());
+  compiler->setInvocation(invocation);
 
   // Create the compilers actual diagnostics engine.
   compiler->createDiagnostics();


### PR DESCRIPTION
r291184 switched the CompilerInvocation argument to a shared_ptr.