### PR TITLE
How to Run: Redirect stderr to /tmp/iwyu.out

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Include What You Use #
 
-This README was generated on 2016-02-01 00:55:37 UTC.
+This README was generated on 2017-01-16 18:38:58 UTC.
 
 For more in-depth documentation, see http://github.com/include-what-you-use/include-what-you-use/tree/master/docs.
 
@@ -98,7 +98,7 @@ Include-what-you-use only analyzes .cc (or .cpp) files built by `make`, along wi
 
 We also include, in this directory, a tool that automatically fixes up your source files based on the IWYU recommendations.  This is also alpha-quality software!  Here's how to use it (requires python):
 
-      make -k CXX=/path/to/llvm/Debug+Asserts/bin/include-what-you-use > /tmp/iwyu.out
+      make -k CXX=/path/to/llvm/Debug+Asserts/bin/include-what-you-use 2> /tmp/iwyu.out
       python fix_includes.py < /tmp/iwyu.out
 
 If you don't like the way `fix_includes.py` munges your `#include` lines, you can control its behavior via flags. `fix_includes.py --help` will give a full list, but these are some common ones:

--- a/docs/InstructionsForUsers.md
+++ b/docs/InstructionsForUsers.md
@@ -91,7 +91,7 @@ Include-what-you-use only analyzes .cc (or .cpp) files built by `make`, along wi
 
 We also include, in this directory, a tool that automatically fixes up your source files based on the IWYU recommendations.  This is also alpha-quality software!  Here's how to use it (requires python):
 
-      make -k CXX=/path/to/llvm/Debug+Asserts/bin/include-what-you-use > /tmp/iwyu.out
+      make -k CXX=/path/to/llvm/Debug+Asserts/bin/include-what-you-use 2> /tmp/iwyu.out
       python fix_includes.py < /tmp/iwyu.out
 
 If you don't like the way `fix_includes.py` munges your `#include` lines, you can control its behavior via flags. `fix_includes.py --help` will give a full list, but these are some common ones:


### PR DESCRIPTION
The messages from include-what-you-use are printed on stderr, so redirect that
to the log file.