### PR TITLE
Handle locations of nested macros better

### DIFF
--- a/tests/cxx/macro_location-byteswap.h
+++ b/tests/cxx/macro_location-byteswap.h
@@ -1,0 +1,2 @@
+#define bswap(x) ({ int __x = (x); bswap2(__x); })
+#define bswap2(x) (x)

--- a/tests/cxx/macro_location-inet.h
+++ b/tests/cxx/macro_location-inet.h
@@ -1,0 +1,12 @@
+//===--- macro_location-inet.h - test input file for iwyu -----------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/macro_location-byteswap.h"
+
+#define htons(x) bswap(x)

--- a/tests/cxx/macro_location.cc
+++ b/tests/cxx/macro_location.cc
@@ -13,6 +13,7 @@
 // expansions when the macro is written in a to-ignore file.
 
 #include "tests/cxx/macro_location.h"
+#include "tests/cxx/macro_location-inet.h"
 
 struct A {
   // This doesn't require us to forward-declare ToBeDeclared because it's
@@ -26,6 +27,13 @@ struct A {
 
 class ToBeDeclaredLater1 { };
 class ToBeDeclaredLater2 { };
+
+// This is lifted from a reduced repro case for htons of inet.h.
+// Its nesting provokes something that isn't covered by the rest of the
+// macro_location suite.
+int my_htons(int x) {
+  return htons(x);
+}
 
 /**** IWYU_SUMMARY
 


### PR DESCRIPTION
Issue #358 describes that htons from inet.h completely misses the mark
when finding the use location.

This patch should handle nested macros better. Test case from #358 added
to macro_location.cc