### PR TITLE
[fix-includes] Enable specifiying a 'base path' relative to which the IWYU output should be interpreted

### DIFF
--- a/fix_includes.py
+++ b/fix_includes.py
@@ -320,7 +320,7 @@ class IWYUOutputParser(object):
     self.filename = '<unknown file>'
     self.lines_by_section = {}     # key is an RE, value is a list of lines
 
-  def _ProcessOneLine(self, line):
+  def _ProcessOneLine(self, line, basedir=None):
     """Reads one line of input, updates self, and returns False at EORecord.
 
     If the line matches one of the hard-coded section names, updates
@@ -347,7 +347,8 @@ class IWYUOutputParser(object):
       if m:
         # Check or set the filename (if the re has a group, it's for filename).
         if section_re.groups >= 1:
-          this_filename = m.group(1)
+          this_filename = NormalizeFilePath(basedir, m.group(1))
+
           if (self.current_section is not None and
               this_filename != self.filename):
             raise FixIncludesError('"%s" section for %s comes after "%s" for %s'
@@ -398,7 +399,8 @@ class IWYUOutputParser(object):
        FixIncludesError: for malformed-looking lines in the iwyu output.
     """
     for line in iwyu_output:
-      if not self._ProcessOneLine(line):   # returns False at end-of-record
+      if not self._ProcessOneLine(line, flags.basedir):
+        # returns False at end-of-record
         break
     else:                                  # for/else
       return None                          # at EOF
@@ -2234,7 +2236,7 @@ def ProcessIWYUOutput(f, files_to_process, flags):
     except FixIncludesError as why:
       print('ERROR: %s' % why)
       continue
-    filename = iwyu_record.filename
+    filename = NormalizeFilePath(flags.basedir, iwyu_record.filename)
     if files_to_process is not None and filename not in files_to_process:
       print('(skipping %s: not listed on commandline)' % filename)
       continue
@@ -2267,6 +2269,11 @@ def ProcessIWYUOutput(f, files_to_process, flags):
   return FixManyFiles(contentful_records, flags)
 
 
+def NormalizeFilePath(basedir, filename):
+    if basedir and not os.path.isabs(filename):
+        return os.path.normpath(os.path.join(basedir, filename))
+    return filename
+
 def SortIncludesInFiles(files_to_process, flags):
   """For each file in files_to_process, sort its #includes.
 
@@ -2285,6 +2292,7 @@ def SortIncludesInFiles(files_to_process, flags):
   """
   sort_only_iwyu_records = []
   for filename in files_to_process:
+    filename = NormalizeFilePath(flags.basedir, filename)
     # An empty iwyu record has no adds or deletes, so its only effect
     # is to cause us to sort the #include lines.  (Since fix_includes
     # gets all its knowledge of where forward-declare lines are from
@@ -2357,6 +2365,11 @@ def main(argv):
                           '\\n}\\n}.'))
   parser.add_option('--nokeep_iwyu_namespace_format', action='store_false',
                     dest='keep_iwyu_namespace_format')
+
+  parser.add_option('--basedir', '-p', default=None,
+                    help=('Specify the base directory. fix_includes will '
+                          'interpret non-absolute filenames relative to this '
+                          'path.'))
 
   (flags, files_to_modify) = parser.parse_args(argv[1:])
   if files_to_modify:

--- a/fix_includes_test.py
+++ b/fix_includes_test.py
@@ -23,7 +23,6 @@ try:
 except ImportError:
     from io import StringIO
 
-import os
 import re
 import sys
 # I use unittest instead of googletest to ease opensourcing.


### PR DESCRIPTION
iwyu likes to output relative filenames, which can make running fix-includes tedious sometimes. This PR adds an option to specify a base-path which gets prepended to relative filenames.