### PR TITLE
A POC on how to refactor fix_includes_test.py into pytests

### DIFF
--- a/pytests/__init__.py
+++ b/pytests/__init__.py
@@ -1,0 +1,6 @@
+#
+#                     The LLVM Compiler Infrastructure
+#
+# This file is distributed under the University of Illinois Open Source
+# License. See LICENSE.TXT for details.
+#

--- a/pytests/harness.py
+++ b/pytests/harness.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+#
+#                     The LLVM Compiler Infrastructure
+#
+# This file is distributed under the University of Illinois Open Source
+# License. See LICENSE.TXT for details.
+#
+import difflib
+import pytest
+import os
+import shutil
+import subprocess
+import tempfile
+
+def simple_run(name):
+    here = os.path.dirname(os.path.realpath(__file__))
+    test_file = name
+    test_path = here + os.sep + test_file
+    input =  test_path + '.input'
+    iwyu = test_path + '.iwyu'
+    diff = test_path + '.diff'
+    fix_includes = here + os.sep + '..' + os.sep + 'fix_includes.py'
+
+    shutil.copyfile(input, test_path)
+    fix_includes_input = open(iwyu)
+    tout = tempfile.TemporaryFile();
+    terr = tempfile.TemporaryFile();
+    o = subprocess.call([fix_includes], stdin=fix_includes_input, stdout=tout, stderr=terr)
+    f = open(input)
+    a = f.read().splitlines()
+    f.close()
+    f = open(test_path)
+    b = f.read().splitlines()
+    f.close()
+    f = open(diff)
+    e = f.read().splitlines()
+    f.close()
+
+    #d = ""
+    ud = difflib.unified_diff(a, b, fromfile=test_file + '.input', tofile=test_file)
+    for dd in ud:
+        dd = dd.strip()
+        # d = d + dd  + '\n'
+
+    #print d
+
+    os.remove(test_path)
+
+    assert(all([i == j for i, j in zip(ud, e)]))

--- a/pytests/simple.c.diff
+++ b/pytests/simple.c.diff
@@ -1,0 +1,15 @@
+--- simple.c.input
++++ simple.c
+@@ -1,8 +1,10 @@
+// Copyright 2010
+
+-#include <notused.h>  ///-
++#include <stdio.h>
++
+///+#include <stdio.h>
+#include "used.h"
++#include "used2.h"
+///+#include "used2.h"
+
+int main() { return 0; }
+

--- a/pytests/simple.c.input
+++ b/pytests/simple.c.input
@@ -1,0 +1,8 @@
+// Copyright 2010
+            
+#include <notused.h>  ///-
+///+#include <stdio.h>
+#include "used.h"
+///+#include "used2.h"
+
+int main() { return 0; }

--- a/pytests/simple.c.iwyu
+++ b/pytests/simple.c.iwyu
@@ -1,0 +1,12 @@
+simple.c should add these lines:
+#include <stdio.h>
+#include "used2.h"
+
+simple.c should remove these lines:
+- #include <notused.h>  // lines 3-3
+
+The full include-list for simple.c:
+#include <stdio.h>
+#include "used.h"
+#include "used2.h"
+---

--- a/pytests/test_simple.py
+++ b/pytests/test_simple.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+#
+#                     The LLVM Compiler Infrastructure
+#
+# This file is distributed under the University of Illinois Open Source
+# License. See LICENSE.TXT for details.
+#
+import difflib
+import pytest
+import os
+import shutil
+import subprocess
+import tempfile
+
+here = os.path.dirname(os.path.realpath(__file__))
+test_file = 'simple.c'
+test_path = here + os.sep + test_file
+input =  test_path + '.input'
+iwyu = test_path + '.iwyu'
+diff = test_path + '.diff'
+fix_includes = here + os.sep + '..' + os.sep + 'fix_includes.py'
+def test_simple():
+    shutil.copyfile(input, test_path)
+    fix_includes_input = open(iwyu)
+    tout = tempfile.TemporaryFile();
+    terr = tempfile.TemporaryFile();
+    o = subprocess.call([fix_includes], stdin=fix_includes_input, stdout=tout, stderr=terr)
+    f = open(input)
+    a = f.read().splitlines()
+    f.close()
+    f = open(test_path)
+    b = f.read().splitlines()
+    f.close()
+    f = open(diff)
+    e = f.read().splitlines()
+    f.close()
+
+    #d = ""
+    ud = difflib.unified_diff(a, b, fromfile=test_file + '.input', tofile=test_file)
+    for dd in ud:
+        dd = dd.strip()
+        # d = d + dd  + '\n'
+
+    #print d
+
+    os.remove(test_path)
+
+    assert(all([i == j for i, j in zip(ud, e)]))
+    
+test_simple()

--- a/pytests/test_simple_2.py
+++ b/pytests/test_simple_2.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+#
+#                     The LLVM Compiler Infrastructure
+#
+# This file is distributed under the University of Illinois Open Source
+# License. See LICENSE.TXT for details.
+#
+import harness
+
+def test_simple_harness():
+    harness.simple_run('simple.c')
+
+test_simple_harness()


### PR DESCRIPTION
A followup on how to refactor the python test setup to pytest.
https://docs.pytest.org/en/latest/

Input files are <the-source>.input,  this is the starting file that will change.
Test copies input to <the-source>
Then runs fix_includes.py <  <the-source>.iwyu
Then generates a diff of the input with the fixed.
The test passes if the diff agrees with a golden copy <the-source>.diff

test_simple.py is the rough hack poc.
The common bits of test_simple.py were exported to harness.py's simple_run function
test_simple_2.py uses the harness to do what test_simple.py did by calling simple_run

Having files as input will make adding tests easier and  allow greater flexibility on the encodings 

To run, run py.test in the pytests dir.
