### PR TITLE
Treat explicit instantiations as full uses

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -109,6 +109,7 @@
 #include "iwyu_location_util.h"
 #include "iwyu_output.h"
 #include "iwyu_path_util.h"
+#include "iwyu_use_flags.h"
 // This is needed for
 // preprocessor_info().PublicHeaderIntendsToProvide().  Somehow IWYU
 // removes it mistakenly.
@@ -1632,12 +1633,13 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
   // Checkers, that tell iwyu_output about uses of symbols.
   // We let, but don't require, subclasses to override these.
 
-  // The comment, if not nullptr, is extra text that is included along
-  // with the warning message that iwyu emits.
+  // The comment, if not nullptr, is extra text that is included along with
+  // the warning message that iwyu emits. The extra use flags is optional
+  // info that can be assigned to the use (see the UF_* constants)
   virtual void ReportDeclUse(SourceLocation used_loc,
                              const NamedDecl* used_decl,
-                             const char* comment = nullptr) {
-
+                             const char* comment = nullptr,
+                             UseFlags extra_use_flags = 0) {
     const NamedDecl* target_decl = used_decl;
 
     // Sometimes a shadow decl comes between us and the 'real' decl.
@@ -1649,12 +1651,14 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
     if (CanIgnoreDecl(target_decl))
       return;
 
+    const UseFlags use_flags =
+        ComputeUseFlags(current_ast_node()) | extra_use_flags;
+
     // Canonicalize the use location and report the use.
     used_loc = GetCanonicalUseLocation(used_loc, target_decl);
     const FileEntry* used_in = GetFileEntry(used_loc);
     preprocessor_info().FileInfoFor(used_in)->ReportFullSymbolUse(
-        used_loc, target_decl, ComputeUseFlags(current_ast_node()),
-        comment);
+        used_loc, target_decl, use_flags, comment);
 
     // Sometimes using a decl drags in a few other uses as well:
 
@@ -1672,8 +1676,7 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
         = GetUsingDeclarationOf(used_decl, 
               GetDeclContext(current_ast_node()))) {
       preprocessor_info().FileInfoFor(used_in)->ReportUsingDeclUse(
-          used_loc, using_decl, ComputeUseFlags(current_ast_node()),
-          "(for using decl)");
+          used_loc, using_decl, use_flags, "(for using decl)");
     }
 
     // For typedefs, the user of the type is sometimes the one
@@ -2910,19 +2913,20 @@ class InstantiatedTemplateVisitor
   // (if templates call other templates, we have to find the right
   // template).
   void ReportDeclUse(SourceLocation used_loc, const NamedDecl* decl,
-                     const char* comment = nullptr) override {
+                     const char* comment = nullptr,
+                     UseFlags extra_use_flags = 0) override {
     const SourceLocation actual_used_loc = GetLocOfTemplateThatProvides(decl);
     if (actual_used_loc.isValid()) {
       // If a template is responsible for this decl, then we don't add
       // it to the cache; the cache is only for decls that the
       // original caller is responsible for.
-      Base::ReportDeclUse(actual_used_loc, decl, comment);
+      Base::ReportDeclUse(actual_used_loc, decl, comment, extra_use_flags);
     } else {
       // Let all the currently active types and decls know about this
       // report, so they can update their cache entries.
       for (CacheStoringScope* storer : cache_storers_)
         storer->NoteReportedDecl(decl);
-      Base::ReportDeclUse(caller_loc(), decl, comment);
+      Base::ReportDeclUse(caller_loc(), decl, comment, extra_use_flags);
     }
   }
 

--- a/iwyu.cc
+++ b/iwyu.cc
@@ -3732,11 +3732,20 @@ class IwyuAstConsumer
   //    template <class T> struct Foo;
   //    template<> struct Foo<int> { ... };
   // we don't want iwyu to recommend removing the 'forward declare' of Foo.
+  //
+  // Additionally, this type of decl is also used to represent explicit template
+  // instantiations, in which case we want the full type, not only a forward
+  // declaration.
   bool VisitClassTemplateSpecializationDecl(
       clang::ClassTemplateSpecializationDecl* decl) {
     if (CanIgnoreCurrentASTNode())  return true;
     ClassTemplateDecl* specialized_decl = decl->getSpecializedTemplate();
-    ReportDeclForwardDeclareUse(CurrentLoc(), specialized_decl);
+
+    if (IsExplicitInstantiation(decl))
+      ReportDeclUse(CurrentLoc(), specialized_decl);
+    else
+      ReportDeclForwardDeclareUse(CurrentLoc(), specialized_decl);
+
     return Base::VisitClassTemplateSpecializationDecl(decl);
   }
 

--- a/iwyu.cc
+++ b/iwyu.cc
@@ -217,6 +217,7 @@ using clang::ValueDecl;
 using clang::VarDecl;
 using llvm::cast;
 using llvm::dyn_cast;
+using llvm::dyn_cast_or_null;
 using llvm::errs;
 using llvm::isa;
 using std::make_pair;
@@ -2832,7 +2833,8 @@ class InstantiatedTemplateVisitor
 
     // As in TraverseExpandedTemplateFunctionHelper, we ignore all AST nodes
     // that will be reported when we traverse the uninstantiated type.
-    if (const NamedDecl* type_decl_as_written = TypeToDeclAsWritten(type)) {
+    if (const NamedDecl* type_decl_as_written =
+            GetDefinitionAsWritten(TypeToDeclAsWritten(type))) {
       AstFlattenerVisitor nodeset_getter(compiler());
       nodes_to_ignore_ = nodeset_getter.GetNodesBelow(
           const_cast<NamedDecl*>(type_decl_as_written));
@@ -3111,7 +3113,49 @@ class InstantiatedTemplateVisitor
     // We attribute all uses in an instantiated template to the
     // template's caller.
     ReportTypeUse(caller_loc(), actual_type);
+
+    // Also report all previous explicit instantiations (declarations and
+    // definitions) as uses of the caller's location.
+    ReportExplicitInstantiations(actual_type);
+
     return Base::VisitSubstTemplateTypeParmType(type);
+  }
+
+  bool VisitTemplateSpecializationType(TemplateSpecializationType* type) {
+    if (CanIgnoreCurrentASTNode())
+      return true;
+
+    CHECK_(current_ast_node()->GetAs<TemplateSpecializationType>() == type)
+        << "The current node must be equal to the template spec. type";
+
+    // Report previous explicit instantiations here, only if the type is needed
+    // fully.
+    if (!CanForwardDeclareType(current_ast_node()))
+      ReportExplicitInstantiations(type);
+
+    return Base::VisitTemplateSpecializationType(type);
+  }
+
+  void ReportExplicitInstantiations(const Type* type) {
+    const auto* decl = dyn_cast_or_null<ClassTemplateSpecializationDecl>(
+        TypeToDeclAsWritten(type));
+
+    if (decl == nullptr)
+      return;
+
+    // Go through all previous redecls and filter out those that are not
+    // explicit template instantiations or already provided by the template.
+    for (const NamedDecl* redecl : decl->redecls()) {
+      if (!IsExplicitInstantiation(redecl) ||
+          !GlobalSourceManager()->isBeforeInTranslationUnit(
+              redecl->getLocation(), caller_loc()) ||
+          IsProvidedByTemplate(decl))
+        continue;
+
+      // Report the specific decl that points to the explicit instantiation
+      Base::ReportDeclUse(caller_loc(), redecl, "(for explicit instantiation)",
+                          UF_ExplicitInstantiation);
+    }
   }
 
   // If constructing an object, check the type we're constructing.

--- a/iwyu.cc
+++ b/iwyu.cc
@@ -3207,7 +3207,7 @@ class InstantiatedTemplateVisitor
          ast_node != caller_ast_node_; ast_node = ast_node->parent()) {
       if (preprocessor_info().PublicHeaderIntendsToProvide(
               GetFileEntry(ast_node->GetLocation()),
-              GetFileEntry(decl)))
+              GetFileEntry(decl->getLocation())))
         return ast_node->GetLocation();
     }
     return SourceLocation();   // an invalid source-loc
@@ -3219,8 +3219,10 @@ class InstantiatedTemplateVisitor
   bool IsProvidedByTemplate(const Type* type) const {
     type = RemoveSubstTemplateTypeParm(type);
     type = RemovePointersAndReferences(type);  // get down to the decl
-    if (const NamedDecl* decl = TypeToDeclAsWritten(type))
+    if (const NamedDecl* decl = TypeToDeclAsWritten(type)) {
+      decl = GetDefinitionAsWritten(decl);
       return GetLocOfTemplateThatProvides(decl).isValid();
+    }
     return true;   // we always provide non-decl types like int, etc.
   }
 

--- a/iwyu_ast_util.h
+++ b/iwyu_ast_util.h
@@ -594,6 +594,10 @@ bool IsDefaultNewOrDelete(const clang::FunctionDecl* decl,
 // Returns true if this decl is part of a friend decl.
 bool IsFriendDecl(const clang::Decl* decl);
 
+// Returns true if this decl is an explicit template instantiation declaration
+// or definition.
+bool IsExplicitInstantiation(const clang::Decl* decl);
+
 // Returns true if a named decl looks like a forward-declaration of a
 // class (rather than a definition, a friend declaration, or an 'in
 // place' declaration like 'struct Foo' in 'void MyFunc(struct Foo*);'

--- a/iwyu_output.h
+++ b/iwyu_output.h
@@ -50,6 +50,7 @@ class OneUse {
 
   OneUse(const clang::NamedDecl* decl,
          clang::SourceLocation use_loc,
+         clang::SourceLocation decl_loc,
          UseKind use_kind,
          UseFlags flags,
          const char* comment);

--- a/iwyu_use_flags.h
+++ b/iwyu_use_flags.h
@@ -16,9 +16,9 @@ namespace include_what_you_use {
 typedef unsigned UseFlags;
 
 const UseFlags UF_None = 0;
-const UseFlags UF_InCxxMethodBody = 1; // use is inside a C++ method body
-const UseFlags UF_FunctionDfn = 2;     // use is a function being defined
-
+const UseFlags UF_InCxxMethodBody = 1;       // use is inside a C++ method body
+const UseFlags UF_FunctionDfn = 2;           // use is a function being defined
+const UseFlags UF_ExplicitInstantiation = 4; // use targets an explicit instantiation
 }
 
 #endif

--- a/tests/cxx/explicit_instantiation-template.h
+++ b/tests/cxx/explicit_instantiation-template.h
@@ -1,0 +1,14 @@
+//===---- explicit_instantiation-template.h - test input file for iwyu ----===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_EXPLICIT_INSTANTIATION_TEMPLATE_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_EXPLICIT_INSTANTIATION_TEMPLATE_H_
+
+template<typename T> class Template {};
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_EXPLICIT_INSTANTIATION_TEMPLATE_H_

--- a/tests/cxx/explicit_instantiation-template_direct.h
+++ b/tests/cxx/explicit_instantiation-template_direct.h
@@ -1,0 +1,14 @@
+//===- explicit_instantiation-template_direct.h - test input file for iwyu ===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_EXPLICIT_INSTANTIATION_TEMPLATE_DIRECT_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_EXPLICIT_INSTANTIATION_TEMPLATE_DIRECT_H_
+
+#include "explicit_instantiation-template.h"
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_EXPLICIT_INSTANTIATION_TEMPLATE_DIRECT_H_

--- a/tests/cxx/explicit_instantiation.cc
+++ b/tests/cxx/explicit_instantiation.cc
@@ -1,0 +1,48 @@
+//===-------- explicit_instantiation.cc - test input file for iwyu --------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "explicit_instantiation-template_direct.h"
+
+// Test that all explicit instantiations variants of the base template
+// require the full type:
+
+// - Declaration and definition
+// IWYU: Template is...*explicit_instantiation-template.h
+extern template class Template<int>;
+// IWYU: Template is...*explicit_instantiation-template.h
+template class Template<int>;
+
+// - Only declaration
+// IWYU: Template is...*explicit_instantiation-template.h
+extern template class Template<short>;
+
+// - Only definition
+// IWYU: Template is...*explicit_instantiation-template.h
+template class Template<double>;
+
+
+// The explicit instantiation of a specialization only needs a declaration
+// of the base template
+// IWYU: Template needs a declaration
+template<> class Template<char> {};
+extern template class Template<char>;
+
+
+/**** IWYU_SUMMARY
+
+tests/cxx/explicit_instantiation.cc should add these lines:
+#include "explicit_instantiation-template.h"
+
+tests/cxx/explicit_instantiation.cc should remove these lines:
+- #include "explicit_instantiation-template_direct.h"  // lines XX-XX
+
+The full include-list for tests/cxx/explicit_instantiation.cc:
+#include "explicit_instantiation-template.h"  // for Template
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/explicit_instantiation2-template_helpers.h
+++ b/tests/cxx/explicit_instantiation2-template_helpers.h
@@ -37,4 +37,12 @@ class TemplateTemplateArgShortFwd {
   T<short>* t;
 };
 
+template <class T>
+class ProvidedTemplate {};
+
+template <class U = short, class T = ProvidedTemplate<U>>
+class TemplateAsDefaultFullProvided {
+  T t;
+};
+
 #endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_EXPLICIT_INSTANTIATION2_TEMPLATE_HELPERS_H_

--- a/tests/cxx/explicit_instantiation2-template_helpers.h
+++ b/tests/cxx/explicit_instantiation2-template_helpers.h
@@ -1,0 +1,40 @@
+//=== explicit_instantiation2-template_helpers.h - test input file for iwyu ==//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_EXPLICIT_INSTANTIATION2_TEMPLATE_HELPERS_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_EXPLICIT_INSTANTIATION2_TEMPLATE_HELPERS_H_
+
+template <class T>
+class Template;
+
+template <class T>
+class FullUseArg {
+  T t;
+};
+template <class T>
+class FwdDeclUseArg {
+  T* t;
+};
+template <class U = short, class T = Template<U>>
+class TemplateAsDefaultFull {
+  T t;
+};
+template <class U = short, class T = Template<U>>
+class TemplateAsDefaultFwd {
+  T* t;
+};
+template <template <class> class T>
+class TemplateTemplateArgShortFull {
+  T<short> t;
+};
+template <template <class> class T>
+class TemplateTemplateArgShortFwd {
+  T<short>* t;
+};
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_EXPLICIT_INSTANTIATION2_TEMPLATE_HELPERS_H_

--- a/tests/cxx/explicit_instantiation2-template_short.h
+++ b/tests/cxx/explicit_instantiation2-template_short.h
@@ -12,4 +12,6 @@
 
 extern template class Template<short>;
 
+extern template class ProvidedTemplate<short>;
+
 #endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_EXPLICIT_INSTANTIATION2_TEMPLATE_SHORT_H_

--- a/tests/cxx/explicit_instantiation2-template_short.h
+++ b/tests/cxx/explicit_instantiation2-template_short.h
@@ -1,0 +1,15 @@
+
+//===- explicit_instantiation2-template_short.h - test input file for iwyu ===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_EXPLICIT_INSTANTIATION2_TEMPLATE_SHORT_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_EXPLICIT_INSTANTIATION2_TEMPLATE_SHORT_H_
+
+extern template class Template<short>;
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_EXPLICIT_INSTANTIATION2_TEMPLATE_SHORT_H_

--- a/tests/cxx/explicit_instantiation2-template_short_direct.h
+++ b/tests/cxx/explicit_instantiation2-template_short_direct.h
@@ -1,0 +1,14 @@
+// explicit_instantiation2-template_short_direct.h - test input file for iwyu //
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_EXPLICIT_INSTANTIATION2_TEMPLATE_SHORT_DIRECT_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_EXPLICIT_INSTANTIATION2_TEMPLATE_SHORT_DIRECT_H_
+
+#include "explicit_instantiation2-template_short.h"
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_EXPLICIT_INSTANTIATION2-TEMPLATE_SHORT_DIRECT_H_

--- a/tests/cxx/explicit_instantiation2.cc
+++ b/tests/cxx/explicit_instantiation2.cc
@@ -1,0 +1,99 @@
+//===------- explicit_instantiation2.cc - test input file for iwyu --------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "explicit_instantiation-template_direct.h"
+#include "explicit_instantiation2-template_helpers.h"
+#include "explicit_instantiation2-template_short_direct.h"
+
+// These tests verify that a dependent explicit instantiation declaration is
+// always required when the main template is also needed, but not otherwise.
+//
+// Positive scenarios:
+// 1a/1b: Implicit instantiation before and after an explicit instantiation
+//        definition (2), as it affects the semantics.
+// 2: Explicit instantiation definition.
+// 3: Full use in a template, provided as an explicit parameter.
+// 4: Fwd-decl use in a template, provided as an explicit parameter.
+// 5: Full use in a template, provided as an default parameter.
+// 7: Full use in a template, provided as a template template parameter.
+// 8: Fwd-decl use in a template, provided as a template template parameter.
+//
+// Negative scenarios, where the dependent template specialization is not
+// required, or it does not provide an explicit instantiation:
+// 6: Fwd-decl use in a template, provided as a default parameter.
+// 9: Implicit instantiation of Template<int>
+// 10: Specialization of Template<T>
+
+
+// IWYU: Template is...*explicit_instantiation-template.h
+// IWYU: Template is...*template_short.h.*for explicit instantiation
+Template<short> t1a; // 1a
+
+// IWYU: Template is...*explicit_instantiation-template.h
+// IWYU: Template is...*template_short.h.*for explicit instantiation
+template class Template<short>;  // 2
+
+// IWYU: Template is...*explicit_instantiation-template.h
+// IWYU: Template is...*template_short.h.*for explicit instantiation
+Template<short> t1b; // 1b
+
+// IWYU: Template is...*explicit_instantiation-template.h
+// IWYU: Template is...*template_short.h.*for explicit instantiation
+FullUseArg<
+    // IWYU: Template needs a declaration...*
+    Template<short>>
+    // IWYU: Template is...*explicit_instantiation-template.h
+    t3; // 3
+
+// IWYU: Template is...*template_short.h.*for explicit instantiation
+FwdDeclUseArg<
+    // IWYU: Template needs a declaration...*
+    Template<short>>
+    t4; // 4
+
+// IWYU: Template is...*explicit_instantiation-template.h
+// IWYU: Template is...*template_short.h.*for explicit instantiation
+TemplateAsDefaultFull<> t5; // 5
+TemplateAsDefaultFwd<> t6; // 6
+
+// IWYU: Template is...*template_short.h.*for explicit instantiation
+TemplateTemplateArgShortFull<
+    // IWYU: Template is...*explicit_instantiation-template.h
+    Template>
+    t7; // 7
+
+TemplateTemplateArgShortFwd<
+    // IWYU: Template is...*explicit_instantiation-template.h
+    Template>
+    t8; // 8
+
+// IWYU: Template is...*explicit_instantiation-template.h
+Template<int> t9; // 9
+
+// IWYU: Template needs a declaration...*
+template <> class Template<char> {};
+
+TemplateAsDefaultFull<char> t10; // 10
+
+/**** IWYU_SUMMARY
+
+tests/cxx/explicit_instantiation2.cc should add these lines:
+#include "explicit_instantiation-template.h"
+#include "explicit_instantiation2-template_short.h"
+
+tests/cxx/explicit_instantiation2.cc should remove these lines:
+- #include "explicit_instantiation-template_direct.h"  // lines XX-XX
+- #include "explicit_instantiation2-template_short_direct.h"  // lines XX-XX
+
+The full include-list for tests/cxx/explicit_instantiation2.cc:
+#include "explicit_instantiation-template.h"  // for Template
+#include "explicit_instantiation2-template_helpers.h"  // for FullUseArg, FwdDeclUseArg, TemplateAsDefaultFull, TemplateAsDefaultFwd, TemplateTemplateArgShortFull, TemplateTemplateArgShortFwd
+#include "explicit_instantiation2-template_short.h"  // for Template
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/explicit_instantiation2.cc
+++ b/tests/cxx/explicit_instantiation2.cc
@@ -29,6 +29,8 @@
 // 6: Fwd-decl use in a template, provided as a default parameter.
 // 9: Implicit instantiation of Template<int>
 // 10: Specialization of Template<T>
+// 11: Explicit instantiation with a dependent instantiation declaration, but
+//     provided by the template helper itself.
 
 
 // IWYU: Template is...*explicit_instantiation-template.h
@@ -81,6 +83,8 @@ template <> class Template<char> {};
 
 TemplateAsDefaultFull<char> t10; // 10
 
+TemplateAsDefaultFullProvided<> t11; // 11
+
 /**** IWYU_SUMMARY
 
 tests/cxx/explicit_instantiation2.cc should add these lines:
@@ -93,7 +97,7 @@ tests/cxx/explicit_instantiation2.cc should remove these lines:
 
 The full include-list for tests/cxx/explicit_instantiation2.cc:
 #include "explicit_instantiation-template.h"  // for Template
-#include "explicit_instantiation2-template_helpers.h"  // for FullUseArg, FwdDeclUseArg, TemplateAsDefaultFull, TemplateAsDefaultFwd, TemplateTemplateArgShortFull, TemplateTemplateArgShortFwd
+#include "explicit_instantiation2-template_helpers.h"  // for FullUseArg, FwdDeclUseArg, TemplateAsDefaultFull, TemplateAsDefaultFullProvided, TemplateAsDefaultFwd, TemplateTemplateArgShortFull, TemplateTemplateArgShortFwd
 #include "explicit_instantiation2-template_short.h"  // for Template
 
 ***** IWYU_SUMMARY */


### PR DESCRIPTION
Modify IsFowardDecl() to check that the decl is not an explicit template instantiation (declaration or definition) This check is also in its own function, IsExplicitInstantiation(), for convenience.