### PR TITLE
Remove test expectation for char_traits

### DIFF
--- a/tests/cxx/badinc.cc
+++ b/tests/cxx/badinc.cc
@@ -1988,7 +1988,7 @@ The full include-list for tests/cxx/badinc.cc:
 #include <fstream>  // for fstream
 #include <list>  // for list
 #include <new>  // for operator new
-#include <string>  // for allocator, basic_string, basic_string<>::iterator, char_traits, operator+, string
+#include <string>  // for allocator, basic_string, basic_string<>::iterator, operator+, string
 #include <typeinfo>  // for type_info
 #include "tests/cxx/badinc-d1.h"  // for D1CopyClassFn, D1Function, D1_Class, D1_CopyClass, D1_Enum, D1_Enum::D11, D1_I1_Typedef, D1_StructPtr, D1_Subclass, D1_TemplateClass, D1_TemplateStructWithDefaultParam, MACRO_CALLING_I4_FUNCTION
 #include "tests/cxx/badinc-d4.h"  // for D4_ClassForOperator, operator<<


### PR DESCRIPTION
Clang no longer desugars as aggressively. As a consequence, char_traits no
longer 'leaks' through the definition of std::string and is not noted in
the why-comment for `<string>`.