### PR TITLE
Add .H as a known header extension

### DIFF
--- a/fix_includes.py
+++ b/fix_includes.py
@@ -1437,7 +1437,7 @@ def _IsMainCUInclude(line_info, filename):
     return False
   # First, normalize the includee by getting rid of -inl.h and .h
   # suffixes (for the #include) and the "'s around the #include line.
-  canonical_include = re.sub(r'(-inl\.h|\.h)$',
+  canonical_include = re.sub(r'(-inl\.h|\.h|\.H)$',
                              '', line_info.key.replace('"', ''))
   # Then normalize includer by stripping extension and Google's test suffixes.
   canonical_file, _ = os.path.splitext(filename)

--- a/fix_includes_test.py
+++ b/fix_includes_test.py
@@ -3187,6 +3187,23 @@ The full include-list for barrier_includes.h:
                          self.actual_after_contents)
     self.assertEqual(1, num_files_modified)
 
+  def testSortingMainCUIncludeWithUpperCaseH(self):
+    """Check that we identify when first .H file is a main-cu #include."""
+    infile = """\
+#include <stdio.h>
+#include "foo.H"
+"""
+    expected_output = """\
+#include "foo.H"
+#include <stdio.h>
+"""
+    self.RegisterFileContents({'foo.cc': infile})
+    num_files_modified = fix_includes.SortIncludesInFiles(
+        ['foo.cc'], self.flags)
+    self.assertListEqual(expected_output.strip().split('\n'),
+                         self.actual_after_contents)
+    self.assertEqual(1, num_files_modified)
+
   def testSortingMainCUIncludeInSameDirectoryWithInl(self):
     """Check that we identify when first -inl.h file is a main-cu #include."""
     infile = """\

--- a/iwyu_path_util.cc
+++ b/iwyu_path_util.cc
@@ -94,6 +94,7 @@ string GetCanonicalName(string file_path) {
   file_path = NormalizeFilePath(file_path);
 
   bool stripped_ext = StripRight(&file_path, ".h")
+      || StripRight(&file_path, ".H")
       || StripRight(&file_path, ".hpp")
       || StripRight(&file_path, ".hxx")
       || StripRight(&file_path, ".hh")


### PR DESCRIPTION
No test coverage, I couldn't find any mention of the header extensions in our current test suite, and I don't think the cost outweighs the benefit here.