### PR TITLE
Use clang-format style namespace comments for fix_includes.py

### DIFF
--- a/fix_includes.py
+++ b/fix_includes.py
@@ -1863,11 +1863,11 @@ def _NormalizeNamespaceForwardDeclareLines(lines):
      namespace bar {
      class A;
      class B;
-     }  // namespace bar
+     } // namespace bar
      namespace bang {
      class C;
-     }  // namespace bang
-     }  // namespace foo
+     } // namespace bang
+     } // namespace foo
 
   Non-namespace lines are left alone.  Only adjacent namespace lines
   from the input are merged.
@@ -1891,7 +1891,7 @@ def _NormalizeNamespaceForwardDeclareLines(lines):
     differ_pos = _CommonPrefixLength(namespaces_in_line, current_namespaces)
     namespaces_to_close = reversed(current_namespaces[differ_pos:])
     namespaces_to_open = namespaces_in_line[differ_pos:]
-    retval.extend('}  // namespace %s' % ns for ns in namespaces_to_close)
+    retval.extend('} // namespace %s' % ns for ns in namespaces_to_close)
     retval.extend('namespace %s {' % ns for ns in namespaces_to_open)
     current_namespaces = namespaces_in_line
     # Now add the current line.  If we were a namespace line, it's the

--- a/fix_includes_test.py
+++ b/fix_includes_test.py
@@ -389,12 +389,12 @@ namespace service_alerts {
 class StaticServiceAlertStore;
 namespace trigger {                  ///-
 class Trigger;                       ///-
-}  // namespace trigger              ///-
+} // namespace trigger               ///-
 namespace ui {                       ///-
 class Alert;                         ///-
-}  // namespace ui                   ///-
-}  // namespace service_alerts
-}  // namespace maps_transit_realtime
+} // namespace ui                    ///-
+} // namespace service_alerts
+} // namespace maps_transit_realtime
 
 int main() { return 0; }
 """
@@ -425,13 +425,13 @@ class StaticServiceAlertStore;
 namespace trigger                    ///-
 {                                    ///-
 class Trigger;                       ///-
-}  // namespace trigger              ///-
+} // namespace trigger               ///-
 namespace ui                         ///-
 {                                    ///-
 class Alert;                         ///-
-}  // namespace ui                   ///-
-}  // namespace service_alerts
-}  // namespace maps_transit_realtime
+} // namespace ui                    ///-
+} // namespace service_alerts
+} // namespace maps_transit_realtime
 
 int main() { return 0; }
 """
@@ -460,13 +460,13 @@ class StaticServiceAlertStore;
 namespace service_alerts { namespace trigger    ///-
 {                                               ///-
 class Trigger;                                  ///-
-}  // namespace trigger                         ///-
+} // namespace trigger                          ///-
 namespace ui                                    ///-
 {                                               ///-
 class Alert;                                    ///-
-}  // namespace ui                              ///-
-}  // namespace service_alerts                  ///-
-}  // namespace maps_transit_realtime
+} // namespace ui                               ///-
+} // namespace service_alerts                   ///-
+} // namespace maps_transit_realtime
 
 int main() { return 0; }
 """
@@ -935,14 +935,14 @@ template<typename T> class Nest::NestedTplClass;  // lines 11-11
 
 ///+namespace Bar {
 ///+class Baz;
-///+}  // namespace Bar
+///+} // namespace Bar
 ///+
 using Bar::baz;
 
 namespace Foo { class Bang; }  ///-
 ///+namespace Foo {
 ///+class Bang;
-///+}  // namespace Foo
+///+} // namespace Foo
 
 int main() { return 0; }
 """
@@ -974,12 +974,12 @@ namespace Foo { class Bang; }  // lines 7-7
 ///+namespace ns3 {
 ///+class Bar;
 ///+template <typename T> class Bang;
-///+}  // namespace ns3
-///+}  // namespace ns2
+///+} // namespace ns3
+///+} // namespace ns2
 ///+namespace ns4 {
 ///+class Baz;
-///+}  // namespace ns4
-///+}  // namespace ns
+///+} // namespace ns4
+///+} // namespace ns
 ///+
 
 int main() { return 0; }
@@ -1022,7 +1022,7 @@ class NsFoo;
 ///+namespace ns3 {
 ///+class NsBang;
 ///+template <typename T> class NsBaz;
-///+}  // namespace ns3
+///+} // namespace ns3
 template <typename T> class NsBar;
 
 }
@@ -1071,7 +1071,7 @@ class NsFoo;
 ///+namespace ns3 {
 ///+class NsBang;
 ///+template <typename T> class NsBaz;
-///+}  // namespace ns3
+///+} // namespace ns3
 template <typename T> class NsBar;
 
 }
@@ -1111,8 +1111,8 @@ class Bar;
 ///+namespace ns2 {
 ///+class NsBang;
 ///+template <typename T> class NsBaz;
-///+}  // namespace ns2
-///+}  // namespace ns
+///+} // namespace ns2
+///+} // namespace ns
 template <typename T> class Baz;
 
 #ifdef THIS_IS_A_CONTENTFUL_LINE
@@ -1169,7 +1169,7 @@ namespace ns {
 ///+namespace ns3 {
 ///+class NsBang;
 ///+template <typename T> class NsBaz;
-///+}  // namespace ns3
+///+} // namespace ns3
 ///+
 int MyFunction() { }
 
@@ -1687,7 +1687,7 @@ class FileAClass;   // kept for file A, not for file B
 class FileBClass;   // kept for file B, not for file A   ///-
 ///+namespace foo {
 ///+template <typename Arg1> ClassTemplate;
-///+}  // namespace foo
+///+} // namespace foo
 ///+template <typename Arg1> ClassTemplate;
 """
     iwyu_output = """\
@@ -1750,7 +1750,7 @@ template <typename Arg2> ClassTemplate;
 class FileAClass;
 ///+namespace foo {
 ///+template <typename Arg1> ClassTemplate;
-///+}  // namespace foo
+///+} // namespace foo
 ///+template <typename Arg1> ClassTemplate;
 """
     iwyu_output = """\
@@ -2458,7 +2458,7 @@ namespace foo {
 // It will, unless we wrongly say the #define is a header-guard define.
 ///+namespace bar {
 ///+class Baz;
-///+}  // namespace bar
+///+} // namespace bar
 ///+
 #define NOT_A_HEADER_GUARD_LINE 1
 }
@@ -2604,7 +2604,7 @@ namespace A {            ///-
    namespace B {         ///-
      class Delete3;      ///-
    }                     ///-
-}  // namespace A        ///-
+} // namespace A         ///-
 
 int main() { return 0; }
 """
@@ -2663,10 +2663,10 @@ class FwdDecl;  // lines 7-7
 
 ///+namespace ns1 {
 ///+class ForwardDeclared;
-///+}  // namespace ns1
+///+} // namespace ns1
 ///+namespace ns2 {
 ///+class ForwardDeclared;
-///+}  // namespace ns2
+///+} // namespace ns2
 """
     iwyu_output = """\
 identical_names should add these lines:
@@ -3500,7 +3500,7 @@ The full include-list for barrier_includes.h:
 class Query;
 ///+namespace util {
 ///+class Status;
-///+}  // namespace util
+///+} // namespace util
 
 namespace structuredsearch {
 


### PR DESCRIPTION
The fix_includes.py script inserts namespace comments for any new
namespace inclusions.  These comments have two spaces in between
closing bracket like so:

```
namespace ns {
}  // namespace ns
```

Modify the inclusions to match clang-format style comments for new
namespace inclusions like so:

```
namespace ns {
} // namespace ns
```

Signed-off-by: Christian Venegas <cvenegas@esri.com>