### PR TITLE
Adding iwyu_tool tests to the CI process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,4 +35,4 @@ script:
  - cd ..
  - python run_iwyu_tests.py -- build/bin/include-what-you-use
  - python fix_includes_test.py
-
+ - python iwyu_tool_test.py


### PR DESCRIPTION
# What? 

While there are some unit tests for the very useful iwyu compilation database driver (iwyu_tool), CI does not checks them. 

I'd like to propose to add these tests into the CI process. An issue proposing this change has been also reported to check if community considers this required as well (#611)