### PR TITLE
Remove second-guessing for DeclRefExprs in CallExprs

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -898,20 +898,12 @@ class BaseAstVisitor : public RecursiveASTVisitor<Derived> {
         const_cast<CXXDestructorDecl*>(dtor), parent_type, expr);
   }
 
-  // This is to catch assigning template functions to function pointers.
+  // This is to catch function pointers to templates.
   // For instance, 'MyFunctionPtr p = &TplFn<MyClass*>;': we need to
   // expand TplFn to see if it needs full type info for MyClass.
   bool TraverseDeclRefExpr(clang::DeclRefExpr* expr) {
     if (!Base::TraverseDeclRefExpr(expr))  return false;
     if (CanIgnoreCurrentASTNode())  return true;
-
-    // If it's a normal function call, that was already handled by a
-    // CallExpr somewhere.  We want only assignments.
-    if (current_ast_node()->template ParentIsA<CallExpr>() ||
-        (current_ast_node()->template ParentIsA<ImplicitCastExpr>() &&
-         current_ast_node()->template AncestorIsA<CallExpr>(2))) {
-      return true;
-    }
 
     if (FunctionDecl* fn_decl = DynCastFrom(expr->getDecl())) {
       // If fn_decl has a class-name before it -- 'MyClass::method' --

--- a/run_iwyu_tests.py
+++ b/run_iwyu_tests.py
@@ -115,6 +115,7 @@ class OneIwyuTest(unittest.TestCase):
       'backwards_includes.cc': ['.'],
       'badinc.cc': ['.'],
       'badinc-extradef.cc': ['.'],
+      'funcptrs.cc': ['.'],
       'casts.cc': ['.'],
       'catch.cc': ['.'],
       'check_also.cc': ['.'],

--- a/run_iwyu_tests.py
+++ b/run_iwyu_tests.py
@@ -96,6 +96,7 @@ class OneIwyuTest(unittest.TestCase):
       'clmode.cc': ['--driver-mode=cl', '/GF', '/Os', '/W2'],
       'conversion_ctor.cc': ['-std=c++11'],
       'deleted_implicit.cc' : ['-std=c++11'],
+      'funcptrs.cc': ['-Wno-unused'],
       'lambda_fwd_decl.cc': ['-std=c++11'],
       'lateparsed_template.cc': ['-fdelayed-template-parsing'],
       'macro_defined_by_includer.cc': [

--- a/tests/cxx/badinc-i1.h
+++ b/tests/cxx/badinc-i1.h
@@ -115,7 +115,6 @@ class I1_TemplateMethodOnlyClass {
  public:
   FOO a() { FOO retval; return retval; }
   FOO* b() { FOO* retval = NULL; return retval; }
-  static int stat() { FOO foo; (void)foo; return 2; }
   template<typename BAR> BAR c() { return BAR(); }
   template<typename BAR> BAR* d() { BAR* retval = NULL; return retval; }
   template<typename BAR> int e(BAR* b) { return (int)b->size(); }

--- a/tests/cxx/badinc.cc
+++ b/tests/cxx/badinc.cc
@@ -1891,42 +1891,6 @@ int main() {
   local_d1_copy_class = D1CopyClassFn(I12);
   local_d1_copy_class.a();
 
-  // Test (templated) function pointers and method pointers.
-  // IWYU: I1_Class needs a declaration
-  // IWYU: I1_Enum is...*badinc-i1.h
-  // IWYU: I1_Function is...*badinc-i1.h
-  I1_Enum (*local_fn_ptr)(I1_Class*) = &I1_Function;
-  // IWYU: I1_Class is...*badinc-i1.h
-  int (*static_method_ptr)() = &I1_Class::s;
-  // IWYU: I1_Struct is...*badinc-i1.h
-  // IWYU: I1_Struct needs a declaration
-  // IWYU: I1_TemplateMethodOnlyClass is...*badinc-i1.h
-  int (*tpl_fn_ptr)() = &I1_TemplateMethodOnlyClass<I1_Struct>::stat;
-  // IWYU: I1_Class is...*badinc-i1.h
-  // IWYU: I1_Class needs a declaration
-  // IWYU: I1_Struct needs a declaration
-  // IWYU: I1_TemplateMethodOnlyClass is...*badinc-i1.h
-  int (*tpl_fn_ptr2)() = &I1_TemplateMethodOnlyClass<I1_Struct>::t<I1_Class>;
-  // IWYU: I1_Class is...*badinc-i1.h
-  int (I1_Class::*method_ptr)() const = &I1_Class::a;
-  // IWYU: I1_Struct is...*badinc-i1.h
-  // IWYU: I1_Struct needs a declaration
-  // IWYU: I1_TemplateMethodOnlyClass is...*badinc-i1.h
-  I1_Struct (I1_TemplateMethodOnlyClass<I1_Struct>::*tpl_method_ptr)()
-      // IWYU: I1_Struct is...*badinc-i1.h
-      // IWYU: I1_Struct needs a declaration
-      // IWYU: I1_TemplateMethodOnlyClass is...*badinc-i1.h
-      = &I1_TemplateMethodOnlyClass<I1_Struct>::a;
-  // IWYU: I1_Struct needs a declaration
-  // IWYU: I1_TemplateMethodOnlyClass is...*badinc-i1.h
-  // IWYU: I2_Struct is...*badinc-i2.h
-  I2_Struct (I1_TemplateMethodOnlyClass<I1_Struct>::*tpl_method_ptr2)()
-      // IWYU: I1_Struct needs a declaration
-      // IWYU: I2_Struct is...*badinc-i2.h
-      // IWYU: I2_Struct needs a declaration
-      // IWYU: I1_TemplateMethodOnlyClass is...*badinc-i1.h
-      = &I1_TemplateMethodOnlyClass<I1_Struct>::c<I2_Struct>;
-
   // Check use of a macro inside an #ifdef.
   // IWYU: I2_MACRO is...*badinc-i2.h
 #ifdef I2_MACRO

--- a/tests/cxx/funcptrs-d1.h
+++ b/tests/cxx/funcptrs-d1.h
@@ -1,0 +1,15 @@
+//===--- funcptrs-d1.h - test input file for iwyu -------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_FUNCPTRS_D1_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_FUNCPTRS_D1_H_
+
+#include "tests/cxx/funcptrs-i1.h"
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_FUNCPTRS_D1_H_

--- a/tests/cxx/funcptrs-i1.h
+++ b/tests/cxx/funcptrs-i1.h
@@ -1,0 +1,70 @@
+//===--- funcptrs-i1.h - test input file for iwyu -------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_FUNCPTRS_I1_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_FUNCPTRS_I1_H_
+
+// Supporting types.
+enum Enum { E_one };
+
+class Retval {
+ public:
+  Retval() : value(0) {}
+  Retval(int v) : value(v) {}
+
+  int Value() const { return value; }
+
+ private:
+  int value;
+};
+
+// Functions of various kinds to which function pointers are bound.
+class Class {
+ public:
+  int MemberFunction() const { return 20; }
+
+  template<typename R>
+  int MemberTemplate() const { return R(50).Value(); }
+
+  static int StaticMemberFunction() { return 100; }
+
+  template<typename R>
+  static int StaticMemberTemplate() {
+    return R(100).Value();
+  }
+};
+
+Enum Function(Class*) {
+  return E_one;
+}
+
+template<typename T>
+int FunctionTemplate(Class*) {
+  return T(10).Value();
+}
+
+template<typename T>
+class ClassTemplate {
+ public:
+  int MemberFunction() const { return 20; }
+
+  template<typename R>
+  int MemberTemplate() const { return R(50).Value(); }
+
+  static int StaticMemberFunction() {
+    return 100;
+  }
+
+  template<typename R>
+  static int StaticMemberTemplate() {
+    return R(100).Value();
+  }
+};
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_FUNCPTRS_I1_H_

--- a/tests/cxx/funcptrs.cc
+++ b/tests/cxx/funcptrs.cc
@@ -1,0 +1,170 @@
+//===--- funcptrs.cc - test input file for iwyu ---------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// Tests that function pointers make the right claims for involved types.
+// Function pointer expressions come in two flavors:
+//
+// 1) Assignments: int (*fptr)(int) = function
+// 2) Calls: FunctionThatTakesFptr(function);
+//
+// A 'function' can be a free function, a static member function, a member
+// function, or any template instantiation of the above.
+
+#include "tests/cxx/funcptrs-d1.h"
+
+
+// Functions to drive call-syntax.
+
+// IWYU: Class needs a declaration
+// IWYU: Enum is...*funcptrs-i1.h
+void FunctionThatTakesFptr(Enum (*fptr)(Class*));
+
+// IWYU: Class needs a declaration
+void FunctionThatTakesFptr(int (*fptr)(Class*));
+
+void FunctionThatTakesFptr(int (*fptr)());
+
+// IWYU: Class needs a declaration
+void FunctionThatTakesMptr(int (Class::*mptr)() const);
+
+// IWYU: ClassTemplate needs a declaration
+// IWYU: Class needs a declaration
+void FunctionThatTakesMptr(int (ClassTemplate<Class>::*mptr)() const);
+
+
+// Test cases below.
+// Note that we test primarily the diagnostics from IWYU for the individual
+// constructs, not which header is chosen -- all relevant types are in
+// funcptrs-i1.h anyway.
+//
+// Each test creates function pointers to a plain function and a template
+// instantiation, and for classes similarly for instance member functions.
+
+void FreeFunctions() {
+  // Assignment of function pointer to function and template instantiation.
+  // IWYU: Class needs a declaration
+  // IWYU: Enum is...*funcptrs-i1.h
+  // IWYU: Function is...*funcptrs-i1.h
+  Enum (*fptr)(Class*) = &Function;
+
+  // IWYU: Class needs a declaration
+  // IWYU: Retval needs a declaration
+  // IWYU: Retval is...*funcptrs-i1.h
+  // IWYU: FunctionTemplate is...*funcptrs-i1.h
+  int (*template_fptr)(Class*) = &FunctionTemplate<Retval>;
+
+  // Call with function pointer to function and template instantiation.
+  // IWYU: Function is...*funcptrs-i1.h
+  FunctionThatTakesFptr(Function);
+
+  // IWYU: Retval needs a declaration
+  // IWYU: Retval is...*funcptrs-i1.h
+  // IWYU: FunctionTemplate is...*funcptrs-i1.h
+  FunctionThatTakesFptr(FunctionTemplate<Retval>);
+}
+
+void ClassMembers() {
+  // IWYU: Class is...*funcptrs-i1.h
+  int (*static_method_ptr)() = &Class::StaticMemberFunction;
+
+  // IWYU: Class is...*funcptrs-i1.h
+  // IWYU: Retval needs a declaration
+  // IWYU: Retval is...*funcptrs-i1.h
+  int (*static_template_method_ptr)() = &Class::StaticMemberTemplate<Retval>;
+
+  // IWYU: Class is...*funcptrs-i1.h
+  int (Class::*method_ptr)() const = &Class::MemberFunction;
+
+  // IWYU: Class is...*funcptrs-i1.h
+  // IWYU: Retval needs a declaration
+  // IWYU: Retval is...*funcptrs-i1.h
+  int (Class::*template_method_ptr)() const = &Class::MemberTemplate<Retval>;
+
+  // Call with pointers to static member function and template instantiation.
+  // IWYU: Class is...*funcptrs-i1.h
+  FunctionThatTakesFptr(Class::StaticMemberFunction);
+
+  // IWYU: Retval needs a declaration
+  // IWYU: Retval is...*funcptrs-i1.h
+  // IWYU: Class is...*funcptrs-i1.h
+  FunctionThatTakesFptr(Class::StaticMemberTemplate<Retval>);
+
+  // Call with pointers to instance member function and template instantiation.
+  // IWYU: Class is...*funcptrs-i1.h
+  FunctionThatTakesMptr(&Class::MemberFunction);
+
+  // IWYU: Retval needs a declaration
+  // IWYU: Retval is...*funcptrs-i1.h
+  // IWYU: Class is...*funcptrs-i1.h
+  FunctionThatTakesMptr(&Class::MemberTemplate<Retval>);
+}
+
+void ClassTemplateMembers() {
+  // IWYU: ClassTemplate is...*funcptrs-i1.h
+  // IWYU: Class needs a declaration
+  int (*static_method_ptr)() = &ClassTemplate<Class>::StaticMemberFunction;
+
+  int (*static_template_method_ptr)() =
+      // IWYU: ClassTemplate is...*funcptrs-i1.h
+      // IWYU: Class needs a declaration
+      // IWYU: Retval needs a declaration
+      // IWYU: Retval is...*funcptrs-i1.h
+      &ClassTemplate<Class>::StaticMemberTemplate<Retval>;
+
+  // IWYU: ClassTemplate is...*funcptrs-i1.h
+  // IWYU: Class needs a declaration
+  int (ClassTemplate<Class>::*method_ptr)() const =
+      // IWYU: ClassTemplate is...*funcptrs-i1.h
+      // IWYU: Class needs a declaration
+      &ClassTemplate<Class>::MemberFunction;
+
+  // IWYU: ClassTemplate is...*funcptrs-i1.h
+  // IWYU: Class needs a declaration
+  int (ClassTemplate<Class>::*template_method_ptr)() const =
+      // IWYU: ClassTemplate is...*funcptrs-i1.h
+      // IWYU: Class needs a declaration
+      // IWYU: Retval needs a declaration
+      // IWYU: Retval is...*funcptrs-i1.h
+      &ClassTemplate<Class>::MemberTemplate<Retval>;
+
+  // Call with pointers to static member function and template instantiation.
+  // IWYU: ClassTemplate is...*funcptrs-i1.h
+  // IWYU: Class needs a declaration
+  FunctionThatTakesFptr(ClassTemplate<Class>::StaticMemberFunction);
+
+  // IWYU: Retval needs a declaration
+  // IWYU: Retval is...*funcptrs-i1.h
+  // IWYU: ClassTemplate is...*funcptrs-i1.h
+  // IWYU: Class needs a declaration
+  FunctionThatTakesFptr(ClassTemplate<Class>::StaticMemberTemplate<Retval>);
+
+  // Call with pointers to instance member function and template instantiation.
+  // IWYU: ClassTemplate is...*funcptrs-i1.h
+  // IWYU: Class needs a declaration
+  FunctionThatTakesMptr(&ClassTemplate<Class>::MemberFunction);
+
+  // IWYU: Retval needs a declaration
+  // IWYU: Retval is...*funcptrs-i1.h
+  // IWYU: ClassTemplate is...*funcptrs-i1.h
+  // IWYU: Class needs a declaration
+  FunctionThatTakesMptr(&ClassTemplate<Class>::MemberTemplate<Retval>);
+}
+
+/**** IWYU_SUMMARY
+
+tests/cxx/funcptrs.cc should add these lines:
+#include "tests/cxx/funcptrs-i1.h"
+
+tests/cxx/funcptrs.cc should remove these lines:
+- #include "tests/cxx/funcptrs-d1.h"  // lines XX-XX
+
+The full include-list for tests/cxx/funcptrs.cc:
+#include "tests/cxx/funcptrs-i1.h"  // for Class, ClassTemplate, Enum, Function, FunctionTemplate, Retval
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/funcptrs.cc
+++ b/tests/cxx/funcptrs.cc
@@ -8,10 +8,11 @@
 //===----------------------------------------------------------------------===//
 
 // Tests that function pointers make the right claims for involved types.
-// Function pointer expressions come in two flavors:
+// Function pointer expressions come in three flavors:
 //
-// 1) Assignments: int (*fptr)(int) = function
+// 1) Assignments: int (*fptr)(int) = function;
 // 2) Calls: FunctionThatTakesFptr(function);
+// 3) Naked expressions: &function;
 //
 // A 'function' can be a free function, a static member function, a member
 // function, or any template instantiation of the above.
@@ -67,6 +68,15 @@ void FreeFunctions() {
   // IWYU: Retval is...*funcptrs-i1.h
   // IWYU: FunctionTemplate is...*funcptrs-i1.h
   FunctionThatTakesFptr(FunctionTemplate<Retval>);
+
+  // Naked function pointer expressions
+  // IWYU: Function is...*funcptrs-i1.h
+  &Function;
+
+  // IWYU: Retval needs a declaration
+  // IWYU: Retval is...*funcptrs-i1.h
+  // IWYU: FunctionTemplate is...*funcptrs-i1.h
+  &FunctionTemplate<Retval>;
 }
 
 void ClassMembers() {
@@ -103,6 +113,23 @@ void ClassMembers() {
   // IWYU: Retval is...*funcptrs-i1.h
   // IWYU: Class is...*funcptrs-i1.h
   FunctionThatTakesMptr(&Class::MemberTemplate<Retval>);
+
+  // Naked function pointer expressions
+  // IWYU: Class is...*funcptrs-i1.h
+  &Class::StaticMemberFunction;
+
+  // IWYU: Retval needs a declaration
+  // IWYU: Retval is...*funcptrs-i1.h
+  // IWYU: Class is...*funcptrs-i1.h
+  &Class::StaticMemberTemplate<Retval>;
+
+  // IWYU: Class is...*funcptrs-i1.h
+  &Class::MemberFunction;
+
+  // IWYU: Retval needs a declaration
+  // IWYU: Retval is...*funcptrs-i1.h
+  // IWYU: Class is...*funcptrs-i1.h
+  &Class::MemberTemplate<Retval>;
 }
 
 void ClassTemplateMembers() {
@@ -154,6 +181,27 @@ void ClassTemplateMembers() {
   // IWYU: ClassTemplate is...*funcptrs-i1.h
   // IWYU: Class needs a declaration
   FunctionThatTakesMptr(&ClassTemplate<Class>::MemberTemplate<Retval>);
+
+  // Naked class template member function pointer expressions
+  // IWYU: ClassTemplate is...*funcptrs-i1.h
+  // IWYU: Class needs a declaration
+  &ClassTemplate<Class>::StaticMemberFunction;
+
+  // IWYU: Retval needs a declaration
+  // IWYU: Retval is...*funcptrs-i1.h
+  // IWYU: ClassTemplate is...*funcptrs-i1.h
+  // IWYU: Class needs a declaration
+  &ClassTemplate<Class>::StaticMemberTemplate<Retval>;
+
+  // IWYU: ClassTemplate is...*funcptrs-i1.h
+  // IWYU: Class needs a declaration
+  &ClassTemplate<Class>::MemberFunction;
+
+  // IWYU: Retval needs a declaration
+  // IWYU: Retval is...*funcptrs-i1.h
+  // IWYU: ClassTemplate is...*funcptrs-i1.h
+  // IWYU: Class needs a declaration
+  &ClassTemplate<Class>::MemberTemplate<Retval>;
 }
 
 /**** IWYU_SUMMARY


### PR DESCRIPTION
In TraverseDeclRefExpr we would exit early if we were under a
CallExpr, with the motivation that CallExpr had already handled the
relevant cases.

However, CallExpr only looks specifically for reference arguments
passed to vararg functions, and ignores anything else.

Let TraverseDeclRefExpr work on all expressions, so that binding of
function pointers to templates works in all contexts, including
CallExprs.

Also took the time to extract function pointer binding from badinc.cc to a new test suite, and add full coverage for (free functions, static members, instance members) x templates.

Fixes issue #425.