### PR TITLE
Depend on clang-headers when built in-tree

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,13 @@ cmake_minimum_required(VERSION 3.4.3)
 
 if (CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
   message(STATUS "IWYU: out-of-tree configuration")
+  set(IWYU_IN_TREE OFF)
+else()
+  message(STATUS "IWYU: in-tree configuration")
+  set(IWYU_IN_TREE ON)
+endif()
 
+if (NOT IWYU_IN_TREE)
   cmake_policy(SET CMP0048 NEW)
   project(include-what-you-use)
 
@@ -12,8 +18,6 @@ if (CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
   list(APPEND CMAKE_MODULE_PATH ${LLVM_DIR})
   include(AddLLVM)
   include(HandleLLVMOptions)
-else()
-  message(STATUS "IWYU: in-tree configuration")
 endif()
 
 message(STATUS "IWYU: configuring for LLVM ${LLVM_VERSION}...")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,13 @@ add_llvm_executable(include-what-you-use
   iwyu_verrs.cc
   )
 
+if (IWYU_IN_TREE)
+  # Add a dependency on clang-headers to ensure the builtin headers are
+  # available when IWYU is executed from the build dir.
+  # The clang-headers target is only available in in-tree builds.
+  add_dependencies(include-what-you-use clang-headers)
+endif()
+
 if (MINGW)
   # Work around 'too many sections' error with MINGW/GCC
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wa,-mbig-obj")


### PR DESCRIPTION
Depends on PR #589.

As an initial refactor, this introduces a CMake variable for in-tree vs out-of-tree. I think this could be made cached, but I don't know enough CMake to make that happen in an idiomatic way. @pfaffe, do you know how to do that?