### PR TITLE
test case where --no_fwd_decls suggest deleting important fwd_decls

### DIFF
--- a/run_iwyu_tests.py
+++ b/run_iwyu_tests.py
@@ -85,6 +85,7 @@ class OneIwyuTest(unittest.TestCase):
       'prefix_header_includes_remove.cc': ['--prefix_header_includes=remove'],
       'prefix_header_operator_new.cc': ['--prefix_header_includes=remove'],
       'quoted_includes_first.cc': ['--pch_in_code', '--quoted_includes_first'],
++     'fwd_decl_without_full_use.cc': ['--no_fwd_decls'],
     }
     prefix_headers = [self.Include('prefix_header_includes-d1.h'),
                       self.Include('prefix_header_includes-d2.h'),
@@ -191,6 +192,7 @@ class OneIwyuTest(unittest.TestCase):
       'using_aliased_symbol_unused.cc': ['.'],
       'varargs_and_references.cc': ['.'],
       'virtual_tpl_method.cc': ['.'],
++     'fwd_decl_without_full_use.cc': ['.'],
     }
     # Internally, we like it when the paths start with rootdir.
     self._iwyu_flags_map = dict((posixpath.join(self.rootdir, k), v)

--- a/tests/cxx/fwd_decl_without_full_use.cc
+++ b/tests/cxx/fwd_decl_without_full_use.cc
@@ -1,0 +1,22 @@
+//===--- fwd_decl_without_full_use.cc - test input file for iwyu --------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// Tests a situation where iwyu tries to remove an important fwd-decl
+// when --no_fwd_decls is enabled.
+
+class Foo;
+
+void foo_fn(const Foo* foo) {}
+
+
+/**** IWYU_SUMMARY
+
+(tests/cxx/fwd_decl_without_full_use.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
With the test case I added currently I get this output:
```
tests/cxx/fwd_decl_without_full_use.cc should add these lines:

tests/cxx/fwd_decl_without_full_use.cc should remove these lines:
- class Foo;  // lines 16-16
```
Which is wrong because if I delete this line obviously it doesn't compile. I think the expected behavior of `--no_fwd_decls` would be to not suggest forward declarations. If a forward declaration is already there it should keep it that way.
