### PR TITLE
Remove TODOs fixed by upstream Clang commit

### DIFF
--- a/tests/cxx/badinc.cc
+++ b/tests/cxx/badinc.cc
@@ -1417,13 +1417,10 @@ int main() {
   local_i2_template_class.InlFileTemplateClassFn();
   // IWYU: I2_TemplateClass is...*badinc-i2.h
   local_i2_template_class.a();
-  // TODO(csilvers): these first three errors are wrong, due to a bug
-  // in IntendsToProvide.  The file defining this template method
-  // *should* be providing badinc-i2-inl.h, but isn't (iwyu will
-  // suggest we add it).  So we don't detect that that file is
-  // responsible for these symbols, and not us.
-  // IWYU: I2_TemplateClass::I2_TemplateClass<.*> is...*badinc-i2-inl.h
-  // IWYU: I2_TemplateClass::~I2_TemplateClass<.*> is...*badinc-i2-inl.h
+  // TODO(csilvers): this first error is wrong, due to a bug in
+  // IntendsToProvide.  The file defining this template method *should* be
+  // providing badinc-i2-inl.h, but isn't (iwyu will suggest we add it).
+  // So we don't detect that file as responsible for these symbols, and not us.
   // IWYU: I2_TemplateClass::InlFileTemplateClassFn is...*badinc-i2-inl.h
   // IWYU: I2_TemplateClass is...*badinc-i2.h
   local_i2_template_class.CcFileFn();


### PR DESCRIPTION
This should fix our broken bot.

Clang r300938 caused these TODO:ed assertions to become unnecessary, which is nice. I haven't quite understood why. It looks like r300398 changes what is considered the definition in some circumstances, so it probably just shuffles responsibility around somehow.

It could be that this exposes another weakness in our `GetDefinitionAsWritten`, but it could also be something else entirely. I'd rather not spend more time on it.