### PR TITLE
Accept methods hiding using declarations

### DIFF
--- a/iwyu_output.cc
+++ b/iwyu_output.cc
@@ -1944,15 +1944,16 @@ void IwyuFileInfo::ResolvePendingAnalysis() {
   for (map<const UsingDecl*, bool>::value_type using_decl_status
       : using_decl_referenced_) {
     if (!using_decl_status.second) {
+      // There are valid cases where there is no shadow decl, e.g. if a derived
+      // class has a using declaration for a member, but also hides it.
+      // Only report the target if we have a shadow decl.
       const UsingDecl* using_decl = using_decl_status.first;
-      // It should not be possible to get here with a using decl without any
-      // shadow decls because doing so would imply that the input code we're
-      // analyzing code doesn't compile.
-      CHECK_(using_decl->shadow_size() > 0);
-      ReportForwardDeclareUse(using_decl->getUsingLoc(),
-        using_decl->shadow_begin()->getTargetDecl(),
-        /* in_cxx_method_body */ false,
-        "(for un-referenced using)");
+      if (using_decl->shadow_size() > 0) {
+        ReportForwardDeclareUse(using_decl->getUsingLoc(),
+                                using_decl->shadow_begin()->getTargetDecl(),
+                                /* in_cxx_method_body */ false,
+                                "(for un-referenced using)");
+      }
     }
   }
 }

--- a/tests/cxx/using_unused-baseclass.h
+++ b/tests/cxx/using_unused-baseclass.h
@@ -1,0 +1,13 @@
+//===--- using_unused-baseclass.h - test input file for iwyu --------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+class Base {
+ public:
+  void Method();
+};

--- a/tests/cxx/using_unused.cc
+++ b/tests/cxx/using_unused.cc
@@ -12,7 +12,18 @@
 // it's not actually used.
 
 #include "using_unused-declare.h"
+#include "using_unused-baseclass.h"
+
 using ns::symbol;
+
+class Hiding : public Base {
+  // Introduce a using shadow decl which is subsequently discarded when this
+  // class hides the using-decl with its own declaration.
+  // This used to trigger an assertion failure.
+  using Base::Method;
+
+  void Method();
+};
 
 /**** IWYU_SUMMARY
 


### PR DESCRIPTION
When a method in a derived class hides a name introduced by a
using-declaration, Clang discards the using shadow declarations for the
hidden name.

We used to have an assertion that every using-declaration must have a
shadow declaration. This patch removes it, to placate the above.

Fixes issue #420.