### PR TITLE
Skip non-ctors during instantiation of implicit methods

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -163,6 +163,7 @@ using clang::CallExpr;
 using clang::ClassTemplateDecl;
 using clang::ClassTemplateSpecializationDecl;
 using clang::CompilerInstance;
+using clang::ConstructorUsingShadowDecl;
 using clang::Decl;
 using clang::DeclContext;
 using clang::DeclRefExpr;
@@ -618,8 +619,10 @@ class BaseAstVisitor : public RecursiveASTVisitor<Derived> {
     clang::Sema& sema = compiler_->getSema();
     DeclContext::lookup_result ctors = sema.LookupConstructors(decl);
     for (NamedDecl* ctor_lookup : ctors) {
-      // Ignore templated constructors.
-      if (isa<FunctionTemplateDecl>(ctor_lookup))
+      // Ignore templated or inheriting constructors.
+      if (isa<FunctionTemplateDecl>(ctor_lookup) ||
+          isa<UsingDecl>(ctor_lookup) ||
+          isa<ConstructorUsingShadowDecl>(ctor_lookup))
         continue;
       CXXConstructorDecl* ctor = cast<CXXConstructorDecl>(ctor_lookup);
       if (!ctor->hasBody() && !ctor->isDeleted() && ctor->isImplicit()) {

--- a/run_iwyu_tests.py
+++ b/run_iwyu_tests.py
@@ -108,6 +108,7 @@ class OneIwyuTest(unittest.TestCase):
       'prefix_header_includes_keep.cc': prefix_headers,
       'prefix_header_includes_remove.cc': prefix_headers,
       'typedef_in_template.cc': ['-std=c++11'],
+      'inheriting_ctor.cc': ['-std=c++11'],
     }
     include_map = {
       'alias_template.cc': ['.'],

--- a/tests/cxx/inheriting_ctor-d1.h
+++ b/tests/cxx/inheriting_ctor-d1.h
@@ -1,0 +1,15 @@
+//===--- inheriting_ctor-d1.h - test input file for iwyu ------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_INHERITING_CTOR_D1_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_INHERITING_CTOR_D1_H_
+
+#include "inheriting_ctor-i1.h"
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_INHERITING_CTOR_D1_H_

--- a/tests/cxx/inheriting_ctor-i1.h
+++ b/tests/cxx/inheriting_ctor-i1.h
@@ -1,0 +1,20 @@
+//===--- inheriting_ctor-i1.h - test input file for iwyu ------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_INHERITING_CTOR_I1_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_INHERITING_CTOR_I1_H_
+
+struct Base {
+  Base(int);
+};
+struct Derived : Base {
+  using Base::Base;
+};
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_INHERITING_CTOR_I1_H_

--- a/tests/cxx/inheriting_ctor.cc
+++ b/tests/cxx/inheriting_ctor.cc
@@ -1,0 +1,26 @@
+//===--- inheriting_ctor.cc - test input file for iwyu --------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "inheriting_ctor-d1.h"
+
+// IWYU: Derived is defined in .*-i1.h
+void func() { Derived d(1); }
+
+/**** IWYU_SUMMARY
+
+tests/cxx/inheriting_ctor.cc should add these lines:
+#include "inheriting_ctor-i1.h"
+
+tests/cxx/inheriting_ctor.cc should remove these lines:
+- #include "inheriting_ctor-d1.h"  // lines XX-XX
+
+The full include-list for tests/cxx/inheriting_ctor.cc:
+#include "inheriting_ctor-i1.h"  // for Derived
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
InstantiateImplicitMethods() wrongly assumed a ctor decl must be present just by checking that it is not a template. This is no longer true in C++11 where a using decl is also a valid ctor type.

Fixes #402 