### PR TITLE
Enable incremental processing

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -3975,6 +3975,7 @@ class IwyuAction : public ASTFrontendAction {
     compiler.getPreprocessor().addPPCallbacks(
         std::unique_ptr<PPCallbacks>(preprocessor_consumer));
     compiler.getPreprocessor().addCommentHandler(preprocessor_consumer);
+    compiler.getPreprocessor().enableIncrementalProcessing();
 
     auto* const visitor_state
         = new VisitorState(&compiler, *preprocessor_consumer);


### PR DESCRIPTION
Fixes a panic building llvm/clang with clang 7 on Ubuntu 18.04

The issue is the Sema::TUScope is set to nullptr by
Sema::ActOnEndOfTranslationUnit unless incremental processing is enabled.

The file lib/TableGen/JSONBackend.cpp reduces to the testcase

template <int a> struct b { static constexpr int c = a; };
template <bool a> using d = b<a>;
template <bool, typename> struct aa;
template <typename...> struct e;
template <typename f, typename g> struct e<f, g> : aa<f::c, g>::h {};
template <typename i> i ab();
struct j {
  b<true> k;
};
template <typename> struct l : j { typedef decltype(k) h; };
template <typename i> struct m : e<d<!bool()>, l<i>> {};
template <typename i> struct n : m<i>::h {};
struct o {
  static b<false> p(...);
};
template <typename i> struct q : o { decltype(p(ab<i>())) h; };
template <typename i> struct r : e<n<i>, q<i>> {};
template <int> struct s;
template <bool, typename ac> struct aa { typedef ac h; };
class G;
struct H {
  template <typename t = G, typename u = int,
            typename s<e<r<t>, u>::c>::h = true>
  H();
};
class G {
  G(G &);
};
struct I {
  H ar;
};