### PR TITLE
Fix iwyu tool for non posix systems

### DIFF
--- a/iwyu_tool.py
+++ b/iwyu_tool.py
@@ -169,7 +169,7 @@ class Invocation(object):
             command = entry['arguments']
         elif 'command' in entry:
             # command is a command-line in string form, split to list.
-            command = shlex.split(entry['command'])
+            command = shlex.split(entry['command'], posix=not sys.platform.startswith('win'))
         else:
             raise ValueError('Invalid compilation database entry: %s' % entry)
 

--- a/iwyu_tool_test.py
+++ b/iwyu_tool_test.py
@@ -9,6 +9,8 @@
 #
 ##===----------------------------------------------------------------------===##
 
+import os
+import sys
 import time
 import random
 import unittest
@@ -101,7 +103,22 @@ class IWYUToolTests(IWYUToolTestBase):
         self._execute(invocations, jobs=1)
         self.assertEqual(['BAR%d' % n for n in range(100)],
                          self.stdout_stub.getvalue().splitlines())
-
+    def test_from_compile_command_splitting_adequately_the_command(self):
+        iwyu_args = []
+        invocation = iwyu_tool.Invocation.from_compile_command(
+            {
+                'directory': '/home/user/llvm/build',
+                'command': '/usr/bin/clang++ -I{} file.cc'.format(os.path.join('include', 'a', 'directory', 'using', 'os', 'separators')),
+                'file': 'file.cc'
+            }, iwyu_args)
+        if sys.platform.startswith('win'):
+            self.assertEqual(
+                invocation.command,
+                [iwyu_tool.IWYU_EXECUTABLE, '-Iinclude\\a\\directory\\using\\os\\separators', 'file.cc'])
+        else:
+            self.assertEqual(
+                invocation.command,
+                [iwyu_tool.IWYU_EXECUTABLE, '-Iinclude/a/directory/using/os/separators', 'file.cc'])            
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
# What?
When dealing with non-posix systems, iwyu_tool run from a compilation commands database handles incorrectly the paths that can appear in the commands (Typically, the -I followed by corresponding paths). This is because of an inaccurate shlex.split call. 

**Issue**: iwyu_tool.py does not work on Windows #583

# Details
When splitting the command from a compile command database, specification on posix or non-posix standard is needed to avoid incorrect parsing on non posix based OS. When running on Windows, a command with complex includes
```
clang -Iinclude\\a\\directory\\using\\os\\separators file.cc
``` 
may be composed by something like
```
[iwyu_tool.IWYU_EXECUTABLE, '-Iincludeadirectoryusingosseparators', 'file.cc']
```
instead of
```
[iwyu_tool.IWYU_EXECUTABLE, ' -Iinclude\\a\\directory\\using\\os\\separators', 'file.cc']
```
As a result, iwyu_tool when running on Windows fails because these paths do not exist.
# Fix
If specifying the non-posix flag to shlex.split, the commands are adequately splitted both in windows and linux/Mac