### PR TITLE
Add alternative mapping for std::function

### DIFF
--- a/gcc.stl.headers.imp
+++ b/gcc.stl.headers.imp
@@ -39,6 +39,7 @@
   { include: ["<bits/ostream_insert.h>", private, "<ostream>", public ] },
   { include: ["<bits/postypes.h>", private, "<iostream>", public ] },
   { include: ["<bits/slice_array.h>", private, "<valarray>", public ] },
+  { include: ["<bits/std_function.h>", private, "<functional>", public ] },
   { include: ["<bits/stl_algo.h>", private, "<algorithm>", public ] },
   { include: ["<bits/stl_algobase.h>", private, "<algorithm>", public ] },
   { include: ["<bits/stl_bvector.h>", private, "<vector>", public ] },

--- a/iwyu_include_picker.cc
+++ b/iwyu_include_picker.cc
@@ -587,6 +587,7 @@ const IncludeMapEntry libstdcpp_include_map[] = {
   { "<bits/ostream_insert.h>", kPrivate, "<ostream>", kPublic },
   { "<bits/postypes.h>", kPrivate, "<iostream>", kPublic },
   { "<bits/slice_array.h>", kPrivate, "<valarray>", kPublic },
+  { "<bits/std_function.h>", kPrivate, "<functional>", kPublic },
   { "<bits/stl_algo.h>", kPrivate, "<algorithm>", kPublic },
   { "<bits/stl_algobase.h>", kPrivate, "<algorithm>", kPublic },
   { "<bits/stl_bvector.h>", kPrivate, "<vector>", kPublic },


### PR DESCRIPTION
libstdc++ 7.1 and later defines std::function in bits/std_function.h
instead of bits/stl_function.h. Support both.

Fixes #487.