### PR TITLE
<bits/move.h> is a part of <utility>.

### DIFF
--- a/gcc.stl.headers.imp
+++ b/gcc.stl.headers.imp
@@ -114,9 +114,7 @@
   { include: ["<tr1_impl/unordered_set>", private, "<unordered_set>", public ] },
   { include: ["<tr1_impl/utility>", private, "<tr1/utility>", public ] },
   { include: ["<tr1_impl/utility>", private, "<utility>", public ] },
-  # This didn't come from the grep, but seems to be where swap()
-  # is defined?
-  { include: ["<bits/move.h>", private, "<algorithm>", public ] },   # for swap<>()
+  { include: ["<bits/move.h>", private, "<utility>", public ] },
   # Hash and hashtable-based containers.
   { include: ["<tr1_impl/functional_hash.h>", private, "<tr1/functional>", public ] },
   { include: ["<tr1_impl/functional_hash.h>", private, "<tr1/unordered_map>", public ] },

--- a/iwyu_include_picker.cc
+++ b/iwyu_include_picker.cc
@@ -662,9 +662,7 @@ const IncludeMapEntry libstdcpp_include_map[] = {
   { "<tr1_impl/unordered_set>", kPrivate, "<unordered_set>", kPublic },
   { "<tr1_impl/utility>", kPrivate, "<tr1/utility>", kPublic },
   { "<tr1_impl/utility>", kPrivate, "<utility>", kPublic },
-  // This didn't come from the grep, but seems to be where swap()
-  // is defined?
-  { "<bits/move.h>", kPrivate, "<algorithm>", kPublic },   // for swap<>()
+  { "<bits/move.h>", kPrivate, "<utility>", kPublic },
   // Hash and hashtable-based containers.
   { "<tr1_impl/functional_hash.h>", kPrivate, "<tr1/functional>", kPublic },
   { "<tr1_impl/functional_hash.h>", kPrivate, "<tr1/unordered_map>", kPublic },

--- a/libcxx.imp
+++ b/libcxx.imp
@@ -4,7 +4,7 @@
   { include: ["<__mutex_base>", private, "<mutex>", public ] },
   { symbol: [ "std::declval", private, "<utility>", public ] },
   { symbol: [ "std::forward", private, "<utility>", public ] },
-  { symbol: [ "std::move", private, "<algorithm>", public ] },
+  { symbol: [ "std::move", private, "<utility>", public ] },
   { symbol: [ "std::nullptr_t", private, "<cstddef>", public ] },
   { symbol: [ "std::string", private, "<string>", public ] },
 ]

--- a/tests/cxx/move_is_in_utility.cc
+++ b/tests/cxx/move_is_in_utility.cc
@@ -1,0 +1,30 @@
+//===--- move_is_in_utility.cc - test input file for iwyu -----------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// std::move comes from <utility>, not <algorithm>.
+
+#include <utility>
+#include <algorithm>
+
+int foo(int x)
+{
+  int k = 3;
+  return std::move(k);
+}
+
+
+/**** IWYU_SUMMARY
+tests/cxx/move_is_in_utility.cc should add these lines:
+
+tests/cxx/move_is_in_utility.cc should remove these lines:
+- #include <algorithm>  // lines XX-XX
+
+The full include-list for tests/cxx/move_is_in_utility.cc:
+#include <utility>  // for move
+***** IWYU_SUMMARY */


### PR DESCRIPTION
`<bits/move.h>` provides std::forward, std::move, and std::swap. These are defined to come from `<utility>` and not `<algorithm>`.

In c++11 and later std::swap comes from `<utility>`, previously it came from `<algorithm>`. Fortunately, `<bits/move.h>` is a c++11 only header, so if any symbols are being seen in it, that's where they should come from.

This was reported in #486.