### PR TITLE
[CMakeLists.txt] remove stale references to ncurses

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,11 +173,9 @@ if( WIN32 )
     version # For clangDriver's MSVCToolchain
   )
 elseif( UNIX )
-  include(FindCurses)
   target_link_libraries(include-what-you-use
     pthread
     z
-    ${CURSES_LIBRARIES}
     ${CMAKE_DL_LIBS}
   )
 else()


### PR DESCRIPTION
It seems ncurses is not used by include-what-you-use.  So, removing the
stale ncurses-related references from CMakeLists.txt.

As a result, the include-what-you-use does not require ncurses header
files during the build phase and the result include-what-you-use binary
does not require ncurses libraries in runtime.