### PR TITLE
Exclude prefix headers from macro-defined-by-includer heuristics (issue #368).

### DIFF
--- a/iwyu_output.cc
+++ b/iwyu_output.cc
@@ -1889,6 +1889,13 @@ size_t PrintableDiffs(const string& filename,
 void IwyuFileInfo::HandlePreprocessingDone() {
   // Check macros defined by includer.  Requires file preprocessing to be
   // finished to know all direct includes and all macro usages.
+  //
+  // Exclude prefix headers from mapping heuristics.  Includes in prefix
+  // headers are kept regardless of their usage in includer.  And entire
+  // include-what-you-use principle isn't really applicable to prefix headers.
+  if (is_prefix_header()) {
+    return;
+  }
   bool should_report_violations = ShouldReportIWYUViolationsFor(file_);
   std::list<const FileEntry*> direct_macro_use_includees;
   std::set_intersection(macro_users_.begin(), macro_users_.end(),

--- a/run_iwyu_tests.py
+++ b/run_iwyu_tests.py
@@ -99,7 +99,8 @@ class OneIwyuTest(unittest.TestCase):
       'lambda_fwd_decl.cc': ['-std=c++11'],
       'lateparsed_template.cc': ['-fdelayed-template-parsing'],
       'macro_defined_by_includer.cc': [
-          '-std=c++11', '-DCOMMAND_LINE_TYPE=double'],
+          '-std=c++11', '-DCOMMAND_LINE_TYPE=double',
+          self.Include('macro_defined_by_includer-prefix.h')],
       'ms_inline_asm.cc': ['-fms-extensions'],
       'prefix_header_attribution.cc': [self.Include('prefix_header_attribution-d1.h')],
       'prefix_header_includes_add.cc': prefix_headers,

--- a/tests/cxx/macro_defined_by_includer-i4.h
+++ b/tests/cxx/macro_defined_by_includer-i4.h
@@ -1,0 +1,16 @@
+//===--- macro_defined_by_includer-i4.h - test input file for iwyu --------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifdef ENABLE_DEBUG
+void foo() {
+  // Extra code for debugging purposes.
+}
+#else
+void foo() {}
+#endif

--- a/tests/cxx/macro_defined_by_includer-prefix.h
+++ b/tests/cxx/macro_defined_by_includer-prefix.h
@@ -1,0 +1,11 @@
+//===--- macro_defined_by_includer-prefix.h - test input file for iwyu ----===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#define ENABLE_DEBUG
+#include "tests/cxx/macro_defined_by_includer-i4.h"


### PR DESCRIPTION
Also considered options of not populating `macro_users_` or
`direct_includes_as_fileentries_` for prefix headers but decided not to
do so. I think it is better to have correct information for prefix
headers but not to give recommendations based on that instead of having
incomplete information.