### PR TITLE
Failing test case when there's a full template use

### DIFF
--- a/run_iwyu_tests.py
+++ b/run_iwyu_tests.py
@@ -191,6 +191,7 @@ class OneIwyuTest(unittest.TestCase):
       'using_aliased_symbol_unused.cc': ['.'],
       'varargs_and_references.cc': ['.'],
       'virtual_tpl_method.cc': ['.'],
+      'template_use.cc': ['.'],
     }
     # Internally, we like it when the paths start with rootdir.
     self._iwyu_flags_map = dict((posixpath.join(self.rootdir, k), v)

--- a/tests/cxx/template_use.cc
+++ b/tests/cxx/template_use.cc
@@ -1,0 +1,24 @@
+//===--- template_use.cc - test input file for iwyu ------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// This test is here because IWYU may incorrectly suggest to delete
+// this include.
+
+#include "template_use.h"
+
+class Bar{
+    Foo<int> foo;
+};
+
+
+
+
+/**** IWYU_SUMMARY
+(tests/cxx/template_use.cc has correct #includes/fwd-decls)
+***** IWYU_SUMMARY */

--- a/tests/cxx/template_use.h
+++ b/tests/cxx/template_use.h
@@ -1,0 +1,10 @@
+//===--- template_use.h - test input file for iwyu ----------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+template<typename T> class Foo { };


### PR DESCRIPTION
IWYU currently suggests to remove the include line even though this is a full use.