### PR TITLE
Enhance fix_includes.py to understand multi-level namespaces

### DIFF
--- a/fix_includes.py
+++ b/fix_includes.py
@@ -1407,12 +1407,14 @@ def _GetNamespaceLevelReorderSpans(file_lines):
       elif ifdef_depth != 0:
         continue # skip lines until we're outside of an ifdef block
 
-      # Build the simplified namespace lists and namespace depths.  When
-      # any new namespace is encountered, add the namespace to the list
-      # using the next line to cover namespaces without forward declares.
-      # When a forward declare is found, add the concatenated namespaces
-      # to the list.  Once a contentful line (None) has been found, add
-      # the final namespace if we're still inside one and stop searching.
+      # Build the simplified namespace dictionary.  When any new namespace is
+      # encountered, add the namespace to the list using the next line to cover
+      # namespaces without forward declarations.  When a forward declare is
+      # found, update the dictionary using the existing namespace span that the
+      # forward declare contains.  Once a contentful line (None) has been found
+      # or any exception occurs, return the results that have been found.  Any
+      # forward declare that wasn't able to have a proper namespace name found
+      # will still propigate to the top of the file.
       elif line_info.type == _NAMESPACE_START_RE:
         for namespace in _GetNamespaceNames(line_info.line):
           if not namespace:

--- a/fix_includes.py
+++ b/fix_includes.py
@@ -1880,21 +1880,22 @@ def _DecoratedMoveSpanLines(iwyu_record, file_lines, move_span_lines, flags):
   if reorder_span is None:     # must be a new #include we're adding
     # If we're a forward-declare inside a namespace, see if there's a
     # reorder span inside the same namespace we can fit into.
-    namespace_reorder_spans = _GetNamespaceLevelReorderSpans(file_lines)
-    for namespace_prefix, possible_reorder_span in namespace_reorder_spans:
-      if (namespace_prefix and possible_reorder_span and
-          firstline.line.startswith(namespace_prefix)):
-        # Great, we can go into this reorder_span.  We also need to
-        # modify all-lines because this line doesn't need the
-        # namespace prefix anymore.  Make sure we can do that before
-        # succeeding.
-        new_firstline = _RemoveNamespacePrefix(firstline.line, namespace_prefix)
-        if new_firstline:
-          assert all_lines[first_contentful_line] == firstline.line
-          all_lines[first_contentful_line] = new_firstline
-          sort_key = re.sub(r'\s+', '', new_firstline)
-          reorder_span = possible_reorder_span
-          break
+    if kind == _FORWARD_DECLARE_KIND:
+      namespace_reorder_spans = _GetNamespaceLevelReorderSpans(file_lines)
+      for namespace_prefix, possible_reorder_span in namespace_reorder_spans:
+        if (namespace_prefix and possible_reorder_span and
+            firstline.line.startswith(namespace_prefix)):
+          # Great, we can go into this reorder_span.  We also need to
+          # modify all-lines because this line doesn't need the
+          # namespace prefix anymore.  Make sure we can do that before
+          # succeeding.
+          new_firstline = _RemoveNamespacePrefix(firstline.line, namespace_prefix)
+          if new_firstline:
+            assert all_lines[first_contentful_line] == firstline.line
+            all_lines[first_contentful_line] = new_firstline
+            sort_key = re.sub(r'\s+', '', new_firstline)
+            reorder_span = possible_reorder_span
+            break
 
     # If that didn't work out, find a top-level reorder span to go into.
     if reorder_span is None:


### PR DESCRIPTION
The fix_includes.sh script has logic to append new forward declares at
the namespace level if possible.  This logic only tries on the first
namespace encountered, however, so projects with a lot of namespaces
require a lot of manual tidying up.  Add multi-level detection so nested
namespaces have includes automatically inserted without creating new
namespace blocks when it is possible to do so cleanly.  If any issues
are encountered when evaluating namespaces, new forward declares will
be added at the top level.  Ifdeffed code will also be ignored when
trying to evaluate namespaces as well.

Signed-off-by: Christian Venegas <cvenegas@esri.com>

@kimgr I've run IWYU on our codebase with these changes and the results
were very successful.  We have our entire codebase formatted with Allman
namespaces so it is very normalized.  I changed from Allman namespaces to
nonAllman and had the same success.  I also tried nonAllman with compact
namespaces.  This covers the cases of
```
// Allman
namespace ns
{
namspace ns1
{
} // namespace ns1
} // namespace ns

// NonAllman
namespace ns {
namspace ns1 {
} // namespace ns1
} // namespace ns
```