### PR TITLE
Fix out-of-tree build for MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,8 +45,10 @@ if( CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR )
       -D_SCL_SECURE_NO_WARNINGS
 
       # Disabled warnings.
+      -wd4141 # Suppress ''modifier' : used more than once' (because of __forceinline combined with inline)
       -wd4146 # Suppress 'unary minus operator applied to unsigned type, result still unsigned'
       -wd4244 # Suppress ''argument' : conversion from 'type1' to 'type2', possible loss of data'
+      -wd4267 # Suppress ''var' : conversion from 'size_t' to 'type', possible loss of data'
       -wd4291 # Suppress ''declaration' : no matching operator delete found; memory will not be freed if initialization throws an exception'
       -wd4345 # Suppress 'behavior change: an object of POD type constructed with an initializer of the form () will be default-initialized'
       -wd4355 # Suppress ''this' : used in base member initializer list'
@@ -103,14 +105,14 @@ if( MINGW )
 endif()
 
 if( MSVC )
-  # Work around 'too many sections' error with MSVC
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj")
-
   # Disable warnings for IWYU, and disable exceptions in MSVC's STL.
   add_definitions(
     -wd4722 # Suppress ''destructor'' : destructor never returns, potential memory leak
     -D_HAS_EXCEPTIONS=0
   )
+
+  # Enable bigobj support and sane C++ exception semantics.
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj /EHsc")
 
   # Put project in solution folder
   set_target_properties(include-what-you-use
@@ -167,6 +169,7 @@ target_link_libraries(include-what-you-use
 if( WIN32 )
   target_link_libraries(include-what-you-use
     shlwapi
+    version # For clangDriver's MSVCToolchain
   )
 elseif( UNIX )
   include(FindCurses)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Include What You Use #
 
-This README was generated on 2017-01-16 18:38:58 UTC.
+This README was generated on 2017-01-30 19:01:29 UTC.
 
 For more in-depth documentation, see http://github.com/include-what-you-use/include-what-you-use/tree/master/docs.
 
@@ -42,7 +42,7 @@ In an out-of-tree configuration, we assume you already have compiled LLVM and Cl
         iwyu-trunk/include-what-you-use$ git checkout clang_3.2
         iwyu-trunk/include-what-you-use$ cd ..
 
-  * Create a build root and use CMake to generate a build system linked with LLVM/Clang prebuilts, e.g.
+  * Create a build root and use CMake to generate a build system linked with LLVM/Clang prebuilts. Note that CMake settings need to match exactly, so you may need to add `-DCMAKE_BUILD_TYPE=Release` or more to the command-line below:
 
         # This example uses the Makefile generator, but anything should work.
         iwyu-trunk$ mkdir build && cd build

--- a/docs/InstructionsForUsers.md
+++ b/docs/InstructionsForUsers.md
@@ -35,7 +35,7 @@ In an out-of-tree configuration, we assume you already have compiled LLVM and Cl
         iwyu-trunk/include-what-you-use$ git checkout clang_3.2
         iwyu-trunk/include-what-you-use$ cd ..
 
-  * Create a build root and use CMake to generate a build system linked with LLVM/Clang prebuilts, e.g.
+  * Create a build root and use CMake to generate a build system linked with LLVM/Clang prebuilts. Note that CMake settings need to match exactly, so you may need to add `-DCMAKE_BUILD_TYPE=Release` or more to the command-line below:
 
         # This example uses the Makefile generator, but anything should work.
         iwyu-trunk$ mkdir build && cd build


### PR DESCRIPTION
We don't build with MSVC out-of-tree regularly, so a number of
compatibility issues with LLVM had snuck in:

- Suppressed warnings in header LLVM files
- Extended object format support (/bigobj)
- Use of noexcept requires sane C++ exception semantics (/EHSc)
- Clang's MSVCToolChain.cpp now uses functions from version.dll, so add it
  to linker deps

While dabbling with this, we also found it was necessary to CMake with
-DCMAKE_BUILD_TYPE=Release to match LLVM's release-built libraries.
Mention this in the user docs.