### PR TITLE
Adjust CMakeLists for out-of-tree builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,8 +45,10 @@ if( CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR )
       -D_SCL_SECURE_NO_WARNINGS
 
       # Disabled warnings.
+      -wd4141 # Suppress ''modifier' : used more than once' (because of __forceinline combined with inline)
       -wd4146 # Suppress 'unary minus operator applied to unsigned type, result still unsigned'
       -wd4244 # Suppress ''argument' : conversion from 'type1' to 'type2', possible loss of data'
+      -wd4267 # Suppress ''var' : conversion from 'size_t' to 'type', possible loss of data'
       -wd4291 # Suppress ''declaration' : no matching operator delete found; memory will not be freed if initialization throws an exception'
       -wd4345 # Suppress 'behavior change: an object of POD type constructed with an initializer of the form () will be default-initialized'
       -wd4355 # Suppress ''this' : used in base member initializer list'
@@ -109,6 +111,9 @@ if( MSVC )
     -D_HAS_EXCEPTIONS=0
   )
 
+  # Enable bigobj-support and sane C++ exception semantics.
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj /EHsc")
+
   # Put project in solution folder
   set_target_properties(include-what-you-use
     PROPERTIES FOLDER "Clang executables"
@@ -163,6 +168,7 @@ target_link_libraries(include-what-you-use
 if( WIN32 )
   target_link_libraries(include-what-you-use
     shlwapi
+    version # For clangDriver's MSVCToolchain
   )
 elseif( UNIX )
   include(FindCurses)

--- a/docs/InstructionsForUsers.md
+++ b/docs/InstructionsForUsers.md
@@ -35,7 +35,7 @@ In an out-of-tree configuration, we assume you already have compiled LLVM and Cl
         iwyu-trunk/include-what-you-use$ git checkout clang_3.2
         iwyu-trunk/include-what-you-use$ cd ..
 
-  * Create a build root and use CMake to generate a build system linked with LLVM/Clang prebuilts, e.g.
+  * Create a build root and use CMake to generate a build system linked with LLVM/Clang prebuilts. Note that CMake settings need to match exactly, so you may need to add `-DCMAKE_BUILD_TYPE=Release` or more to the command-line below:
 
         # This example uses the Makefile generator, but anything should work.
         iwyu-trunk$ mkdir build && cd build


### PR DESCRIPTION
PR #390 showed that IWYU doesn't actually build out-of-tree with Clang
3.9, as advertised.

The PR only added a link dependency on version.lib, but there were several
other problems:

- Warnings disabled by Clang/LLVM that we hadn't picked up
- Extended object format needed to be enabled (/bigobj)
- Sane exception handling (/EHsc) needed to explicitly enabled

I noticed these when building with MSVC 2015 for 64-bit, so some may be
sparked by that configuration.