### PR TITLE
Remove missing diagnostic for C++11 and later

### DIFF
--- a/tests/cxx/badinc.cc
+++ b/tests/cxx/badinc.cc
@@ -1520,8 +1520,9 @@ int main() {
   // IWYU: std::vector is...*<vector>
   // IWYU: I2_Enum is...*badinc-i2.h
   std::vector<I2_Enum> local_enum_vector;
-  // I2_Enum here is redundant but harmless.
-  // IWYU: I2_Enum is...*badinc-i2.h
+  // TODO: In C++03 and earlier I2_Enum is required below. The fact that this
+  // depends on standard version indicates a bug in our template handling, as
+  // the instantiation chain is different in old vs. new standard libraries.
   // IWYU: std::vector is...*<vector>
   // IWYU: I21 is...*badinc-i2.h
   local_enum_vector.push_back(I21);


### PR DESCRIPTION
Clang r320250 switched to -std=gnu++14 by default, instead of gnu++98.

Something in the instantiation chain for old vs. new std::vector makes
the diagnostic for I2Enum disappear in C++11 and later.

Replace test expectation with a TODO -- we still get the (redundant)
diagnostic if we pass -std=gnu++98 to IWYU, and I haven't been able to
figure out exactly why we get it (or why it disappears under
gnu++14). More bugs to be found and fixed here.