### PR TITLE
Add optional terse flag to PrintableDecl

### DIFF
--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -402,10 +402,16 @@ string PrintableSourceRange(SourceRange range) {
   return PrintableLoc(range.getBegin()) + " - " + PrintableLoc(range.getEnd());
 }
 
-string PrintableDecl(const Decl* decl) {
-  std::string buffer;    // llvm wants regular string, not our versa-string
+string PrintableDecl(const Decl* decl, bool terse/*=true*/) {
+  // Use the terse flag to limit the level of output to one line.
+  clang::PrintingPolicy policy = decl->getASTContext().getPrintingPolicy();
+  policy.TerseOutput = terse;
+  policy.SuppressInitializers = terse;
+  policy.PolishForDeclaration = terse;
+
+  std::string buffer;
   raw_string_ostream ostream(buffer);
-  decl->print(ostream);  // Note: can also set indentation and printingpolicy
+  decl->print(ostream, policy);
   return ostream.str();
 }
 

--- a/iwyu_ast_util.h
+++ b/iwyu_ast_util.h
@@ -424,7 +424,7 @@ const clang::DeclContext* GetDeclContext(const ASTNode* ast_node);
 
 string PrintableLoc(clang::SourceLocation loc);
 string PrintableSourceRange(clang::SourceRange range);
-string PrintableDecl(const clang::Decl* decl);
+string PrintableDecl(const clang::Decl* decl, bool terse=true);
 string PrintableStmt(const clang::Stmt* stmt);
 string PrintableType(const clang::Type* type);
 string PrintableTypeLoc(const clang::TypeLoc& typeloc);


### PR DESCRIPTION
When working on the nested macros bug, I found it useful to be able log decls with less formatting.

I hacked up my own ugly post-formatting to get what I wanted, but then I realized that Clang has a printing policy specifically for this.

Hoping to use this in my upcoming nested-macros patch.