### PR TITLE
Make the instantiated type part of the caller stack

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -2819,19 +2819,20 @@ class InstantiatedTemplateVisitor
   // This isn't a Stmt, but sometimes we need to fully instantiate
   // a template class to get at a field of it, for instance:
   // MyClass<T>::size_type s;
-  void ScanInstantiatedType(
-      const Type* type, const ASTNode* caller_ast_node,
-      const map<const Type*, const Type*>& resugar_map) {
+  void ScanInstantiatedType(ASTNode* caller_ast_node,
+                            const map<const Type*, const Type*>& resugar_map) {
     Clear();
     caller_ast_node_ = caller_ast_node;
     resugar_map_ = resugar_map;
 
-    // Make sure that the caller didn't already put the type on the ast-stack.
-    CHECK_(caller_ast_node->GetAs<Type>() != type && "AST node already set");
-    // caller_ast_node requires a non-const ASTNode, but our node is
-    // const.  This cast is safe because we don't do anything with this
-    // node (instead, we immediately push a new node on top of it).
-    set_current_ast_node(const_cast<ASTNode*>(caller_ast_node));
+    // The caller node *is* the current node, unlike ScanInstantiatedFunction
+    // which instead starts in the context of the parent expression and relies
+    // on a TraverseDecl call to push the decl to the top of the AST stack.
+    set_current_ast_node(caller_ast_node);
+
+    const TemplateSpecializationType* type =
+        caller_ast_node->GetAs<TemplateSpecializationType>();
+    CHECK_(type != nullptr && "Not a template specialization");
 
     // As in TraverseExpandedTemplateFunctionHelper, we ignore all AST nodes
     // that will be reported when we traverse the uninstantiated type.
@@ -2841,7 +2842,8 @@ class InstantiatedTemplateVisitor
           const_cast<NamedDecl*>(type_decl_as_written));
     }
 
-    TraverseType(QualType(type, 0));
+    TraverseTemplateSpecializationType(
+        const_cast<TemplateSpecializationType*>(type));
   }
 
   //------------------------------------------------------------
@@ -3774,18 +3776,23 @@ class IwyuAstConsumer
   bool VisitUnaryExprOrTypeTraitExpr(clang::UnaryExprOrTypeTraitExpr* expr) {
     if (CanIgnoreCurrentASTNode())  return true;
 
-    const Type* arg_type = expr->getTypeOfArgument().getTypePtr();
+    const Type* arg_type =
+        RemoveElaboration(expr->getTypeOfArgument().getTypePtr());
     // Calling sizeof on a reference-to-X is the same as calling it on X.
     if (const ReferenceType* reftype = DynCastFrom(arg_type)) {
       arg_type = reftype->getPointeeTypeAsWritten().getTypePtr();
     }
-    if (!IsTemplatizedType(arg_type))
-      return Base::VisitUnaryExprOrTypeTraitExpr(expr);
 
-    const map<const Type*, const Type*> resugar_map
-        = GetTplTypeResugarMapForClass(arg_type);
-    instantiated_template_visitor_.ScanInstantiatedType(
-        arg_type, current_ast_node(), resugar_map);
+    if (const TemplateSpecializationType* arg_tmpl = DynCastFrom(arg_type)) {
+
+      // Special case: We are instantiating the type in the context of an
+      // expression. Need to push the type to the AST stack explicitly.
+      ASTNode node(arg_tmpl, *GlobalSourceManager());
+      node.SetParent(current_ast_node());
+
+      instantiated_template_visitor_.ScanInstantiatedType(
+          &node, GetTplTypeResugarMapForClass(arg_type));
+    }
 
     return Base::VisitUnaryExprOrTypeTraitExpr(expr);
   }
@@ -3852,12 +3859,9 @@ class IwyuAstConsumer
     if (!CanForwardDeclareType(current_ast_node())) {
       const map<const Type*, const Type*> resugar_map
           = GetTplTypeResugarMapForClass(type);
-      // ScanInstantiatedType requires that type not already be on the
-      // ast-stack that it sees, but in our case it will be.  So we
-      // pass in the parent-node.
-      const ASTNode* ast_parent = current_ast_node()->parent();
-      instantiated_template_visitor_.ScanInstantiatedType(
-          type, ast_parent, resugar_map);
+
+      instantiated_template_visitor_.ScanInstantiatedType(current_ast_node(),
+                                                          resugar_map);
     }
 
     return Base::VisitTemplateSpecializationType(type);

--- a/tests/cxx/template_default_args_roundtrip-direct.h
+++ b/tests/cxx/template_default_args_roundtrip-direct.h
@@ -1,0 +1,14 @@
+//=== template_default_args_roundtrip-direct.h - test input file for iwyu -===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_TEMPLATE_DEFAULT_ARGS_ROUNDTRIP_DIRECT_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_TEMPLATE_DEFAULT_ARGS_ROUNDTRIP_DIRECT_H_
+
+template<> struct DefaultArgument<int> {};
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_TEMPLATE_DEFAULT_ARGS_ROUNDTRIP_DIRECT_H_

--- a/tests/cxx/template_default_args_roundtrip-indirect.h
+++ b/tests/cxx/template_default_args_roundtrip-indirect.h
@@ -1,0 +1,15 @@
+//=== template_default_args_roundtrip-indirect.h - test input file for iwyu ==//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_TEMPLATE_DEFAULT_ARGS_ROUNDTRIP_INDIRECT_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_TEMPLATE_DEFAULT_ARGS_ROUNDTRIP_INDIRECT_H_
+
+#include "template_default_args_roundtrip-direct.h"
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_TEMPLATE_DEFAULT_ARGS_ROUNDTRIP_INDIRECT_H_

--- a/tests/cxx/template_default_args_roundtrip-template.h
+++ b/tests/cxx/template_default_args_roundtrip-template.h
@@ -1,0 +1,28 @@
+//=== template_default_args_roundtrip-template.h - test input file for iwyu ==//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_TEMPLATE_DEFAULT_ARGS_ROUNDTRIP_TEMPLATE_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_TEMPLATE_DEFAULT_ARGS_ROUNDTRIP_TEMPLATE_H_
+
+template <class T>
+struct Type {
+  struct Base {
+    T t;
+  };
+  struct NestedType : Base {};
+};
+
+template <class T>
+struct DefaultArgument;
+
+template <class T, class U = DefaultArgument<T>>
+struct Template {
+  typename Type<U>::NestedType t;
+};
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_TEMPLATE_DEFAULT_ARGS_ROUNDTRIP_TEMPLATE_H_

--- a/tests/cxx/template_default_args_roundtrip.cc
+++ b/tests/cxx/template_default_args_roundtrip.cc
@@ -1,0 +1,51 @@
+//===--- template_default_args_roundtrip.cc - test input file for iwyu ----===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// The real-world issue reduced in this test case is an implicit use of a
+// specialization of std::hash, by way of a default template argument.
+// For example:
+//
+//   class C {};
+//
+//   namespace std {
+//   template<> struct hash<C> {
+//     size_t operator()(C c) const {
+//       return sizeof(c);
+//     }
+//   };
+//   }
+//
+//   // The default for the unordered_set Hash type parameter is std::hash<C>
+//   // from above.
+//   std::unordered_set<C> s;
+
+
+#include "template_default_args_roundtrip-template.h"
+
+// Provides DefaultArgument<int> indirectly
+#include "template_default_args_roundtrip-indirect.h"
+// Provides DefaultArgument<int> directly
+#include "template_default_args_roundtrip-direct.h"
+
+
+//Template making a full use of DefaultArgument<int>
+Template<int> templ;
+
+/**** IWYU_SUMMARY
+
+tests/cxx/template_default_args_roundtrip.cc should add these lines:
+
+tests/cxx/template_default_args_roundtrip.cc should remove these lines:
+- #include "template_default_args_roundtrip-indirect.h"  // lines XX-XX
+
+The full include-list for tests/cxx/template_default_args_roundtrip.cc:
+#include "template_default_args_roundtrip-direct.h"  // for DefaultArgument
+#include "template_default_args_roundtrip-template.h"  // for Template
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
Right before starting with the template traversal, to differentiate
between the template proper and the calling code, the AST stack is
partitioned by pointing the data member *caller_ast_node_* to the root
node where the template code starts.

However, ScanInstantiatedType started in the context of the parent
expression and relied on TraverseType to push the current template
instantiation type to the AST stack before continuing.

This was wrong, since it caused the instantiation site (user code) to
be attributed as part of the template being instantiated (library code).
Specifically for default arguments, this AST stack was queried by
*GetLocOfTemplateThatProvides* to decide if the user, or the template,
should be responsible for the types of the arguments, ultimately causing
a type that the user defined not to be reported as a full use.

Closes #500