### PR TITLE
Enchance fix_includes.py to properly scan allman namespaces

### DIFF
--- a/fix_includes.py
+++ b/fix_includes.py
@@ -104,6 +104,10 @@ _ENDIF_RE = re.compile(r'\s*#\s*endif\b')
 _NAMESPACE_START_RE = re.compile(r'\s*(namespace\b[^{]*{\s*)+(//.*)?$|'
                                  r'\s*(U_NAMESPACE_BEGIN)|'
                                  r'\s*(HASH_NAMESPACE_DECLARATION_START)')
+# Also detect Allman style namespaces.  Use a continue regex for validation
+# but don't add it to the normal regex list.
+_NAMESPACE_START_ALLMAN_RE = re.compile(r'\s*(namespace\b[^{]*)+(//.*)?$')
+_NAMESPACE_CONTINUE_ALLMAN_RE = re.compile(r'\s*{\s*(//.*)?$')
 _NAMESPACE_END_RE = re.compile(r'\s*(})|'
                                r'\s*(U_NAMESPACE_END)|'
                                r'\s*(HASH_NAMESPACE_DECLARATION_END)')
@@ -125,8 +129,8 @@ _HEADER_GUARD_DEFINE_RE = re.compile(r'\s*#\s*define\s+')
 # Note that not all of the above RE's are represented here; for instance,
 # we fold _C_COMMENT_START_RE and _C_COMMENT_END_RE into _COMMENT_LINE_RE.
 _LINE_TYPES = [_COMMENT_LINE_RE, _BLANK_LINE_RE,
-               _NAMESPACE_START_RE, _NAMESPACE_END_RE,
-               _IF_RE, _ELSE_RE, _ENDIF_RE,
+               _NAMESPACE_START_RE, _NAMESPACE_START_ALLMAN_RE,
+               _NAMESPACE_END_RE, _IF_RE, _ELSE_RE, _ENDIF_RE,
                _INCLUDE_RE, _FORWARD_DECLARE_RE,
                _HEADER_GUARD_RE, _HEADER_GUARD_DEFINE_RE,
                _PRAGMA_ONCE_LINE_RE,
@@ -683,6 +687,7 @@ def _CalculateLineTypesAndKeys(file_lines, iwyu_record):
   """
   seen_types = set()
   in_c_style_comment = False
+  in_allman_namespace = False
   for line_info in file_lines:
     if line_info.line is None:
       line_info.type = None
@@ -706,6 +711,9 @@ def _CalculateLineTypesAndKeys(file_lines, iwyu_record):
       in_c_style_comment = False
     elif in_c_style_comment:
       line_info.type = _COMMENT_LINE_RE
+    elif in_allman_namespace and _NAMESPACE_CONTINUE_ALLMAN_RE.match(line_info.line):
+      in_allman_namespace = False
+      line_info.type = _NAMESPACE_CONTINUE_ALLMAN_RE
     else:
       for type_re in _LINE_TYPES:
         # header-guard-define-re has a two-part decision criterion: it
@@ -719,6 +727,9 @@ def _CalculateLineTypesAndKeys(file_lines, iwyu_record):
           line_info.type = type_re
           if type_re == _INCLUDE_RE:
             line_info.key = m.group(1)   # get the 'key' for the #include.
+          elif type_re == _NAMESPACE_START_ALLMAN_RE:
+            # set in_allman_namespace to true in order to find {}
+            in_allman_namespace = True
           break
       else:    # for/else
         line_info.type = None   # means we didn't match any re
@@ -968,14 +979,21 @@ def _DeleteEmptyNamespaces(file_lines):
   start_line = 0
   while start_line < len(file_lines):
     line_info = file_lines[start_line]
-    if line_info.deleted or line_info.type != _NAMESPACE_START_RE:
+    if (line_info.deleted or 
+       (line_info.type != _NAMESPACE_START_RE and
+        line_info.type != _NAMESPACE_START_ALLMAN_RE)):
       start_line += 1
       continue
-    # Because multiple namespaces can be on one line
-    # ("namespace foo { namespace bar { ..."), we need to count.
-    # We use the max because line may have 0 '{'s if it's a macro.
-    # TODO(csilvers): ignore { in comments.
-    namespace_depth = max(line_info.line.count('{'), 1)
+    if line_info.type == _NAMESPACE_START_RE:
+      # Because multiple namespaces can be on one line
+      # ("namespace foo { namespace bar { ..."), we need to count.
+      # We use the max because line may have 0 '{'s if it's a macro.
+      # TODO(csilvers): ignore { in comments.
+      namespace_depth = max(line_info.line.count('{'), 1)
+    elif line_info.type == _NAMESPACE_START_ALLMAN_RE:
+      # For Allman namespaces, keep the start line and increment
+      # the namespace depths when the actual brace is encountered.
+      namespace_depth = 0
     end_line = start_line + 1
     while end_line < len(file_lines):
       line_info = file_lines[end_line]
@@ -983,8 +1001,14 @@ def _DeleteEmptyNamespaces(file_lines):
         end_line += 1
       elif line_info.type in (_COMMENT_LINE_RE, _BLANK_LINE_RE):
         end_line += 1                # ignore blank lines
+      elif line_info.type == _NAMESPACE_CONTINUE_ALLMAN_RE:
+        namespace_depth += 1
+        end_line += 1
       elif line_info.type == _NAMESPACE_START_RE:     # nested namespace
         namespace_depth += max(line_info.line.count('{'), 1)
+        end_line += 1
+      elif line_info.type == _NAMESPACE_START_ALLMAN_RE:
+        # nested allman namespace
         end_line += 1
       elif line_info.type == _NAMESPACE_END_RE:
         namespace_depth -= max(line_info.line.count('}'), 1)
@@ -1189,7 +1213,8 @@ def _ShouldInsertBlankLine(decorated_move_span, next_decorated_move_span,
            file_lines[next_line].type == _COMMENT_LINE_RE):
       next_line += 1
     return (next_line and next_line < len(file_lines) and
-            file_lines[next_line].type in (_NAMESPACE_START_RE, None))
+            file_lines[next_line].type in 
+            (_NAMESPACE_START_RE, _NAMESPACE_START_ALLMAN_RE, None))
 
   # We never insert a blank line between two spans of the same kind.
   # Nor do we ever insert a blank line at EOF.
@@ -1259,6 +1284,8 @@ def _GetToplevelReorderSpans(file_lines):
     if line_info.type == _NAMESPACE_START_RE:
       # The 'max' is because the namespace-re may be a macro.
       namespace_depth += max(line_info.line.count('{'), 1)
+    elif line_info.type == _NAMESPACE_CONTINUE_ALLMAN_RE:
+      namespace_depth += 1
     elif line_info.type == _NAMESPACE_END_RE:
       namespace_depth -= max(line_info.line.count('}'), 1)
     if namespace_depth > 0:
@@ -1310,7 +1337,10 @@ def _GetFirstNamespaceLevelReorderSpan(file_lines):
     'namespace ns1 { namespace ns2 {', and reorder-span is a
     [start_line, end_line) pair.
   """
-  simple_namespace_re = re.compile(r'^\s*namespace\s+([^{\s]+)\s*\{\s*(//.*)?$')
+  simple_namespace_re = re.compile(
+    r'^\s*namespace\s+([^{\s]+)\s*\{\s*(//.*)?$')
+  simple_allman_namespace_re = re.compile(
+    r'^\s*namespace\s+([^{\s]+)\s*(//.*)?$')
   namespace_prefix = ''
 
   for line_number in range(len(file_lines)):
@@ -1343,6 +1373,18 @@ def _GetFirstNamespaceLevelReorderSpan(file_lines):
       if not m:
         break
       namespace_prefix += ('namespace %s { ' % m.group(1).strip())
+
+    elif line_info.type == _NAMESPACE_START_ALLMAN_RE:
+      # Trim any possibly comments on namespace to properly build
+      # the namespace level spans
+      m = simple_allman_namespace_re.match(line_info.line)
+      if not m:
+        break
+      namespace_prefix += ('namespace %s' % m.group(1).strip())
+
+    elif line_info.type == _NAMESPACE_CONTINUE_ALLMAN_RE:
+      # Append to the simplified allman namespace
+      namespace_prefix += ' { '
 
     elif line_info.type == _FORWARD_DECLARE_RE:
       # If we're not in a namespace, keep going.  Otherwise, this is

--- a/fix_includes.py
+++ b/fix_includes.py
@@ -130,9 +130,9 @@ _HEADER_GUARD_DEFINE_RE = re.compile(r'\s*#\s*define\s+')
 # We annotate every line in the source file by the re it matches, or None.
 # Note that not all of the above RE's are represented here; for instance,
 # we fold _C_COMMENT_START_RE and _C_COMMENT_END_RE into _COMMENT_LINE_RE.
-# The _NAMESPACE_CONTINUE_ALLMAN_MIXED_RE is also set on lines when allman
+# The _NAMESPACE_CONTINUE_ALLMAN_MIXED_RE is also set on lines when Allman
 # and mixed namespaces are detected but the RE is too easy to match to add
-# under normal circumstances (must always be proceded by allman/mixed).
+# under normal circumstances (must always be proceded by Allman/mixed).
 _LINE_TYPES = [_COMMENT_LINE_RE, _BLANK_LINE_RE,
                _NAMESPACE_START_RE, _NAMESPACE_START_ALLMAN_RE,
                _NAMESPACE_START_MIXED_RE, _NAMESPACE_END_RE,
@@ -718,7 +718,7 @@ def _CalculateLineTypesAndKeys(file_lines, iwyu_record):
     elif in_c_style_comment:
       line_info.type = _COMMENT_LINE_RE
     elif (in_allman_or_mixed_namespace and
-         _NAMESPACE_CONTINUE_ALLMAN_MIXED_RE.match(line_info.line)):
+          _NAMESPACE_CONTINUE_ALLMAN_MIXED_RE.match(line_info.line)):
       in_allman_or_mixed_namespace = False
       line_info.type = _NAMESPACE_CONTINUE_ALLMAN_MIXED_RE
     else:
@@ -988,7 +988,7 @@ def _DeleteEmptyNamespaces(file_lines):
   while start_line < len(file_lines):
     line_info = file_lines[start_line]
     if (line_info.deleted or 
-       (line_info.type != _NAMESPACE_START_RE and
+        (line_info.type != _NAMESPACE_START_RE and
         line_info.type != _NAMESPACE_START_ALLMAN_RE and
         line_info.type != _NAMESPACE_START_MIXED_RE)):
       start_line += 1
@@ -1022,7 +1022,7 @@ def _DeleteEmptyNamespaces(file_lines):
         namespace_depth += max(line_info.line.count('{'), 1)
         end_line += 1
       elif line_info.type == _NAMESPACE_START_ALLMAN_RE:
-        # nested allman namespace
+        # nested Allman namespace
         end_line += 1
       elif line_info.type == _NAMESPACE_END_RE:
         namespace_depth -= max(line_info.line.count('}'), 1)
@@ -1227,9 +1227,10 @@ def _ShouldInsertBlankLine(decorated_move_span, next_decorated_move_span,
            file_lines[next_line].type == _COMMENT_LINE_RE):
       next_line += 1
     return (next_line and next_line < len(file_lines) and
-            file_lines[next_line].type in 
-            (_NAMESPACE_START_RE, _NAMESPACE_START_ALLMAN_RE,
-            _NAMESPACE_START_MIXED_RE, None))
+            file_lines[next_line].type in (_NAMESPACE_START_RE,
+                                           _NAMESPACE_START_ALLMAN_RE,
+                                           _NAMESPACE_START_MIXED_RE,
+                                           None))
 
   # We never insert a blank line between two spans of the same kind.
   # Nor do we ever insert a blank line at EOF.
@@ -1399,7 +1400,7 @@ def _GetFirstNamespaceLevelReorderSpan(file_lines):
       namespace_prefix += ('namespace %s' % m.group(1).strip())
 
     elif line_info.type == _NAMESPACE_CONTINUE_ALLMAN_MIXED_RE:
-      # Append to the simplified allman namespace
+      # Append to the simplified Allman namespace
       namespace_prefix += ' { '
 
     elif line_info.type == _FORWARD_DECLARE_RE:

--- a/fix_includes.py
+++ b/fix_includes.py
@@ -104,10 +104,12 @@ _ENDIF_RE = re.compile(r'\s*#\s*endif\b')
 _NAMESPACE_START_RE = re.compile(r'\s*(namespace\b[^{]*{\s*)+(//.*)?$|'
                                  r'\s*(U_NAMESPACE_BEGIN)|'
                                  r'\s*(HASH_NAMESPACE_DECLARATION_START)')
-# Also detect Allman style namespaces.  Use a continue regex for validation
-# but don't add it to the normal regex list.
+# Also detect Allman and mixed style namespaces.  Use a continue regex for
+# validation and to correctly set the line info.
 _NAMESPACE_START_ALLMAN_RE = re.compile(r'\s*(namespace\b[^{]*)+(//.*)?$')
-_NAMESPACE_CONTINUE_ALLMAN_RE = re.compile(r'\s*{\s*(//.*)?$')
+_NAMESPACE_START_MIXED_RE = re.compile(
+  r'\s*(namespace\b[^{]*{\s*)+(namespace\b[^{]*)+(//.*)?$')
+_NAMESPACE_CONTINUE_ALLMAN_MIXED_RE = re.compile(r'\s*{\s*(//.*)?$')
 _NAMESPACE_END_RE = re.compile(r'\s*(})|'
                                r'\s*(U_NAMESPACE_END)|'
                                r'\s*(HASH_NAMESPACE_DECLARATION_END)')
@@ -128,9 +130,13 @@ _HEADER_GUARD_DEFINE_RE = re.compile(r'\s*#\s*define\s+')
 # We annotate every line in the source file by the re it matches, or None.
 # Note that not all of the above RE's are represented here; for instance,
 # we fold _C_COMMENT_START_RE and _C_COMMENT_END_RE into _COMMENT_LINE_RE.
+# The _NAMESPACE_CONTINUE_ALLMAN_MIXED_RE is also set on lines when allman
+# and mixed namespaces are detected but the RE is too easy to match to add
+# under normal circumstances (must always be proceded by allman/mixed).
 _LINE_TYPES = [_COMMENT_LINE_RE, _BLANK_LINE_RE,
                _NAMESPACE_START_RE, _NAMESPACE_START_ALLMAN_RE,
-               _NAMESPACE_END_RE, _IF_RE, _ELSE_RE, _ENDIF_RE,
+               _NAMESPACE_START_MIXED_RE, _NAMESPACE_END_RE,
+               _IF_RE, _ELSE_RE, _ENDIF_RE,
                _INCLUDE_RE, _FORWARD_DECLARE_RE,
                _HEADER_GUARD_RE, _HEADER_GUARD_DEFINE_RE,
                _PRAGMA_ONCE_LINE_RE,
@@ -687,7 +693,7 @@ def _CalculateLineTypesAndKeys(file_lines, iwyu_record):
   """
   seen_types = set()
   in_c_style_comment = False
-  in_allman_namespace = False
+  in_allman_or_mixed_namespace = False
   for line_info in file_lines:
     if line_info.line is None:
       line_info.type = None
@@ -711,9 +717,10 @@ def _CalculateLineTypesAndKeys(file_lines, iwyu_record):
       in_c_style_comment = False
     elif in_c_style_comment:
       line_info.type = _COMMENT_LINE_RE
-    elif in_allman_namespace and _NAMESPACE_CONTINUE_ALLMAN_RE.match(line_info.line):
-      in_allman_namespace = False
-      line_info.type = _NAMESPACE_CONTINUE_ALLMAN_RE
+    elif (in_allman_or_mixed_namespace and
+         _NAMESPACE_CONTINUE_ALLMAN_MIXED_RE.match(line_info.line)):
+      in_allman_or_mixed_namespace = False
+      line_info.type = _NAMESPACE_CONTINUE_ALLMAN_MIXED_RE
     else:
       for type_re in _LINE_TYPES:
         # header-guard-define-re has a two-part decision criterion: it
@@ -727,9 +734,10 @@ def _CalculateLineTypesAndKeys(file_lines, iwyu_record):
           line_info.type = type_re
           if type_re == _INCLUDE_RE:
             line_info.key = m.group(1)   # get the 'key' for the #include.
-          elif type_re == _NAMESPACE_START_ALLMAN_RE:
-            # set in_allman_namespace to true in order to find {}
-            in_allman_namespace = True
+          elif type_re in (_NAMESPACE_START_ALLMAN_RE,
+                           _NAMESPACE_START_MIXED_RE):
+            # set in_allman_or_mixed_namespace to true to find the next {
+            in_allman_or_mixed_namespace = True
           break
       else:    # for/else
         line_info.type = None   # means we didn't match any re
@@ -981,10 +989,11 @@ def _DeleteEmptyNamespaces(file_lines):
     line_info = file_lines[start_line]
     if (line_info.deleted or 
        (line_info.type != _NAMESPACE_START_RE and
-        line_info.type != _NAMESPACE_START_ALLMAN_RE)):
+        line_info.type != _NAMESPACE_START_ALLMAN_RE and
+        line_info.type != _NAMESPACE_START_MIXED_RE)):
       start_line += 1
       continue
-    if line_info.type == _NAMESPACE_START_RE:
+    if line_info.type in (_NAMESPACE_START_RE, _NAMESPACE_START_MIXED_RE):
       # Because multiple namespaces can be on one line
       # ("namespace foo { namespace bar { ..."), we need to count.
       # We use the max because line may have 0 '{'s if it's a macro.
@@ -994,6 +1003,10 @@ def _DeleteEmptyNamespaces(file_lines):
       # For Allman namespaces, keep the start line and increment
       # the namespace depths when the actual brace is encountered.
       namespace_depth = 0
+    else:
+      # We should have handled all the namespace styles above!
+      assert False, ('unknown namespace type',
+                     _LINE_TYPES.index(line_info.type))
     end_line = start_line + 1
     while end_line < len(file_lines):
       line_info = file_lines[end_line]
@@ -1001,10 +1014,11 @@ def _DeleteEmptyNamespaces(file_lines):
         end_line += 1
       elif line_info.type in (_COMMENT_LINE_RE, _BLANK_LINE_RE):
         end_line += 1                # ignore blank lines
-      elif line_info.type == _NAMESPACE_CONTINUE_ALLMAN_RE:
+      elif line_info.type == _NAMESPACE_CONTINUE_ALLMAN_MIXED_RE:
         namespace_depth += 1
         end_line += 1
-      elif line_info.type == _NAMESPACE_START_RE:     # nested namespace
+      elif line_info.type in (_NAMESPACE_START_RE, _NAMESPACE_START_MIXED_RE):
+        # nested namespace
         namespace_depth += max(line_info.line.count('{'), 1)
         end_line += 1
       elif line_info.type == _NAMESPACE_START_ALLMAN_RE:
@@ -1214,7 +1228,8 @@ def _ShouldInsertBlankLine(decorated_move_span, next_decorated_move_span,
       next_line += 1
     return (next_line and next_line < len(file_lines) and
             file_lines[next_line].type in 
-            (_NAMESPACE_START_RE, _NAMESPACE_START_ALLMAN_RE, None))
+            (_NAMESPACE_START_RE, _NAMESPACE_START_ALLMAN_RE,
+            _NAMESPACE_START_MIXED_RE, None))
 
   # We never insert a blank line between two spans of the same kind.
   # Nor do we ever insert a blank line at EOF.
@@ -1281,10 +1296,10 @@ def _GetToplevelReorderSpans(file_lines):
     line_info = file_lines[line_number]
     if line_info.deleted:
       continue
-    if line_info.type == _NAMESPACE_START_RE:
+    if line_info.type in (_NAMESPACE_START_RE, _NAMESPACE_START_MIXED_RE):
       # The 'max' is because the namespace-re may be a macro.
       namespace_depth += max(line_info.line.count('{'), 1)
-    elif line_info.type == _NAMESPACE_CONTINUE_ALLMAN_RE:
+    elif line_info.type == _NAMESPACE_CONTINUE_ALLMAN_MIXED_RE:
       namespace_depth += 1
     elif line_info.type == _NAMESPACE_END_RE:
       namespace_depth -= max(line_info.line.count('}'), 1)
@@ -1374,15 +1389,16 @@ def _GetFirstNamespaceLevelReorderSpan(file_lines):
         break
       namespace_prefix += ('namespace %s { ' % m.group(1).strip())
 
-    elif line_info.type == _NAMESPACE_START_ALLMAN_RE:
-      # Trim any possibly comments on namespace to properly build
+    elif line_info.type in (_NAMESPACE_START_ALLMAN_RE,
+                            _NAMESPACE_START_MIXED_RE):
+      # Trim any possible comments on namespace to properly build
       # the namespace level spans
       m = simple_allman_namespace_re.match(line_info.line)
       if not m:
         break
       namespace_prefix += ('namespace %s' % m.group(1).strip())
 
-    elif line_info.type == _NAMESPACE_CONTINUE_ALLMAN_RE:
+    elif line_info.type == _NAMESPACE_CONTINUE_ALLMAN_MIXED_RE:
       # Append to the simplified allman namespace
       namespace_prefix += ' { '
 

--- a/fix_includes_test.py
+++ b/fix_includes_test.py
@@ -307,7 +307,7 @@ The full include-list for empty_namespace:
     self.ProcessAndTest(iwyu_output)
 
   def testRemoveEmptyAllmanNamespace(self):
-    """Tests we remove a namespace with allman braces if we remove all fwd-decls inside it."""
+    """Tests we remove a namespace with Allman braces if we remove all fwd-decls inside it."""
     infile = """\
 // Copyright 2010
 
@@ -412,7 +412,7 @@ namespace maps_transit_realtime { namespace service_alerts { class StaticService
     self.ProcessAndTest(iwyu_output)
 
   def testRemovePartOfEmptyAllmanNamespace(self):
-    """Tests we remove a namespace with allman braces if empty, but not enclosing namespaces."""
+    """Tests we remove a namespace with Allman braces if empty, but not enclosing namespaces."""
     infile = """\
 // Copyright 2010
 
@@ -2708,7 +2708,7 @@ The full include-list for iterative_namespace:
     self.ProcessAndTest(iwyu_output)
 
   def testIterativeAllmanNamespaceDelete(self):
-    """Tests deleting an allman namespace with an emptied #ifdef inside it."""
+    """Tests deleting an Allman namespace with an emptied #ifdef inside it."""
     infile = """\
 // Copyright 2010
                  ///-

--- a/fix_includes_test.py
+++ b/fix_includes_test.py
@@ -339,6 +339,80 @@ namespace maps_transit_realtime { namespace service_alerts { class StaticService
     self.RegisterFileContents({'empty_internal_namespace': infile})
     self.ProcessAndTest(iwyu_output)
 
+  def testRemoveEmptyAllmanNamespace(self):
+    """Tests we remove a namespace with allman braces if we remove all fwd-decls inside it."""
+    infile = """\
+// Copyright 2010
+
+#include <stdio.h>
+
+namespace ns     ///-
+{                ///-
+class Foo;       ///-
+namespace ns2    ///-
+{                ///-
+namespace ns3    ///-
+{                ///-
+class Bar;       ///-
+}                ///-
+}                ///-
+class Baz;       ///-
+}                ///-
+                 ///-
+int main() { return 0; }
+"""
+    iwyu_output = """\
+empty_namespace should add these lines:
+
+empty_namespace should remove these lines:
+- class Foo;  // lines 7-7
+- namespace ns { namespace ns2 { namespace ns3 { class Bar; } } }  // lines 12-12
+- namespace ns { class Baz; } }  // lines 15-15
+
+The full include-list for empty_namespace:
+#include <stdio.h>
+---
+"""
+    self.RegisterFileContents({'empty_namespace': infile})
+    self.ProcessAndTest(iwyu_output)
+
+  def testRemovePartOfEmptyAllmanNamespace(self):
+    """Tests we remove a namespace with allman braces if empty, but not enclosing namespaces."""
+    infile = """\
+// Copyright 2010
+
+namespace maps_transit_realtime
+{
+namespace service_alerts
+{
+class StaticServiceAlertStore;
+namespace trigger                    ///-
+{                                    ///-
+class Trigger;                       ///-
+}  // namespace trigger              ///-
+namespace ui                         ///-
+{                                    ///-
+class Alert;                         ///-
+}  // namespace ui                   ///-
+}  // namespace service_alerts
+}  // namespace maps_transit_realtime
+
+int main() { return 0; }
+"""
+    iwyu_output = """\
+empty_internal_namespace should add these lines:
+
+empty_internal_namespace should remove these lines:
+- namespace maps_transit_realtime { namespace service_alerts { namespace trigger { class Trigger; } } }  // lines 10-10
+- namespace maps_transit_realtime { namespace service_alerts { namespace ui { class Alert; } } }  // lines 14-14
+
+The full include-list for empty_internal_namespace:
+namespace maps_transit_realtime { namespace service_alerts { class StaticServiceAlertStore; } }   // lines 7-7
+---
+"""
+    self.RegisterFileContents({'empty_internal_namespace': infile})
+    self.ProcessAndTest(iwyu_output)
+
   def testRemoveEmptyIfdef(self):
     """Tests we remove an #ifdef if we remove all #includes inside it."""
     # Also makes sure we reorder properly around the removed ifdef.
@@ -2556,6 +2630,32 @@ iterative_namespace should add these lines:
 
 iterative_namespace should remove these lines:
 - class Bar;  // lines 5-5
+
+The full include-list for iterative_namespace:
+---
+"""
+    self.RegisterFileContents({'iterative_namespace': infile})
+    self.ProcessAndTest(iwyu_output)
+
+  def testIterativeAllmanNamespaceDelete(self):
+    """Tests deleting an allman namespace with an emptied #ifdef inside it."""
+    infile = """\
+// Copyright 2010
+                 ///-
+namespace foo    ///-
+{                ///-
+#ifdef FWD_DECL  ///-
+class Bar;       ///-
+#endif           ///-
+}                ///-
+
+int main() { return 0; }
+"""
+    iwyu_output = """\
+iterative_namespace should add these lines:
+
+iterative_namespace should remove these lines:
+- class Bar;  // lines 6-6
 
 The full include-list for iterative_namespace:
 ---


### PR DESCRIPTION
The fix_includes.py script has been tailored to work for
namespaces that have { on the same line as the namespace.
For styles that do not follow this format, namespace
detection does not work properly as the line numbers and
regex statement are not able to be evaluated.  Logic has
been added to detect when an allman namespace has been
found and shifts the line numbers appropriately.

Signed-off-by: Christian Venegas <cvenegas@esri.com>

Fixes issue https://github.com/include-what-you-use/include-what-you-use/issues/557