### PR TITLE
Recognize C++11 range-for statements

### DIFF
--- a/run_iwyu_tests.py
+++ b/run_iwyu_tests.py
@@ -108,6 +108,7 @@ class OneIwyuTest(unittest.TestCase):
       'prefix_header_includes_add.cc': prefix_headers,
       'prefix_header_includes_keep.cc': prefix_headers,
       'prefix_header_includes_remove.cc': prefix_headers,
+      'range_for.cc': ['-std=c++11'],
       'typedef_in_template.cc': ['-std=c++11'],
       'inheriting_ctor.cc': ['-std=c++11'],
     }
@@ -167,6 +168,7 @@ class OneIwyuTest(unittest.TestCase):
       'prefix_header_includes_add.cc': ['.'],
       'prefix_header_includes_keep.cc': ['.'],
       'prefix_header_includes_remove.cc': ['.'],
+      'range_for.cc': ['.'],
       're_fwd_decl.cc': ['.'],
       'redecls.cc': ['.'],
       'remove_fwd_decl_when_including.cc': ['.'],

--- a/tests/cxx/range_for-iterable.h
+++ b/tests/cxx/range_for-iterable.h
@@ -1,0 +1,22 @@
+//===--- range_for-iterable.h - test input file for iwyu ------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/indirect.h"
+
+class Iterable {
+ public:
+  Iterable() : items(nullptr), count(0) {}
+
+  const IndirectClass* begin() const { return items; }
+  const IndirectClass* end() const { return items + count; }
+
+ private:
+  IndirectClass* items;
+  unsigned count;
+};

--- a/tests/cxx/range_for.cc
+++ b/tests/cxx/range_for.cc
@@ -1,0 +1,45 @@
+//===--- range_for.cc - test input file for iwyu --------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// Verify correct handling of the C++11 range-for statement.
+// The range-init expression always needs the complete type.
+// The loop variable should behave like any variable use.
+
+#include "tests/cxx/range_for-iterable.h"
+#include "tests/cxx/direct.h"
+
+int ref_item(const Iterable& items) {
+  int total = 0;
+  // IWYU: IndirectClass needs a declaration
+  for (const IndirectClass& i : items)
+    ;
+  return 0;
+}
+
+int value_item(const Iterable& items) {
+  // IWYU: IndirectClass is...*indirect.h
+  for (IndirectClass i : items)
+    ;
+  return 0;
+}
+
+
+/**** IWYU_SUMMARY
+
+tests/cxx/range_for.cc should add these lines:
+#include "tests/cxx/indirect.h"
+
+tests/cxx/range_for.cc should remove these lines:
+- #include "tests/cxx/direct.h"  // lines XX-XX
+
+The full include-list for tests/cxx/range_for.cc:
+#include "tests/cxx/indirect.h"  // for IndirectClass
+#include "tests/cxx/range_for-iterable.h"  // for Iterable
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
The range-init expression requires special treatment: it's a reference
type, but the language generates code that needs to see its complete
type.

Should fix #463.