### PR TITLE
Better handling of encoding in fix_includes.py file I/O

### DIFF
--- a/fix_includes.py
+++ b/fix_includes.py
@@ -530,7 +530,7 @@ class FileInfo(object):
     return FileInfo.DEFAULT_LINESEP
 
 
-def _ReadFile(filename):
+def _ReadFile(filename, fileinfo):
   """Read from filename and return a list of file lines."""
   try:
     return open(filename).read().splitlines()
@@ -539,12 +539,9 @@ def _ReadFile(filename):
   return None
 
 
-def _WriteFile(filename, file_lines):
+def _WriteFile(filename, fileinfo, file_lines):
   """Write the given file-lines to the file."""
   try:
-    # Detect encoding details
-    fileinfo = FileInfo.parse(filename)
-
     # Open file in binary mode to preserve line endings
     with open(filename, 'wb') as f:
       f.write(fileinfo.linesep.join(file_lines))
@@ -2006,7 +2003,9 @@ def FixManyFiles(iwyu_records, flags):
   files_fixed = 0
   for iwyu_record in iwyu_records:
     try:
-      file_contents = _ReadFile(iwyu_record.filename)
+      fileinfo = FileInfo.parse(iwyu_record.filename)
+
+      file_contents = _ReadFile(iwyu_record.filename, fileinfo)
       if not file_contents:
         continue
 
@@ -2019,7 +2018,7 @@ def FixManyFiles(iwyu_records, flags):
       if flags.dry_run:
         PrintFileDiff(old_lines, fixed_lines)
       else:
-        _WriteFile(iwyu_record.filename, fixed_lines)
+        _WriteFile(iwyu_record.filename, fileinfo, fixed_lines)
 
       files_fixed += 1
     except FixIncludesError as why:

--- a/fix_includes_test.py
+++ b/fix_includes_test.py
@@ -46,12 +46,15 @@ class FakeFlags(object):
 class FixIncludesBase(unittest.TestCase):
   """Does setup that every test will want."""
 
-  def _ReadFile(self, filename):
+  def _ReadFile(self, filename, fileinfo):
     assert filename in self.before_map, filename
     return self.before_map[filename]
 
-  def _WriteFile(self, filename, file_lines):
-      self.actual_after_contents.extend(file_lines)
+  def _ParseFileInfo(self, filename):
+      return fix_includes.FileInfo('\n')
+
+  def _WriteFile(self, filename, fileinfo, contents):
+      return self.actual_after_contents.extend(contents)
 
   def setUp(self):
     self.flags = FakeFlags()
@@ -63,7 +66,11 @@ class FixIncludesBase(unittest.TestCase):
 
     # INPUT: fix_includes._ReadFile takes a filename
     # and returns the contents of filename (as a list).
+    # FileInfo controls encoding details of the file,
+    # wire it to return something that agrees with the
+    # tests.
     fix_includes._ReadFile = self._ReadFile
+    fix_includes.FileInfo.parse = self._ParseFileInfo
 
     # OUTPUT: Instead of writing to file, save full output.
     self.actual_after_contents = []

--- a/fix_includes_test.py
+++ b/fix_includes_test.py
@@ -51,7 +51,7 @@ class FixIncludesBase(unittest.TestCase):
     return self.before_map[filename]
 
   def _ParseFileInfo(self, filename):
-      return fix_includes.FileInfo('\n')
+      return fix_includes.FileInfo('\n', 'utf-8')
 
   def _WriteFile(self, filename, fileinfo, contents):
       return self.actual_after_contents.extend(contents)
@@ -3464,6 +3464,25 @@ class FileInfoTest(unittest.TestCase):
     buf = b'first\nsecond\nthird\r\nfourth\r\n'
     self.assertEqual(fix_includes.FileInfo.DEFAULT_LINESEP,
                      fix_includes.FileInfo.guess_linesep(buf))
+
+  def testEncodingASCII(self):
+    buf = b'abcdefgh'
+    self.assertEqual('ascii', fix_includes.FileInfo.guess_encoding(buf))
+
+  def testEncodingUTF8BOM(self):
+    buf = b'\xef\xbb\xbfSomeASCIIButWithTheBOM'
+    self.assertEqual('utf-8', fix_includes.FileInfo.guess_encoding(buf))
+
+  def testEncodingUTF8NoBOM(self):
+    # This is a recurring test input in Swedish, translates to "shrimp sandwich"
+    # and contains all three Swedish exotic characters.
+    buf = b'r\xc3\xa4ksm\xc3\xb6rg\xc3\xa5s'
+    self.assertEqual('utf-8', fix_includes.FileInfo.guess_encoding(buf))
+
+  def testEncodingISO8859_1(self):
+    # Yours truly
+    buf = b'Kim Gr\xe4sman'
+    self.assertEqual('windows-1250', fix_includes.FileInfo.guess_encoding(buf))
 
 
 if __name__ == '__main__':

--- a/fix_includes_test.py
+++ b/fix_includes_test.py
@@ -3434,5 +3434,30 @@ namespace ns { namespace ns4 { class Baz; } }
                       ['fix_includes.py', '-s'])
 
 
+class FileInfoTest(unittest.TestCase):
+  """ Unit test for file info detection """
+
+  def testEndingsWindows(self):
+    buf = b'first\r\nsecond\r\nthird\r\n'
+    self.assertEqual('\r\n', fix_includes.FileInfo.guess_linesep(buf))
+
+  def testEndingsUnix(self):
+    buf = b'first\nsecond\nthird\n'
+    self.assertEqual('\n', fix_includes.FileInfo.guess_linesep(buf))
+
+  def testEndingsMixedUnixMajority(self):
+    buf = b'first\nsecond\nsecond-and-a-half\r\nthird\nfourth\r\n'
+    self.assertEqual('\n', fix_includes.FileInfo.guess_linesep(buf))
+
+  def testEndingsMixedWindowsMajority(self):
+    buf = b'first\nsecond\r\nsecond-and-a-half\r\nthird\nfourth\r\n'
+    self.assertEqual('\r\n', fix_includes.FileInfo.guess_linesep(buf))
+
+  def testEndingsMixedTie(self):
+    buf = b'first\nsecond\nthird\r\nfourth\r\n'
+    self.assertEqual(fix_includes.FileInfo.DEFAULT_LINESEP,
+                     fix_includes.FileInfo.guess_linesep(buf))
+
+
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
Replaces PR #489.

Still a little hacky, but this appears to get the job done.

The first commit is already covered by PR #527, so only the last four apply to this problem.

@dakotahawkins, can you try this and see if it works in your context? Also, a thorough code review would be welcome from anyone.