### PR TITLE
WIN32: Link against version.dll to fix link error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,6 +163,7 @@ target_link_libraries(include-what-you-use
 if( WIN32 )
   target_link_libraries(include-what-you-use
     shlwapi
+    version
   )
 elseif( UNIX )
   include(FindCurses)


### PR DESCRIPTION
Fixes three missing symbols linker errors:

- `GetFileVersionInfoSizeW`
- `GetFileVersionInfoW`
- `VerQueryValueW`

Fixes the following build error:

```
[14/14] Linking CXX executable include-what-you-use.exe
FAILED: include-what-you-use.exe
cmd.exe /C "cd . && "C:\Program Files\CMake\bin\cmake.exe" -E vs_link_exe --intdir=CMakeFiles\include-what-you-use.dir --manifests  -- C:\PROGRA~2\MICROS~3.0\VC\bin\amd64\link.exe /nologo CMakeFiles\include-what-you-use.dir\iwyu.cc.obj CMakeFiles\include-what-you-use.dir\iwyu_ast_util.cc.obj CMakeFiles\include-what-you-use.dir\iwyu_cache.cc.obj CMakeFiles\include-what-you-use.dir\iwyu_driver.cc.obj CMakeFiles\include-what-you-use.dir\iwyu_getopt.cc.obj CMakeFiles\include-what-you-use.dir\iwyu_globals.cc.obj CMakeFiles\include-what-you-use.dir\iwyu_include_picker.cc.obj CMakeFiles\include-what-you-use.dir\iwyu_lexer_utils.cc.obj CMakeFiles\include-what-you-use.dir\iwyu_location_util.cc.obj CMakeFiles\include-what-you-use.dir\iwyu_output.cc.obj CMakeFiles\include-what-you-use.dir\iwyu_path_util.cc.obj CMakeFiles\include-what-you-use.dir\iwyu_preprocessor.cc.obj CMakeFiles\include-what-you-use.dir\iwyu_verrs.cc.obj  /out:include-what-you-use.exe /implib:include-what-you-use.lib /pdb:include-what-you-use.pdb /version:0.0  /machine:x64 /INCREMENTAL:NO /subsystem:console -LIBPATH:C:\Users\tbraunjones\opt\LLVM-master\lib clangFrontend.lib clangSerialization.lib clangDriver.lib clangParse.lib clangSema.lib clangAnalysis.lib clangAST.lib clangBasic.lib clangEdit.lib clangLex.lib LLVMX86AsmParser.lib LLVMX86CodeGen.lib LLVMX86Desc.lib LLVMX86AsmPrinter.lib LLVMX86Info.lib LLVMX86Utils.lib LLVMCodeGen.lib LLVMipo.lib LLVMScalarOpts.lib LLVMInstCombine.lib LLVMTransformUtils.lib LLVMTarget.lib LLVMAnalysis.lib LLVMOption.lib LLVMMCDisassembler.lib LLVMMCParser.lib LLVMMC.lib LLVMProfileData.lib LLVMObject.lib LLVMBitReader.lib LLVMCore.lib LLVMSupport.lib shlwapi.lib kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib ole32.lib oleaut32.lib uuid.lib comdlg32.lib advapi32.lib && cd ."
clangDriver.lib(MSVCToolChain.cpp.obj) : error LNK2019: unresolved external symbol GetFileVersionInfoSizeW referenced in function "public: virtual class clang::VersionTuple __cdecl clang::driver::toolchains::MSVCToolChain::getMSVCVersionFromExe(void)const " (?getMSVCVersionFromExe@MSVCToolChain@toolchains@driver@clang@@UEBA?AVVersionTuple@4@XZ)
clangDriver.lib(MSVCToolChain.cpp.obj) : error LNK2019: unresolved external symbol GetFileVersionInfoW referenced in function "public: virtual class clang::VersionTuple __cdecl clang::driver::toolchains::MSVCToolChain::getMSVCVersionFromExe(void)const " (?getMSVCVersionFromExe@MSVCToolChain@toolchains@driver@clang@@UEBA?AVVersionTuple@4@XZ)
clangDriver.lib(MSVCToolChain.cpp.obj) : error LNK2019: unresolved external symbol VerQueryValueW referenced in function "public: virtual class clang::VersionTuple __cdecl clang::driver::toolchains::MSVCToolChain::getMSVCVersionFromExe(void)const " (?getMSVCVersionFromExe@MSVCToolChain@toolchains@driver@clang@@UEBA?AVVersionTuple@4@XZ)
include-what-you-use.exe : fatal error LNK1120: 3 unresolved externals
LINK failed. with 1120
ninja: build stopped: subcommand failed.
```

(note the LLVM root path shown in the build log above suggests that I'm using the master branch of LLVM but I'm actually using 3.9.1 from `cfe-3.9.1.src.tar.xz` and  `llvm-3.9.1.src.tar.xz` downloads)

This fix may also be necessary in the master branch, but I have not tested that case.