### PR TITLE
Improve path normalization in windows

### DIFF
--- a/iwyu_location_util.h
+++ b/iwyu_location_util.h
@@ -92,6 +92,11 @@ inline string GetFilePath(const clang::FileEntry* file) {
           NormalizeFilePath(file->getName()));
 }
 
+inline string GetFileFullPath(const clang::FileEntry* file) {
+  return (IsBuiltinFile(file) || file->tryGetRealPathName().empty())
+          ? "<built-in>" : NormalizeFilePath(file->tryGetRealPathName());
+}
+
 //------------------------------------------------------------
 // Helper functions for SourceLocation
 

--- a/iwyu_path_util.cc
+++ b/iwyu_path_util.cc
@@ -122,6 +122,11 @@ string GetCanonicalName(string file_path) {
   if (include_pos != string::npos)
     file_path = (file_path.substr(0, include_pos) + "/src/" +
                  file_path.substr(include_pos + strlen("/include/")));
+
+#ifdef _WIN32
+  std::transform(file_path.begin(), file_path.end(), file_path.begin(), tolower);
+#endif
+
   return file_path;
 }
 

--- a/iwyu_preprocessor.cc
+++ b/iwyu_preprocessor.cc
@@ -988,8 +988,12 @@ bool IwyuPreprocessorInfo::BelongsToMainCompilationUnit(
   // currently sometimes called with a nullptr main_file_.
   if (!includee)
     return false;
-  if (GetCanonicalName(GetFilePath(includee)) ==
-      GetCanonicalName(GetFilePath(main_file_)))
+
+  auto const includeeFullpath = GetFileFullPath(includee);
+  auto const mainFileFullpath = GetFileFullPath(main_file_);
+
+  if (GetCanonicalName(includeeFullpath) ==
+      GetCanonicalName(mainFileFullpath))
     return true;
   // Heuristic: if the main compilation unit's *first* include is
   // a file with the same basename, assume that it's the 'associated'
@@ -1001,8 +1005,8 @@ bool IwyuPreprocessorInfo::BelongsToMainCompilationUnit(
   int first_include_index = GlobalFlags().pch_in_code ? 2 : 1;
   if (includer == main_file_ &&
       ContainsKeyValue(num_includes_seen_, includer, first_include_index)) {
-    if (GetCanonicalName(Basename(GetFilePath(includee))) ==
-        GetCanonicalName(Basename(GetFilePath(main_file_))))
+    if (GetCanonicalName(Basename(includeeFullpath)) ==
+        GetCanonicalName(Basename(mainFileFullpath)))
       return true;
   }
   return false;

--- a/iwyu_tool.py
+++ b/iwyu_tool.py
@@ -95,6 +95,9 @@ def get_output(cwd, command):
                                stderr=subprocess.STDOUT)
     return process.communicate()[0].decode("utf-8").splitlines()
 
+def normalize_path(path):
+    return os.path.normcase(os.path.normpath(os.path.realpath(path)))
+
 
 def run_iwyu(cwd, compile_command, iwyu_args, verbose):
     """ Rewrite compile_command to an IWYU command, and run it. """
@@ -133,10 +136,10 @@ def main(compilation_db_path, source_files, verbose, formatter, jobs, iwyu_args)
 
     # expand symlinks
     for entry in compilation_db:
-        entry['file'] = os.path.realpath(entry['file'])
+        entry['file'] = normalize_path(entry['file'])
 
     # Cross-reference source files with compilation database
-    source_files = [os.path.realpath(s) for s in source_files]
+    source_files = [normalize_path(s) for s in source_files]
     if not source_files:
         # No source files specified, analyze entire compilation database
         entries = compilation_db


### PR DESCRIPTION
When using --clang-mode=cl and the flag /I., paths will be reported relative to the current directory. To make sure associate includes are always found, convert to full path before making canonical and
comparing. Additionally, make all lowercase in GetCanonicalName() as the last step, only for windows systems.

Also fixed iwyu_tool.py