### PR TITLE
Plain cmake

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ script:
 # Build IWYU
  - mkdir build
  - cd build
- - cmake -GNinja -DIWYU_LLVM_ROOT_PATH=$ROOT_PATH -DCMAKE_C_COMPILER=$BIN_PATH/clang -DCMAKE_CXX_COMPILER=$BIN_PATH/clang++ -DCMAKE_INSTALL_PREFIX=./ ../
+ - cmake -GNinja -DCMAKE_PREFIX_PATH=$ROOT_PATH -DCMAKE_C_COMPILER=$BIN_PATH/clang -DCMAKE_CXX_COMPILER=$BIN_PATH/clang++ -DCMAKE_INSTALL_PREFIX=./ ../
  - ninja install
 
 # Test IWYU

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,89 +1,34 @@
 cmake_minimum_required(VERSION 3.4.3)
 
-if( POLICY CMP0048 )
+if (POLICY CMP0048)
   # Silence CMP0048 warning about missing project VERSION.
   cmake_policy(SET CMP0048 NEW)
 endif()
 
 project(include-what-you-use)
 
-if( CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR )
-  message(STATUS "IWYU out-of-tree configuration")
+if (CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+  message(STATUS "IWYU: out-of-tree configuration")
 
-  if( DEFINED LLVM_PATH )
-    set(IWYU_LLVM_ROOT_PATH ${LLVM_PATH})
-    message(WARNING "LLVM_PATH is deprecated, use IWYU_LLVM_ROOT_PATH instead.")
-  endif()
+  find_package(LLVM CONFIG REQUIRED)
+  find_package(Clang CONFIG REQUIRED)
 
-  if( DEFINED IWYU_LLVM_INCLUDE_PATH AND DEFINED IWYU_LLVM_LIB_PATH )
-    # User provided include/lib paths, fall through
-  elseif ( DEFINED IWYU_LLVM_ROOT_PATH )
-    # Synthesize include/lib relative to a root.
-    set(IWYU_LLVM_INCLUDE_PATH ${IWYU_LLVM_ROOT_PATH}/include)
-    set(IWYU_LLVM_LIB_PATH ${IWYU_LLVM_ROOT_PATH}/lib)
-  else()
-    # If none provided, fail.
-    message(FATAL_ERROR
-      "Don't know how to find LLVM headers/libraries. "
-      "Use -DIWYU_LLVM_ROOT_PATH=/xyz or both "
-      "-DIWYU_LLVM_INCLUDE_PATH=/xyz/include and -DIWYU_LLVM_LIB_PATH=/xyz/lib")
-  endif()
+  list(APPEND CMAKE_MODULE_PATH ${LLVM_DIR})
+  include(AddLLVM)
+  include(HandleLLVMOptions)
+else()
+  message(STATUS "IWYU: in-tree configuration")
+endif()
 
-  include_directories(${IWYU_LLVM_INCLUDE_PATH})
-  link_directories(${IWYU_LLVM_LIB_PATH})
+message(STATUS "IWYU: configuring for LLVM ${LLVM_VERSION}...")
 
-  add_definitions(
-    -D__STDC_LIMIT_MACROS
-    -D__STDC_CONSTANT_MACROS
+add_definitions(${LLVM_DEFINITIONS})
+include_directories(
+  ${LLVM_INCLUDE_DIRS}
+  ${CLANG_INCLUDE_DIRS}
   )
 
-  if( MSVC )
-    # Adjust MSVC warning levels.
-    add_definitions(
-      # Ignore security warnings for standard functions.
-      -D_CRT_SECURE_NO_WARNINGS
-      -D_SCL_SECURE_NO_WARNINGS
-
-      # Disabled warnings.
-      -wd4141 # Suppress ''modifier' : used more than once' (because of __forceinline combined with inline)
-      -wd4146 # Suppress 'unary minus operator applied to unsigned type, result still unsigned'
-      -wd4244 # Suppress ''argument' : conversion from 'type1' to 'type2', possible loss of data'
-      -wd4267 # Suppress ''var' : conversion from 'size_t' to 'type', possible loss of data'
-      -wd4291 # Suppress ''declaration' : no matching operator delete found; memory will not be freed if initialization throws an exception'
-      -wd4345 # Suppress 'behavior change: an object of POD type constructed with an initializer of the form () will be default-initialized'
-      -wd4355 # Suppress ''this' : used in base member initializer list'
-      -wd4624 # Suppress ''derived class' : destructor could not be generated because a base class destructor is inaccessible'
-      -wd4800 # Suppress ''type' : forcing value to bool 'true' or 'false' (performance warning)'
-
-      # Promoted warnings.
-      -w14062 # Promote 'enumerator in switch of enum is not handled' to level 1 warning.
-
-      # Promoted warnings to errors.
-      -we4238 # Promote 'nonstandard extension used : class rvalue used as lvalue' to error.
-    )
-  endif()
-
-  if( APPLE )
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility-inlines-hidden")
-  endif()
-else()
-  message(STATUS "IWYU in-tree configuration")
-endif()
-
-# Pick up Git revision so we can report it in version information.
-include(FindGit)
-if( GIT_FOUND AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git" )
-  execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse --short HEAD
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    OUTPUT_VARIABLE IWYU_GIT_REV
-    OUTPUT_STRIP_TRAILING_WHITESPACE)
-else()
-  message(STATUS "Warning: IWYU Git version info not found, DO NOT release "
-                 "from this build tree!")
-endif()
-add_definitions(-DIWYU_GIT_REV="${IWYU_GIT_REV}")
-
-add_executable(include-what-you-use
+add_llvm_executable(include-what-you-use
   iwyu.cc
   iwyu_ast_util.cc
   iwyu_cache.cc
@@ -97,19 +42,19 @@ add_executable(include-what-you-use
   iwyu_path_util.cc
   iwyu_preprocessor.cc
   iwyu_verrs.cc
-)
+  )
 
-if( MINGW )
+if (MINGW)
   # Work around 'too many sections' error with MINGW/GCC
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wa,-mbig-obj")
 endif()
 
-if( MSVC )
+if (MSVC)
   # Disable warnings for IWYU, and disable exceptions in MSVC's STL.
   add_definitions(
     -wd4722 # Suppress ''destructor'' : destructor never returns, potential memory leak
     -D_HAS_EXCEPTIONS=0
-  )
+    )
 
   # Enable bigobj support and sane C++ exception semantics.
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj /EHsc")
@@ -117,82 +62,54 @@ if( MSVC )
   # Put project in solution folder
   set_target_properties(include-what-you-use
     PROPERTIES FOLDER "Clang executables"
-  )
-else()
-  # Disable RTTI, use C++11 to be compatible with LLVM/Clang libraries.
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti -std=c++11")
+    )
 endif()
 
-# Clang dependencies.
-target_link_libraries(include-what-you-use
-  PRIVATE
-  clangFrontend
-  clangSerialization
-  clangDriver
-  clangParse
-  clangSema
-  clangAnalysis
-  clangAST
-  clangBasic
-  clangEdit
-  clangLex
-)
+# Prefer dynamic library if it exists.
+if (TARGET LLVM)
+  message(STATUS "IWYU: Linking LLVM dynamically")
+  set(IWYU_LLVM_LIBS LLVM)
+else()
+  message(STATUS "IWYU: Linking LLVM statically")
+  set(IWYU_LLVM_LIBS
+    LLVMSupport
+    LLVMX86AsmParser
+    )
+endif()
 
-# LLVM dependencies.
 target_link_libraries(include-what-you-use
   PRIVATE
-  LLVMX86AsmParser # MC, MCParser, Support, X86CodeGen, X86Desc, X86Info
-  LLVMX86CodeGen # Analysis, AsmPrinter, CodeGen, Core, MC, Support, Target, 
-                 # X86AsmPrinter, X86Desc, X86Info, X86Utils
-  LLVMX86Desc # MC, MCDisassembler, Object, Support, X86AsmPrinter, X86Info
-  LLVMX86AsmPrinter # MC, Support, X86Utils
-  LLVMX86Info # Support
-  LLVMX86Utils # Core, Support
-  LLVMCodeGen # Analysis, Core, MC, Scalar, Support, Target, TransformUtils
-  LLVMipo
-  LLVMScalarOpts
-  LLVMInstCombine
-  LLVMTransformUtils
-  LLVMTarget # Analysis, MC, Core, Support
-  LLVMAnalysis # Core, Support
-  LLVMOption # Support
-  LLVMMCDisassembler # MC, Support
-  LLVMMCParser # MC, Support
-  LLVMMC # Object, Support
-  LLVMProfileData # Core, Support, Object
-  LLVMObject # BitReader, Core, Support
-  LLVMBitReader # Core, Support
-  LLVMCore # BinaryFormat, Support
-  LLVMBinaryFormat # Support
-  LLVMSupport # Demangle
-  LLVMDemangle
-)
+  clangBasic
+  clangLex
+  clangAST
+  clangSema
+  clangFrontend
+  clangDriver
+  ${IWYU_LLVM_LIBS}
+  )
 
 # Platform dependencies.
-if( WIN32 )
+if (WIN32)
   target_link_libraries(include-what-you-use
     PRIVATE
-    shlwapi
-    version # For clangDriver's MSVCToolchain
-  )
-elseif( UNIX )
-  include(FindCurses)
-  include(FindBacktrace)
-
-  target_link_libraries(include-what-you-use
-    PRIVATE
-    pthread
-    z
-    ${Backtrace_LIBRARIES}
-    ${CURSES_LIBRARIES}
-    ${CMAKE_DL_LIBS}
-  )
-else()
-  message(WARNING
-    "Unknown system: ${CMAKE_SYSTEM_NAME}. "
-    "No platform link-dependencies added.")
+    shlwapi  # For PathMatchSpecA
+    )
 endif()
 
+# Pick up Git revision so we can report it in version information.
+include(FindGit)
+if (GIT_FOUND AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
+  execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse --short HEAD
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    OUTPUT_VARIABLE IWYU_GIT_REV
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+else()
+  message(STATUS "Warning: IWYU Git version info not found, DO NOT release "
+                 "from this build tree!")
+endif()
+add_definitions(-DIWYU_GIT_REV="${IWYU_GIT_REV}")
+
+# Install programs
 install(TARGETS include-what-you-use RUNTIME DESTINATION bin)
 install(PROGRAMS fix_includes.py iwyu_tool.py DESTINATION bin)
 

--- a/README.md
+++ b/README.md
@@ -25,50 +25,50 @@ Include-what-you-use makes heavy use of Clang internals, and will occasionally b
 
 We also have convenience tags and branches for released versions of Clang (called `clang_<version>`, e.g. `clang_5.0`). To build against a Clang release, check out the corresponding branch in IWYU before configuring the build. More details in the instructions below.
 
-We support two build configurations: out-of-tree and in-tree.
- 
+We assume you already have compiled LLVM and Clang libraries on your system, either via packages for your platform or built from source.
 
-#### Building out-of-tree ####
+> NOTE: If you use the Debian/Ubuntu packaging available from <https://apt.llvm.org>, you'll need the following packages installed:
+>
+> - `llvm-<version>-dev`
+> - `libclang-<version>-dev`
+> - `clang-<version>`
+>
+> Packaging for other platforms will likely be subtly different.
 
-In an out-of-tree configuration, we assume you already have compiled LLVM and Clang headers and libs somewhere on your filesystem, such as via the `libclang-dev` package.
+To set up an environment for building:
 
-  * Create a directory for IWYU development, e.g. `iwyu-trunk`
+  * Create a directory for IWYU development, e.g. `iwyu`
 
   * Clone the IWYU Git repo:
 
-        iwyu-trunk$ git clone https://github.com/include-what-you-use/include-what-you-use.git
+        iwyu$ git clone https://github.com/include-what-you-use/include-what-you-use.git
 
-  * Presumably, you'll be building IWYU with a released version of LLVM and Clang, so check out the corresponding branch. For example if you have Clang 3.2 installed, use the `clang_3.2` branch. IWYU `master` tracks LLVM & Clang trunk:
+  * Presumably, you'll be building IWYU with a released version of LLVM and Clang, so check out the corresponding branch. For example, if you have Clang 6.0 installed, use the `clang_6.0` branch. IWYU `master` tracks LLVM & Clang trunk:
 
-        iwyu-trunk$ cd include-what-you-use
-        iwyu-trunk/include-what-you-use$ git checkout clang_3.2
-        iwyu-trunk/include-what-you-use$ cd ..
+        iwyu$ cd include-what-you-use
+        iwyu/include-what-you-use$ git checkout clang_6.0
 
-  * Create a build root and use CMake to generate a build system linked with LLVM/Clang prebuilts. Note that CMake settings need to match exactly, so you may need to add `-DCMAKE_BUILD_TYPE=Release` or more to the command-line below:
+  * Create a build root and use CMake to generate a build system linked with LLVM/Clang prebuilts:
 
         # This example uses the Makefile generator, but anything should work.
-        iwyu-trunk$ mkdir build && cd build
-        iwyu-trunk/build$ cmake -G "Unix Makefiles" -DIWYU_LLVM_ROOT_PATH=/usr/lib/llvm-3.4 ../include-what-you-use
+        iwyu/include-what-you-use$ cd ..
+        iwyu$ mkdir build && cd build
+
+        # For IWYU 0.10/Clang 6 and earlier
+        iwyu/build$ cmake -G "Unix Makefiles" -DIWYU_LLVM_ROOT_PATH=/usr/lib/llvm-6.0 ../include-what-you-use
+
+        # For IWYU 0.11/Clang 7 and later
+        iwyu/build$ cmake -G "Unix Makefiles" -DCMAKE_PREFIX_PATH=/usr/lib/llvm-7 ../include-what-you-use
+
+    or, if you have a local LLVM and Clang build tree, you can specify that as `CMAKE_PREFIX_PATH` for IWYU 0.11 and later:
+
+        iwyu/build$ cmake -G "Unix Makefiles" -DCMAKE_PREFIX_PATH=/llvm-trunk/build ../include-what-you-use
 
   * Once CMake has generated a build system, you can invoke it directly from `build`, e.g.
 
-        iwyu-trunk/build$ make
+        iwyu/build$ make
 
-This configuration is more useful if you want to get IWYU up and running quickly without building Clang and LLVM from scratch.
-
-
-#### Building in-tree ####
-
-You will need the Clang and LLVM trees on your system, such as by [checking out](http://clang.llvm.org/get_started.html) their SVN trees (but don't configure or build before you've done the following.)
-
-  * Clone the IWYU Git repo into the Clang source tree:
-
-        llvm/tools/clang/tools$ git clone https://github.com/include-what-you-use/include-what-you-use.git
-
-  * Edit `tools/clang/tools/CMakeLists.txt` and put in `add_subdirectory(include-what-you-use)`
-  * Once this is done, IWYU is recognized and picked up by CMake workflow as described in the Clang Getting Started guide
-
-This configuration is more useful if you're actively developing IWYU against Clang trunk. It's easier to set up correctly, but it requires that you build all of LLVM and Clang.
+Instructions for building Clang are available at <https://clang.llvm.org/get_started.html>.
 
 
 ### How to Install ###


### PR DESCRIPTION
It looks like Debian packaging for Clang is fixed now, so simplify CMakeLists.txt and documentation.

This PR is mostly to see if Travis picks up the change and builds correctly.