### PR TITLE
Create a travis script to build with latest LLVM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,38 @@
+
+language: cpp
+
+addons:
+  apt:
+    sources:
+     - ubuntu-toolchain-r-test
+     - llvm-toolchain-trusty
+    packages:
+     - ninja-build
+     - llvm-dev
+     - libclang-dev
+     - clang
+
+before_install:
+ # Install a supported cmake version (>= 3.4.3)
+ - wget -O cmake.sh https://cmake.org/files/v3.10/cmake-3.10.0-rc1-Linux-x86_64.sh 
+ - sudo sh cmake.sh --skip-license --exclude-subdir --prefix=/usr/local
+
+ # Extract the version number from the most-recently installed LLVM
+ - VERSION=`ls -t /usr/lib/ | grep '^llvm-' | head -n 1 | sed -E 's/llvm-(.+)/\1/'`
+
+ # Absolute paths to LLVM's root and bin directory
+ - ROOT_PATH=`llvm-config-$VERSION --prefix`
+ - BIN_PATH=`llvm-config-$VERSION --bindir`
+
+script:
+# Build IWYU
+ - mkdir build
+ - cd build
+ - cmake -GNinja -DIWYU_LLVM_ROOT_PATH=$ROOT_PATH -DCMAKE_C_COMPILER=$BIN_PATH/clang -DCMAKE_CXX_COMPILER=$BIN_PATH/clang++ -DCMAKE_INSTALL_PREFIX=./ ../
+ - ninja install
+
+# Test IWYU
+ - cd ..
+ - python run_iwyu_tests.py -- build/bin/include-what-you-use
+ - python fix_includes_test.py
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Include What You Use #
 
+[![Build Status](https://travis-ci.org/include-what-you-use/include-what-you-use.svg?branch=master)](https://travis-ci.org/include-what-you-use/include-what-you-use)
+
 For more in-depth documentation, see http://github.com/include-what-you-use/include-what-you-use/tree/master/docs.
 
 


### PR DESCRIPTION
Hi,

After some fighting I got the Travis integration working. Phew!

You can check the result of the latest run (as configured on my fork) here: 
https://travis-ci.org/jru/include-what-you-use/builds/285073561

By default it will build PRs and master immediately after pushing. You just need to configure you account and enable the iwyu repo by going to https://travis-ci.org/

I figured it would be most useful if we keep building against the latest LLVM snapshot (as published in apt.llvm.org) so that we can react proactively should something break. What do you think?

Cheers.
