### PR TITLE
Fix warning on MinGW

### DIFF
--- a/port.h
+++ b/port.h
@@ -65,7 +65,7 @@ class OstreamVoidifier {
 
 #define snprintf _snprintf
 
-#define NOMINMAX  // Prevent Windows headers from redefining min/max.
+#define NOMINMAX 1 // Prevent Windows headers from redefining min/max.
 #include "Shlwapi.h"  // for PathMatchSpecA
 
 // This undef is necessary to prevent conflicts between llvm


### PR DESCRIPTION
```
In file included from F:/Projects/include-what-you-use/iwyu_string_util.h:21:0,
                 from F:/Projects/include-what-you-use/iwyu_path_util.h:18,
                 from F:/Projects/include-what-you-use/iwyu_path_util.cc:10:
F:/Projects/include-what-you-use/port.h:68:0: warning: "NOMINMAX" redefined
 #define NOMINMAX  // Prevent Windows headers from redefining min/max.

In file included from F:/git-sdk-64/mingw64/include/c++/7.3.0/x86_64-w64-mingw32/bits/c++config.h:533:0,
                 from F:/git-sdk-64/mingw64/include/c++/7.3.0/string:38,
                 from F:/Projects/include-what-you-use/iwyu_path_util.h:15,
                 from F:/Projects/include-what-you-use/iwyu_path_util.cc:10:
F:/git-sdk-64/mingw64/include/c++/7.3.0/x86_64-w64-mingw32/bits/os_defines.h:45:0: note: this is the location of the previous definition
 #define NOMINMAX 1
```