### PR TITLE
When include-what-you-use if found, return the real path

### DIFF
--- a/iwyu_tool.py
+++ b/iwyu_tool.py
@@ -108,7 +108,7 @@ def find_include_what_you_use():
     for dirpath in search_path:
         full = os.path.join(dirpath, executable_name)
         if os.path.isfile(full):
-            return full
+            return os.path.realpath(full)
 
     return None
 


### PR DESCRIPTION
If iwyu_tool.py is call by a relative path, include-what-you-use will
also be called with a static, relative path. Which breaks once the
cwd changes.  So force the tool path to be absolute.