### PR TITLE
Map FILE to <stdio.h>

### DIFF
--- a/gcc.symbols.imp
+++ b/gcc.symbols.imp
@@ -104,6 +104,7 @@
   # add them in by hand as I discover them.
   { symbol: [ "EOF", private, "<stdio.h>", public ] },
   { symbol: [ "EOF", private, "<libio.h>", public ] },
+  { symbol: [ "FILE", private, "<stdio.h>", public ] },
   { symbol: [ "va_list", private, "<stdarg.h>", public ] },
   # These are symbols that could be defined in either stdlib.h or
   # malloc.h, but we always want the stdlib location.

--- a/iwyu_include_picker.cc
+++ b/iwyu_include_picker.cc
@@ -186,6 +186,7 @@ const IncludeMapEntry libc_symbol_map[] = {
   // add them in by hand as I discover them.
   { "EOF", kPrivate, "<stdio.h>", kPublic },
   { "EOF", kPrivate, "<libio.h>", kPublic },
+  { "FILE", kPrivate, "<stdio.h>", kPublic },
   { "va_list", kPrivate, "<stdarg.h>", kPublic },
   // These are symbols that could be defined in either stdlib.h or
   // malloc.h, but we always want the stdlib location.


### PR DESCRIPTION
Newer glibc has FILE in a separate header.

Fix for issue #447.