### PR TITLE
Let scrub-logs accept input from stdin

### DIFF
--- a/scrub-logs.py
+++ b/scrub-logs.py
@@ -18,6 +18,7 @@ values and path prefixes from ast-dump output, so they can be diffed directly.
 
 import re
 import sys
+import fileinput
 
 
 def strip_path_prefix(line):
@@ -30,16 +31,15 @@ def strip_addrs(line):
     return line
 
 
-def main(args):
-    with open(args[1]) as fd:
-        for line in fd:
-            line = line.strip()
-            line = strip_addrs(line)
-            line = strip_path_prefix(line)
-            print(line)
+def main():
+    for line in fileinput.input():
+        line = line.strip()
+        line = strip_addrs(line)
+        line = strip_path_prefix(line)
+        print(line)
 
     return 0
 
 
 if __name__ == '__main__':
-    sys.exit(main(sys.argv))
+    sys.exit(main())


### PR DESCRIPTION
Use the fileinput module to take input from stdin or a named file.

This enables:

    $ include-what-you-use -Xiwyu -v7 file.cc 2>&1 | ./scrub-logs.py

which is very useful for comparing execution flows.