### PR TITLE
Improvements for iwyu_tool.py on Windows

### DIFF
--- a/iwyu_tool.py
+++ b/iwyu_tool.py
@@ -100,6 +100,21 @@ else:
         return s
 
 
+def is_msvc_driver(compile_command):
+    """ Return True if compile_command matches an MSVC CL-style driver. """
+    compile_command = normcase(compile_command)
+
+    if compile_command.endswith('cl.exe'):
+        # Native MSVC compiler or clang-cl.exe
+        return True
+
+    if compile_command.endswith('clang-cl'):
+        # Cross clang-cl on non-Windows
+        return True
+
+    return False
+
+
 def is_subpath_of(path, parent):
     """ Return True if path is equal to or fully contained within parent.
 
@@ -189,8 +204,8 @@ class Invocation(object):
 
         # Rewrite the compile command for IWYU
         compile_command, compile_args = command[0], command[1:]
-        if compile_command.endswith('cl.exe'):
-            # If the compiler name is cl.exe, let IWYU be cl-compatible.
+        if is_msvc_driver(compile_command):
+            # If the compiler is cl-compatible, let IWYU be cl-compatible.
             extra_args = ['--driver-mode=cl'] + extra_args
 
         command = [IWYU_EXECUTABLE] + extra_args + compile_args


### PR DESCRIPTION
* Attempt to fix #583 with custom command-string splitting
* Fix #582 by improving selection filtering
* Improve MSVC CL-style driver detection to be case-insensitive and also recognizing `clang-cl`

I've had no opportunity to test this :-/ @jru, could you take it for a spin?