### PR TITLE
Add pragma to set associated header

### DIFF
--- a/docs/IWYUPragmas.md
+++ b/docs/IWYUPragmas.md
@@ -146,6 +146,28 @@ If the expression contains spaces, it must be enclosed in quotes.
       AlsoPrivate p;
 
 
+### IWYU pragma: associated ###
+
+Associated headers have special significance in IWYU, they're analyzed together with their .cpp file to give an optimal result for the whole component.
+
+By default, IWYU uses the .cpp file's stem (filename without extension) to automatically detect which is the associated header, but sometimes local conventions don't allow a component's .cpp and header file to share a stem, which makes life harder for IWYU.
+
+You can explicitly mark an arbitrary `#include` directive as denoting the associated header with `IWYU pragma: associated`:
+
+    component/public.h:
+      struct Foo {
+        void Bar();
+      };
+
+    component/component.cc:
+      #include "component/public.h"  // IWYU pragma: associated
+
+      void Foo::Bar() {
+      }
+
+You can mark multiple `#include` directives as associated and they will all be considered as such.
+
+
 ### Which pragma should I use? ###
 
 Ideally, IWYU should be smart enough to understand your intentions (and intentions of the authors of libraries you use), so the first answer should always be: none.

--- a/iwyu_preprocessor.h
+++ b/iwyu_preprocessor.h
@@ -347,6 +347,10 @@ class IwyuPreprocessorInfo : public clang::PPCallbacks,
   // per file in the current inclusion chain..
   stack<clang::SourceLocation> begin_exports_location_stack_;
 
+  // For processing associated pragma. It is the current open
+  // "associated" pragma.
+  clang::SourceLocation associated_pragma_location_;
+
   // Filename spelling location in the last encountered inclusion directive.
   // Should be used only in FileChanged_EnterFile, FileSkipped when
   // corresponding callback is caused by inclusion directive.  Don't use in

--- a/run_iwyu_tests.py
+++ b/run_iwyu_tests.py
@@ -155,6 +155,7 @@ class OneIwyuTest(unittest.TestCase):
       'overloaded_class.cc': ['.'],
       'pch_in_code.cc': ['.'],
       'pointer_arith.cc': ['.'],
+      'pragma_associated.cc': ['.'],
       'precomputed_tpl_args.cc': ['.'],
       'prefix_header_attribution.cc': ['.'],
       'prefix_header_includes_add.cc': ['.'],

--- a/tests/cxx/pragma_associated-d1.h
+++ b/tests/cxx/pragma_associated-d1.h
@@ -1,0 +1,19 @@
+//===--- pragma_associated-d1.h - test input file for iwyu ----------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// This file does not provide any symbols, and only exists to be
+// force-associated by `pragma associated`.
+//
+// Since it's associated, it will be analyzed, and needs the IWYU summary.
+
+/**** IWYU_SUMMARY
+
+(tests/cxx/pragma_associated-d1.h has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/pragma_associated-d2.h
+++ b/tests/cxx/pragma_associated-d2.h
@@ -1,0 +1,19 @@
+//===--- pragma_associated-d2.h - test input file for iwyu ----------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// This file does not provide any symbols, and only exists to be
+// force-associated by `pragma associated`.
+//
+// Since it's associated, it will be analyzed, and needs the IWYU summary.
+
+/**** IWYU_SUMMARY
+
+(tests/cxx/pragma_associated-d2.h has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/pragma_associated.cc
+++ b/tests/cxx/pragma_associated.cc
@@ -1,0 +1,27 @@
+//===--- pragma_associated.cc - test input file for iwyu ------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/pragma_associated-d1.h"  // IWYU pragma: associated
+#include "tests/cxx/pragma_associated-d2.h"  // IWYU pragma: associated
+#include "tests/cxx/pragma_associated.h"  // This still counts as associated.
+#include "tests/cxx/direct.h"  // This is unused.
+
+/**** IWYU_SUMMARY
+
+tests/cxx/pragma_associated.cc should add these lines:
+
+tests/cxx/pragma_associated.cc should remove these lines:
+- #include "tests/cxx/direct.h"  // lines XX-XX
+
+The full include-list for tests/cxx/pragma_associated.cc:
+#include "tests/cxx/pragma_associated-d1.h"
+#include "tests/cxx/pragma_associated-d2.h"
+#include "tests/cxx/pragma_associated.h"
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/pragma_associated.h
+++ b/tests/cxx/pragma_associated.h
@@ -1,0 +1,19 @@
+//===--- pragma_associated.h - test input file for iwyu -------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// This file does not provide any symbols, and only serves to be auto-detected
+// as an associated include.
+//
+// Since it's associated, it will be analyzed, and needs the IWYU summary.
+
+/**** IWYU_SUMMARY
+
+(tests/cxx/pragma_associated.h has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
Sometimes IWYU's auto-detection of associated headers is insufficient.
Add an IWYU pragma to explicitly set associated header.

This is based on an original patch by Ivan Koster.

I added a test and some documentation.

This supersedes PR #302.