### PR TITLE
Reworked fix done in c182d6a to allow compiling with stable clang/llv…

### DIFF
--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -452,16 +452,26 @@ string PrintableTemplateName(const TemplateName& tpl_name) {
 string PrintableTemplateArgument(const TemplateArgument& arg) {
   std::string buffer;
   raw_string_ostream ostream(buffer);
+#if __clang_major__ > 5
   printTemplateArgumentList(ostream, ArrayRef<TemplateArgument>(arg),
                             DefaultPrintPolicy());
+#else
+  TemplateSpecializationType::PrintTemplateArgumentList(
+      ostream, ArrayRef<TemplateArgument>(arg), DefaultPrintPolicy());
+#endif
   return ostream.str();
 }
 
 string PrintableTemplateArgumentLoc(const TemplateArgumentLoc& arg) {
   std::string buffer;
   raw_string_ostream ostream(buffer);
+#if __clang_major__ > 5
   printTemplateArgumentList(ostream, ArrayRef<TemplateArgumentLoc>(arg),
                             DefaultPrintPolicy());
+#else
+  TemplateSpecializationType::PrintTemplateArgumentList(
+      ostream, ArrayRef<TemplateArgumentLoc>(arg), DefaultPrintPolicy());
+#endif
   return ostream.str();
 }
 


### PR DESCRIPTION
The original commit disallow compiling iwyu using actual stable version 5.0.1. So better check, if the version fits. It might be necessary, to check further parts of the version, if the related SVN commit is applied to upcoming stable releases before 6.x.