### PR TITLE
Use flags to solve the definition-is-use problem

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -1400,7 +1400,7 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
             preprocessor_info().FileInfoFor(macro_def_file);
         file_info->ReportForwardDeclareUse(
             spelling_loc, fwd_decl,
-            IsNodeInsideCXXMethodBody(current_ast_node()), nullptr);
+            ComputeUseFlags(current_ast_node()), nullptr);
         break;
       }
     }
@@ -1649,7 +1649,7 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
     used_loc = GetCanonicalUseLocation(used_loc, target_decl);
     const FileEntry* used_in = GetFileEntry(used_loc);
     preprocessor_info().FileInfoFor(used_in)->ReportFullSymbolUse(
-        used_loc, target_decl, IsNodeInsideCXXMethodBody(current_ast_node()),
+        used_loc, target_decl, ComputeUseFlags(current_ast_node()),
         comment);
 
     // Sometimes using a decl drags in a few other uses as well:
@@ -1668,7 +1668,7 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
         = GetUsingDeclarationOf(used_decl, 
               GetDeclContext(current_ast_node()))) {
       preprocessor_info().FileInfoFor(used_in)->ReportUsingDeclUse(
-          used_loc, using_decl, IsNodeInsideCXXMethodBody(current_ast_node()),
+          used_loc, using_decl, ComputeUseFlags(current_ast_node()),
           "(for using decl)");
     }
 
@@ -1720,7 +1720,7 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
     used_loc = GetCanonicalUseLocation(used_loc, target_decl);
     const FileEntry* used_in = GetFileEntry(used_loc);
     preprocessor_info().FileInfoFor(used_in)->ReportForwardDeclareUse(
-        used_loc, target_decl, IsNodeInsideCXXMethodBody(current_ast_node()),
+        used_loc, target_decl, ComputeUseFlags(current_ast_node()),
         comment);
 
     // If we're a use that depends on a using declaration, make sure
@@ -1729,7 +1729,7 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
         = GetUsingDeclarationOf(used_decl, 
               GetDeclContext(current_ast_node()))) {
       preprocessor_info().FileInfoFor(used_in)->ReportUsingDeclUse(
-          used_loc, using_decl, IsNodeInsideCXXMethodBody(current_ast_node()),
+          used_loc, using_decl, ComputeUseFlags(current_ast_node()),
           "(for using decl)");
     }
   }

--- a/iwyu.cc
+++ b/iwyu.cc
@@ -1867,7 +1867,14 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
   bool VisitFunctionDecl(clang::FunctionDecl* decl) {
     if (CanIgnoreCurrentASTNode())  return true;
 
-    if (!decl->isThisDeclarationADefinition()) {
+    if (decl->isThisDeclarationADefinition()) {
+      // For free functions, report use of all previously seen decls.
+      if (decl->getKind() == Decl::Function) {
+        FunctionDecl* redecl = decl;
+        while ((redecl = redecl->getPreviousDecl()))
+          ReportDeclUse(CurrentLoc(), redecl);
+      }
+    } else {
       // Make all our types forward-declarable...
       current_ast_node()->set_in_forward_declare_context(true);
     }

--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -262,6 +262,15 @@ bool IsNodeInsideCXXMethodBody(const ASTNode* ast_node) {
   return false;
 }
 
+UseFlags ComputeUseFlags(const ASTNode* ast_node) {
+  UseFlags flags = UF_None;
+
+  if (IsNodeInsideCXXMethodBody(ast_node))
+    flags |= UF_InCxxMethodBody;
+
+  return flags;
+}
+
 bool IsNestedClassAsWritten(const ASTNode* ast_node) {
   return (ast_node->IsA<RecordDecl>() &&
           (ast_node->ParentIsA<CXXRecordDecl>() ||

--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -268,6 +268,16 @@ UseFlags ComputeUseFlags(const ASTNode* ast_node) {
   if (IsNodeInsideCXXMethodBody(ast_node))
     flags |= UF_InCxxMethodBody;
 
+  // Definitions of free functions are a little special, because they themselves
+  // count as uses of all prior declarations (ideally we should probably just
+  // require one but it's hard so say which, so we pick all previously seen).
+  // Later IWYU analysis phases do some canonicalization that isn't
+  // necessary/valid for this case, so mark it up for later.
+  if (const auto* fd = ast_node->GetAs<FunctionDecl>()) {
+    if (fd->getKind() == Decl::Function && fd->isThisDeclarationADefinition())
+      flags |= UF_FunctionDfn;
+  }
+
   return flags;
 }
 

--- a/iwyu_ast_util.h
+++ b/iwyu_ast_util.h
@@ -16,6 +16,7 @@
 #include <set>                          // for set
 #include <string>                       // for string
 
+#include "iwyu_use_flags.h"
 #include "port.h"  // for CHECK_
 #include "llvm/Support/Casting.h"
 #include "clang/AST/DeclBase.h"
@@ -385,6 +386,10 @@ bool IsQualifiedNameNode(const ASTNode* ast_node);
 // also check if the node is in an initializer (either explicitly or
 // implicitly), or the implicit (non-body) code of a destructor.
 bool IsNodeInsideCXXMethodBody(const ASTNode* ast_node);
+
+// Return UseFlags for the current node.
+// These flags provide context around the use to help later IWYU analysis,
+UseFlags ComputeUseFlags(const ASTNode* ast_node);
 
 // Return true if we're a nested class as written, that is, we're a
 // class decl inside another class decl.  The parent class may be

--- a/iwyu_output.cc
+++ b/iwyu_output.cc
@@ -237,7 +237,7 @@ string GetShortNameAsString(const clang::NamedDecl* named_decl) {
 
 // Holds information about a single full or fwd-decl use of a symbol.
 OneUse::OneUse(const NamedDecl* decl, SourceLocation use_loc,
-               OneUse::UseKind use_kind, bool in_cxx_method_body,
+               OneUse::UseKind use_kind, UseFlags flags,
                const char* comment)
     : symbol_name_(internal::GetQualifiedNameAsString(decl)),
       short_symbol_name_(internal::GetShortNameAsString(decl)),
@@ -247,7 +247,7 @@ OneUse::OneUse(const NamedDecl* decl, SourceLocation use_loc,
       decl_filepath_(GetFilePath(decl_file_)),
       use_loc_(use_loc),
       use_kind_(use_kind),             // full use or fwd-declare use
-      in_cxx_method_body_(in_cxx_method_body),
+      use_flags_(flags),
       comment_(comment ? comment : ""),
       ignore_use_(false),
       is_iwyu_violation_(false) {
@@ -263,7 +263,7 @@ OneUse::OneUse(const string& symbol_name, const FileEntry* dfn_file,
       decl_filepath_(dfn_filepath),
       use_loc_(use_loc),
       use_kind_(kFullUse),
-      in_cxx_method_body_(false),
+      use_flags_(UF_None),
       ignore_use_(false),
       is_iwyu_violation_(false) {
   // Sometimes dfn_filepath is actually a fully quoted include.  In
@@ -574,13 +574,13 @@ static void LogSymbolUse(const string& prefix, const OneUse& use) {
 
 void IwyuFileInfo::ReportFullSymbolUse(SourceLocation use_loc,
                                        const NamedDecl* decl,
-                                       bool in_cxx_method_body,
+                                       UseFlags flags,
                                        const char* comment) {
   if (decl) {
     // Since we need the full symbol, we need the decl's definition-site.
     decl = GetDefinitionAsWritten(decl);
     symbol_uses_.push_back(OneUse(decl, use_loc, OneUse::kFullUse,
-                                  in_cxx_method_body, comment));
+                                  flags, comment));
     LogSymbolUse("Marked full-info use of decl", symbol_uses_.back());
   }
 }
@@ -617,7 +617,7 @@ void IwyuFileInfo::ReportKnownDesiredFile(const FileEntry* included_file) {
 
 void IwyuFileInfo::ReportForwardDeclareUse(SourceLocation use_loc,
                                            const NamedDecl* decl,
-                                           bool in_cxx_method_body,
+                                           UseFlags flags,
                                            const char* comment) {
   if (!decl)
     return;
@@ -626,13 +626,13 @@ void IwyuFileInfo::ReportForwardDeclareUse(SourceLocation use_loc,
   // happened here, replace the friend with a real fwd decl.
   decl = GetNonfriendClassRedecl(decl);
   symbol_uses_.push_back(OneUse(decl, use_loc, OneUse::kForwardDeclareUse,
-                                in_cxx_method_body, comment));
+                                flags, comment));
   LogSymbolUse("Marked fwd-decl use of decl", symbol_uses_.back());
 }
 
 void IwyuFileInfo::ReportUsingDeclUse(SourceLocation use_loc,
                                       const UsingDecl* using_decl,
-                                      bool in_cxx_method_body,
+                                      UseFlags flags,
                                       const char* comment) {  
   // If accessing a symbol through a using decl in the same file that contains
   // the using decl, we must mark the using decl as referenced. At the end of
@@ -648,7 +648,7 @@ void IwyuFileInfo::ReportUsingDeclUse(SourceLocation use_loc,
   // When a symbol is accessed through a using decl, we must report
   // that as a full use of the using decl because whatever file that
   // using decl is in is now required.
-  ReportFullSymbolUse(use_loc, using_decl, in_cxx_method_body, comment);
+  ReportFullSymbolUse(use_loc, using_decl, flags, comment);
 }
 
 // Given a collection of symbol-uses for symbols defined in various
@@ -1970,7 +1970,7 @@ void IwyuFileInfo::ResolvePendingAnalysis() {
       if (using_decl->shadow_size() > 0) {
         ReportForwardDeclareUse(using_decl->getUsingLoc(),
                                 using_decl->shadow_begin()->getTargetDecl(),
-                                /* in_cxx_method_body */ false,
+                                /* flags */ UF_None,
                                 "(for un-referenced using)");
       }
     }

--- a/iwyu_output.h
+++ b/iwyu_output.h
@@ -72,6 +72,7 @@ class OneUse {
   clang::SourceLocation decl_loc() const { return decl_loc_; }
   bool is_full_use() const { return use_kind_ == kFullUse; }
   bool in_cxx_method_body() const { return (use_flags_ & UF_InCxxMethodBody); }
+  bool is_function_being_defined() const { return (use_flags_ & UF_FunctionDfn); }
   const string& comment() const { return comment_; }
   bool ignore_use() const { return ignore_use_; }
   bool is_iwyu_violation() const { return is_iwyu_violation_; }

--- a/iwyu_use_flags.h
+++ b/iwyu_use_flags.h
@@ -17,6 +17,7 @@ typedef unsigned UseFlags;
 
 const UseFlags UF_None = 0;
 const UseFlags UF_InCxxMethodBody = 1; // use is inside a C++ method body
+const UseFlags UF_FunctionDfn = 2;     // use is a function being defined
 
 }
 

--- a/iwyu_use_flags.h
+++ b/iwyu_use_flags.h
@@ -1,0 +1,23 @@
+//===--- iwyu_use_flags.h - describe various contextual features of uses --===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_WHAT_YOU_USE_IWYU_USE_FLAGS_H_
+#define INCLUDE_WHAT_YOU_USE_IWYU_USE_FLAGS_H_
+
+namespace include_what_you_use {
+
+// Flags describing special features of a use that influence IWYU analysis.
+typedef unsigned UseFlags;
+
+const UseFlags UF_None = 0;
+const UseFlags UF_InCxxMethodBody = 1; // use is inside a C++ method body
+
+}
+
+#endif

--- a/tests/cxx/defn_is_use-decl.h
+++ b/tests/cxx/defn_is_use-decl.h
@@ -1,0 +1,15 @@
+//===--- defn_is_use-decl.h - test input file for iwyu --------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_DEFN_IS_USE_DECL_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_DEFN_IS_USE_DECL_H_
+
+void SomeFunction();
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_DEFN_IS_USE_DECL_H_

--- a/tests/cxx/defn_is_use-namespace.h
+++ b/tests/cxx/defn_is_use-namespace.h
@@ -1,0 +1,19 @@
+//===--- defn_is_use-namespace.h - test input file for iwyu ---------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_DEFN_IS_USE_NAMESPACE_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_DEFN_IS_USE_NAMESPACE_H_
+
+namespace ns1 {
+namespace ns2 {
+  void Foo();
+}
+}
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_DEFN_IS_USE_NAMESPACE_H_

--- a/tests/cxx/defn_is_use.cc
+++ b/tests/cxx/defn_is_use.cc
@@ -1,0 +1,23 @@
+//===--- defn_is_use.cc - test input file for iwyu ------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "defn_is_use-decl.h"
+#include "defn_is_use-namespace.h"
+
+void ns1::ns2::Foo() {
+}
+
+void SomeFunction() {
+}
+
+/**** IWYU_SUMMARY
+
+(tests/cxx/defn_is_use.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
Here's a stab at fixing the problem where IWYU doesn't recognize the definition of free functions as uses of previous declarations of the functions.

This has been reported in #179, and with a slight wrinkle around namespaces in #441.

@bungeman, @EdSchouten, @pseyfert and @Tim020 -- could you take a look and see if this works in your respective contexts? Thanks!