### PR TITLE
Equate alias declarations and typedef in templates

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -205,6 +205,7 @@ using clang::TranslationUnitDecl;
 using clang::Type;
 using clang::TypeLoc;
 using clang::TypedefDecl;
+using clang::TypedefNameDecl;
 using clang::TypedefType;
 using clang::UnaryExprOrTypeTraitExpr;
 using clang::UsingDecl;
@@ -3042,7 +3043,7 @@ class InstantiatedTemplateVisitor
     // you do 'Foo<MyClass>::value_type m;'?
     for (const ASTNode* ast_node = current_ast_node();
          ast_node != caller_ast_node_; ast_node = ast_node->parent()) {
-      if (ast_node->IsA<TypedefDecl>())
+      if (ast_node->IsA<TypedefNameDecl>())
         return Base::VisitSubstTemplateTypeParmType(type);
     }
 

--- a/run_iwyu_tests.py
+++ b/run_iwyu_tests.py
@@ -173,6 +173,7 @@ class OneIwyuTest(unittest.TestCase):
       'template_specialization.cc': ['.'],
       'typedef_chain_in_template.cc': ['.'],
       'typedef_chain_no_follow.cc': ['.'],
+      'typedef_in_template.cc': ['.'],
       'typedefs_and_resugaring.cc': ['.'],
       'unused_class_template_ctor.cc': ['.'],
       'uses_printf.cc': ['.'],

--- a/run_iwyu_tests.py
+++ b/run_iwyu_tests.py
@@ -106,6 +106,7 @@ class OneIwyuTest(unittest.TestCase):
       'prefix_header_includes_add.cc': prefix_headers,
       'prefix_header_includes_keep.cc': prefix_headers,
       'prefix_header_includes_remove.cc': prefix_headers,
+      'typedef_in_template.cc': ['-std=c++11'],
     }
     include_map = {
       'alias_template.cc': ['.'],

--- a/tests/cxx/badinc.cc
+++ b/tests/cxx/badinc.cc
@@ -619,11 +619,6 @@ H_TemplateStruct<I1_TemplateClass<int> > h_template_struct_tplclass_arg;
 // via a default template argument.
 // IWYU: I2_TemplateClass::~I2_TemplateClass<.*> is...*badinc-i2-inl.h
 H_TemplateTemplateClass<> h_templatetemplateclass;
-// These do not need the full type for I1_Class because they're tpl params.
-// IWYU: I1_Class needs a declaration
-H_TypedefStruct<I1_Class>::t_type h_typdef_struct_t;
-// IWYU: I1_Class needs a declaration
-H_TypedefStruct<I1_Class>::pair_type h_typdef_struct_pair;
 // IWYU: I2_Class is...*badinc-i2.h
 // IWYU: I2_Class needs a declaration
 // IWYU: I2_TemplateFn is...*badinc-i2.h

--- a/tests/cxx/badinc.h
+++ b/tests/cxx/badinc.h
@@ -274,13 +274,6 @@ template<class T, class Functor = OperateOn<T> > class H_TemplateStruct {
   void a() { return ts.a(); }
 };
 
-template<class T> struct H_TypedefStruct {
-  // Should not be an iwyu violation for T
-  typedef T t_type;
-  // IWYU: std::pair is...*<utility>
-  typedef std::pair<T, T> pair_type;
-};
-
 // IWYU: I2_EnumForTypedefs is...*badinc-i2.h
 typedef I2_EnumForTypedefs H_Typedef;
 // IWYU: std::set is...*<set>
@@ -382,7 +375,6 @@ H_TemplateTemplateClass<H_TemplateClass> h_i2_templatetemlpate_class;
 tests/cxx/badinc.h should add these lines:
 #include <stdio.h>
 #include <set>
-#include <utility>
 #include <vector>
 #include "tests/cxx/badinc-i2-inl.h"
 #include "tests/cxx/badinc-i2.h"
@@ -400,7 +392,6 @@ The full include-list for tests/cxx/badinc.h:
 #include <queue>  // for queue
 #include <set>  // for set
 #include <string>  // for string
-#include <utility>  // for pair
 #include <vector>  // for vector
 #include "tests/cxx/badinc-d3.h"  // for D3_Enum, D3_Enum::D31
 #include "tests/cxx/badinc-i2-inl.h"  // for I2_Class::I2_Class, I2_Class::InlFileFn, I2_Class::InlFileStaticFn, I2_Class::InlFileTemplateFn, I2_Class::~I2_Class, I2_TemplateClass::I2_TemplateClass<FOO>, I2_TemplateClass::InlFileTemplateClassFn, I2_TemplateClass::~I2_TemplateClass<FOO>

--- a/tests/cxx/typedef_in_template-d1.h
+++ b/tests/cxx/typedef_in_template-d1.h
@@ -1,0 +1,15 @@
+//===--- typedef_in_template-d1.h - test input file for iwyu --------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_TYPEDEF_IN_TEMPLATE_D1_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_TYPEDEF_IN_TEMPLATE_D1_H_
+
+#include "tests/cxx/typedef_in_template-i1.h"
+
+#endif // INCLUDE_WHAT_YOU_USE_TESTS_CXX_TYPEDEF_IN_TEMPLATE_D1_H_

--- a/tests/cxx/typedef_in_template-i1.h
+++ b/tests/cxx/typedef_in_template-i1.h
@@ -1,0 +1,22 @@
+//===--- typedef_in_template-i1.h - test input file for iwyu --------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_TYPEDEF_IN_TEMPLATE_I1_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_TYPEDEF_IN_TEMPLATE_I1_H_
+
+class Class {};
+
+template<class T, class U>
+struct Pair {
+  T first;
+  U second;
+};
+
+#endif // INCLUDE_WHAT_YOU_USE_TESTS_CXX_TYPEDEF_IN_TEMPLATE_I1_H_

--- a/tests/cxx/typedef_in_template.cc
+++ b/tests/cxx/typedef_in_template.cc
@@ -1,0 +1,51 @@
+//===--- typedef_in_template.cc - test input file for iwyu ----------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/typedef_in_template-d1.h"
+
+template<class T>
+class Container {
+ public:
+  // Should not be an iwyu violation for T
+  typedef T value_type;
+
+  // IWYU: Pair is...*typedef_in_template-i1.h
+  typedef Pair<T,T> pair_type;
+};
+
+
+void Declarations() {
+  // These do not need the full type for Class because they're template params.
+
+  // TODO: This is almost certainly wrong, see bug #431
+  // We should not require the full definition of Class for passing it as a
+  // template argument, but we must require it when the typedef it's aliasing
+  // is full-used.
+  // The bug has instructions for how to provoke the error more obviously.
+
+  // IWYU: Class needs a declaration
+  Container<Class>::value_type vt;
+
+  // IWYU: Class needs a declaration
+  Container<Class>::pair_type pt;
+}
+
+
+/**** IWYU_SUMMARY
+
+tests/cxx/typedef_in_template.cc should add these lines:
+#include "tests/cxx/typedef_in_template-i1.h"
+
+tests/cxx/typedef_in_template.cc should remove these lines:
+- #include "tests/cxx/typedef_in_template-d1.h"  // lines XX-XX
+
+The full include-list for tests/cxx/typedef_in_template.cc:
+#include "tests/cxx/typedef_in_template-i1.h"  // for Class (ptr only), Pair
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/typedef_in_template.cc
+++ b/tests/cxx/typedef_in_template.cc
@@ -15,6 +15,9 @@ class Container {
   // Should not be an iwyu violation for T
   typedef T value_type;
 
+  // C++11 alias declaration, should not be an iwyu violation for T
+  using alias_type = T;
+
   // IWYU: Pair is...*typedef_in_template-i1.h
   typedef Pair<T,T> pair_type;
 };
@@ -34,6 +37,9 @@ void Declarations() {
 
   // IWYU: Class needs a declaration
   Container<Class>::pair_type pt;
+
+  // IWYU: Class needs a declaration
+  Container<Class>::alias_type at;
 }
 
 


### PR DESCRIPTION
Typedefs are exempted from IWYU checks in templates, so treat C++11
alias declarations the same.

(side note: this behavior is broken, but at least now it's consistent. See bug #431.)

Fixes issue #412.