### PR TITLE
Nested wrapper header support

### DIFF
--- a/iwyu_output.cc
+++ b/iwyu_output.cc
@@ -754,8 +754,10 @@ set<string> CalculateMinimalIncludes(
     // this is a file that the use-file is re-exporting symbols for,
     // and we should keep the #include as-is.
     const string use_file = ConvertToQuotedInclude(GetFilePath(use.use_loc()));
-    if (use.PublicHeadersContain(use_file)) {
-      use.set_suggested_header(ConvertToQuotedInclude(use.decl_filepath()));
+    const string decl_file = ConvertToQuotedInclude(use.decl_filepath());
+    if (use.PublicHeadersContain(use_file) &&
+        ContainsKey(direct_includes, decl_file)) {
+      use.set_suggested_header(decl_file);
       desired_headers.insert(use.suggested_header());
       LogIncludeMapping("private header", use);
     } else if (use.public_headers().size() == 1) {

--- a/run_iwyu_tests.py
+++ b/run_iwyu_tests.py
@@ -137,6 +137,7 @@ class OneIwyuTest(unittest.TestCase):
       'double_include.cc': ['.'],
       'elaborated_struct.c': ['.'],
       'elaborated_type.cc': ['.'],
+      'export_nesting.cc': ['.'],
       'external_including_internal.cc': ['.'],
       'forward_declare_in_macro.cc': ['.'],
       'fullinfo_for_templates.cc': ['.'],

--- a/tests/cxx/export_nesting-d1.h
+++ b/tests/cxx/export_nesting-d1.h
@@ -1,0 +1,15 @@
+//===--- export_nesting-d1.h - test input file for iwyu -------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_EXPORT_NESTING_D1_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_EXPORT_NESTING_D1_H_
+
+#include "tests/cxx/export_nesting-i1.h" // IWYU pragma: export
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_EXPORT_NESTING_D1_H_

--- a/tests/cxx/export_nesting-i1.h
+++ b/tests/cxx/export_nesting-i1.h
@@ -1,0 +1,15 @@
+//===--- export_nesting-i1.h - test input file for iwyu -------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_EXPORT_NESTING_I1_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_EXPORT_NESTING_I1_H_
+
+enum Nested_Enum {};
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_EXPORT_NESTING_I1_H_

--- a/tests/cxx/export_nesting.cc
+++ b/tests/cxx/export_nesting.cc
@@ -1,0 +1,18 @@
+//===--- export_nesting.cc - test input file for iwyu ---------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/export_nesting.h"
+
+Nested_Enum x;
+
+/**** IWYU_SUMMARY
+
+(tests/cxx/export_nesting.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/export_nesting.h
+++ b/tests/cxx/export_nesting.h
@@ -1,0 +1,26 @@
+//===--- export_nesting.h - test input file for iwyu ----------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_EXPORT_NESTING_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_EXPORT_NESTING_H_
+
+// We export a header which already re-exports things to verify that nested
+// exports are acceptable.
+
+#include "tests/cxx/export_nesting-d1.h" // IWYU pragma: export
+
+Nested_Enum f;
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_EXPORT_NESTING_H_
+
+/**** IWYU_SUMMARY
+
+(tests/cxx/export_nesting.h has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
I ran into a problem attempting to use IWYU on a project with the following pattern:

* a 3rd-party library private header, included by
* a 3rd party library public header, included by
* a local project header intended to be the only way to include headers from that 3rd party library (and which also uses symbols from that library), included by
* a local project source file.

The existing special case code for handling private headers forces the last header to include the first one, even when a mapping exists from the first to the second.

This PR fixes that, by tweaking the logic so that we will retain private includes when they exist, but not necessarily add them whenever we are a potential public header for them.

The test I've added piggy-backs on an existing test to take advantage of its mapping file.  Let me know if that's inappropriate and I should make this test independent of existing test files.