### PR TITLE
Issue #479: Make dry-run return proper exit code

### DIFF
--- a/fix_includes.py
+++ b/fix_includes.py
@@ -2157,10 +2157,11 @@ def FixManyFiles(iwyu_records, flags):
   for iwyu_record in iwyu_records:
     try:
       fixed_lines = GetFixedFile(iwyu_record, flags)
-      if not flags.dry_run and fixed_lines is not None:
+      if fixed_lines is not None:
         file_and_fix_pairs.append((iwyu_record.filename, fixed_lines))
-        if (flags.checkout_command and
-            not os.access(iwyu_record.filename, os.W_OK)):
+        if flags.checkout_command and \
+           not flags.dry_run and \
+           not os.access(iwyu_record.filename, os.W_OK):
           files_to_checkout.append(iwyu_record.filename)
     except FixIncludesError as why:
       print('ERROR: %s - skipping file %s' % (why, iwyu_record.filename))
@@ -2187,8 +2188,9 @@ def FixManyFiles(iwyu_records, flags):
       checkout_command += (' -c %d' % flags.append_to_cl)
     _RunCommand(checkout_command, files_to_checkout)
 
-  for filename, fixed_lines in file_and_fix_pairs:
-    _WriteFileContents(filename, fixed_lines)
+  if not flags.dry_run:
+    for filename, fixed_lines in file_and_fix_pairs:
+      _WriteFileContents(filename, fixed_lines)
 
   files_fixed = [filename for filename, _ in file_and_fix_pairs]
 

--- a/fix_includes_test.py
+++ b/fix_includes_test.py
@@ -291,7 +291,7 @@ The full include-list for unified_diff.cc:
 -#include <notused.h>
 
  int main() { return 0; }
-IWYU edited 0 files on your behalf.
+IWYU edited 1 files on your behalf.
 
 """
 
@@ -3388,7 +3388,7 @@ The full include-list for dry_run:
     num_modified_files = fix_includes.ProcessIWYUOutput(
         StringIO(iwyu_output), ['dry_run'], self.flags)
     self.assertListEqual([], self.actual_after_contents)
-    self.assertEqual(0, num_modified_files)
+    self.assertEqual(1, num_modified_files)
 
   def testAddForwardDeclareAndKeepIwyuNamespaceFormat(self):
     """Tests that --keep_iwyu_namespace_format writes namespace lines


### PR DESCRIPTION
This makes the script match the documentation better.