### PR TITLE
Add option to disable line re-ordering

### DIFF
--- a/fix_includes.py
+++ b/fix_includes.py
@@ -2172,10 +2172,16 @@ def main(argv):
   parser.add_option('--nosafe_headers', action='store_false',
                     dest='safe_headers')
 
+  # --reorder and --no-reorder share the same destination variable.  Omitting
+  # the default here would still produce the intended behavior, however if
+  # the code is re-organized such that these two specifications are swapped
+  # relative to each-other there will be a change in behavior.
   parser.add_option('--reorder', default=False, action='store_true', dest='reorder',
                     help=('Re-order lines relative to other similar lines '
                           '(eg, headers relative to other headers)'))
 
+  # --reorder and --no-reorder share the same destination variable.  Omitting
+  # the default here would make the default True.
   parser.add_option('--no-reorder', default=False, action='store_false', dest='reorder',
                     help=('Do not re-order lines relative to other similar lines.'))
 

--- a/fix_includes.py
+++ b/fix_includes.py
@@ -1929,7 +1929,7 @@ def FixFileLines(iwyu_record, file_lines, flags):
   # For every move-span in our file -- that's every #include and
   # forward-declare we saw -- 'decorate' the move-range to allow us
   # to sort them.
-  move_spans = OrderedSet([fl.move_span for fl in file_lines if fl.move_span])  decorated_move_spans = []
+  move_spans = OrderedSet([fl.move_span for fl in file_lines if fl.move_span])
   for (start_line, end_line) in move_spans:
     decorated_span = _DecoratedMoveSpanLines(iwyu_record, file_lines,
                                              file_lines[start_line:end_line],

--- a/fix_includes.py
+++ b/fix_includes.py
@@ -2177,7 +2177,7 @@ def main(argv):
                     help=('Re-order lines relative to other similar lines '
                           '(eg, headers relative to other headers)'))
 
-  parser.add_option('--no-reorder', default=False, action='store_false', dest='reorder'
+  parser.add_option('--no-reorder', default=False, action='store_false', dest='reorder',
                     help=('Do not re-order lines relative to other similar lines.'))
 
   parser.add_option('-s', '--sort_only', action='store_true',

--- a/fix_includes.py
+++ b/fix_includes.py
@@ -1930,6 +1930,7 @@ def FixFileLines(iwyu_record, file_lines, flags):
   # forward-declare we saw -- 'decorate' the move-range to allow us
   # to sort them.
   move_spans = OrderedSet([fl.move_span for fl in file_lines if fl.move_span])
+  decorated_move_spans = []
   for (start_line, end_line) in move_spans:
     decorated_span = _DecoratedMoveSpanLines(iwyu_record, file_lines,
                                              file_lines[start_line:end_line],

--- a/fix_includes.py
+++ b/fix_includes.py
@@ -1929,9 +1929,7 @@ def FixFileLines(iwyu_record, file_lines, flags):
   # For every move-span in our file -- that's every #include and
   # forward-declare we saw -- 'decorate' the move-range to allow us
   # to sort them.
-  seen = set()
-  move_spans = [fl.move_span for fl in file_lines if fl.move_span and not (fl.move_span in seen or seen.add(fl.move_span))]
-  decorated_move_spans = []
+  move_spans = OrderedSet([fl.move_span for fl in file_lines if fl.move_span])  decorated_move_spans = []
   for (start_line, end_line) in move_spans:
     decorated_span = _DecoratedMoveSpanLines(iwyu_record, file_lines,
                                              file_lines[start_line:end_line],
@@ -1967,7 +1965,7 @@ def FixFileLines(iwyu_record, file_lines, flags):
   if flags.reorder:
     decorated_move_spans.sort()
   else:
-     decorated_move_spans.sort(key=lambda x: x[0:-2])
+    decorated_move_spans.sort(key=lambda x: x[0:-2])
 
   # Now go through all the lines of the input file and construct the
   # output file.  Before we get to the next reorder-span, we just

--- a/fix_includes.py
+++ b/fix_includes.py
@@ -2172,11 +2172,8 @@ def main(argv):
   parser.add_option('--nosafe_headers', action='store_false',
                     dest='safe_headers')
 
-  # --reorder and --no-reorder share the same destination variable.  Omitting
-  # the default here would still produce the intended behavior, however if
-  # the code is re-organized such that these two specifications are swapped
-  # relative to each-other there will be a change in behavior.
-  parser.add_option('--reorder', default=False, action='store_true', dest='reorder',
+  # --reorder and --no-reorder share the same destination variable.
+  parser.add_option('--reorder', action='store_true', dest='reorder',
                     help=('Re-order lines relative to other similar lines '
                           '(eg, headers relative to other headers)'))
 

--- a/fix_includes_test.py
+++ b/fix_includes_test.py
@@ -3503,7 +3503,9 @@ namespace A { class AC; } // A
 // endif
 #endif
 """
-    self.RegisterFileContents({'test_reordering': infile})
+    self.RegisterFileContents({'inclusions_reordered.cc': infile})
+    self.RegisterFileContents({'inclusions_not_reordered.cc': infile})
+    
     self.flags.reorder = True
     num_files_modified = fix_includes.SortIncludesInFiles(['inclusions_reordered.cc'], self.flags)
     self.assertListEqual(expected_output_headers_reordered.strip().split('\n'), self.actual_after_contents)

--- a/fix_includes_test.py
+++ b/fix_includes_test.py
@@ -3503,16 +3503,16 @@ namespace A { class AC; } // A
 // endif
 #endif
 """
-    self.RegisterFileContents({'inclusions_reordered.cc': infile})
     self.RegisterFileContents({'inclusions_not_reordered.cc': infile})
-    
-    self.flags.reorder = True
-    num_files_modified = fix_includes.SortIncludesInFiles(['inclusions_reordered.cc'], self.flags)
-    self.assertListEqual(expected_output_headers_reordered.strip().split('\n'), self.actual_after_contents)
-    self.assertEqual(1, num_files_modified)
     self.flags.reorder = False
     num_files_modified = fix_includes.SortIncludesInFiles(['inclusions_not_reordered.cc'], self.flags)
     self.assertListEqual(expected_output_headers_not_reordered.strip().split('\n'), self.actual_after_contents)
+    self.assertEqual(1, num_files_modified)
+    
+    self.RegisterFileContents({'inclusions_reordered.cc': infile})
+    self.flags.reorder = True
+    num_files_modified = fix_includes.SortIncludesInFiles(['inclusions_reordered.cc'], self.flags)
+    self.assertListEqual(expected_output_headers_reordered.strip().split('\n'), self.actual_after_contents)
     self.assertEqual(1, num_files_modified)
 
 

--- a/fix_includes_test.py
+++ b/fix_includes_test.py
@@ -3505,11 +3505,11 @@ namespace A { class AC; } // A
 """
     self.RegisterFileContents({'test_reordering': infile})
     self.flags.reorder = True
-    num_files_modified = fix_includes.SortIncludesInFiles(['sort'], self.flags)
+    num_files_modified = fix_includes.SortIncludesInFiles(['inclusions_reordered.cc'], self.flags)
     self.assertListEqual(expected_output_headers_reordered.strip().split('\n'), self.actual_after_contents)
     self.assertEqual(1, num_files_modified)
     self.flags.reorder = False
-    num_files_modified = fix_includes.SortIncludesInFiles(['sort'], self.flags)
+    num_files_modified = fix_includes.SortIncludesInFiles(['inclusions_not_reordered.cc'], self.flags)
     self.assertListEqual(expected_output_headers_not_reordered.strip().split('\n'), self.actual_after_contents)
     self.assertEqual(1, num_files_modified)
 


### PR DESCRIPTION
Current default behavior is to re-order modified lines relative to lines of a similar type (all forward decls get sorted, all project headers get sorted, etc).

This commit makes two changes:

* Adds options to enable/disable line re-ordering
* Defaults to no re-ordering; to get the original behavior the user must specify --reorder