### PR TITLE
Add library dependency for backtrace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,9 +174,12 @@ if( WIN32 )
   )
 elseif( UNIX )
   include(FindCurses)
+  include(FindBacktrace)
+
   target_link_libraries(include-what-you-use
     pthread
     z
+    ${Backtrace_LIBRARIES}
     ${CURSES_LIBRARIES}
     ${CMAKE_DL_LIBS}
   )


### PR DESCRIPTION
The out-of-tree build on my FreeBSD 11 machine failed with an unresolved
symbol for `backtrace`.

Use CMake's find provider for backtrace to satisfy the dependency.