### PR TITLE
Define and use UF_Macro to determine when a use is a macro

### DIFF
--- a/iwyu_output.cc
+++ b/iwyu_output.cc
@@ -255,7 +255,8 @@ OneUse::OneUse(const NamedDecl* decl, SourceLocation use_loc,
 
 // This constructor always creates a full use.
 OneUse::OneUse(const string& symbol_name, const FileEntry* dfn_file,
-               const string& dfn_filepath, SourceLocation use_loc)
+               const string& dfn_filepath, SourceLocation use_loc,
+	       UseFlags use_flags)
     : symbol_name_(symbol_name),
       short_symbol_name_(symbol_name),
       decl_(nullptr),
@@ -263,7 +264,7 @@ OneUse::OneUse(const string& symbol_name, const FileEntry* dfn_file,
       decl_filepath_(dfn_filepath),
       use_loc_(use_loc),
       use_kind_(kFullUse),
-      use_flags_(UF_None),
+      use_flags_(use_flags),
       ignore_use_(false),
       is_iwyu_violation_(false) {
   // Sometimes dfn_filepath is actually a fully quoted include.  In
@@ -601,7 +602,7 @@ void IwyuFileInfo::ReportMacroUse(clang::SourceLocation use_loc,
                                   clang::SourceLocation dfn_loc,
                                   const string& symbol) {
   symbol_uses_.push_back(OneUse(symbol, GetFileEntry(dfn_loc),
-                                GetFilePath(dfn_loc), use_loc));
+                                GetFilePath(dfn_loc), use_loc, UF_Macro));
   LogSymbolUse("Marked full-info use of macro", symbol_uses_.back());
 }
 

--- a/iwyu_output.h
+++ b/iwyu_output.h
@@ -61,7 +61,8 @@ class OneUse {
   OneUse(const string& symbol_name,
          const clang::FileEntry* dfn_file,
          const string& dfn_filepath,
-         clang::SourceLocation use_loc);
+         clang::SourceLocation use_loc,
+	 UseFlags use_flags = UF_None);
 
   const string& symbol_name() const { return symbol_name_; }
   const string& short_symbol_name() const { return short_symbol_name_; }
@@ -73,6 +74,7 @@ class OneUse {
   bool is_full_use() const { return use_kind_ == kFullUse; }
   bool in_cxx_method_body() const { return (use_flags_ & UF_InCxxMethodBody); }
   bool is_function_being_defined() const { return (use_flags_ & UF_FunctionDfn); }
+  bool is_macro() const { return (use_flags_ & UF_Macro); }
   const string& comment() const { return comment_; }
   bool ignore_use() const { return ignore_use_; }
   bool is_iwyu_violation() const { return is_iwyu_violation_; }

--- a/iwyu_use_flags.h
+++ b/iwyu_use_flags.h
@@ -18,6 +18,7 @@ typedef unsigned UseFlags;
 const UseFlags UF_None = 0;
 const UseFlags UF_InCxxMethodBody = 1; // use is inside a C++ method body
 const UseFlags UF_FunctionDfn = 2;     // use is a function being defined
+const UseFlags UF_Macro = 4;           // use is a macro
 
 }
 


### PR DESCRIPTION
Added this in another development effort to track which uses were macros.
Turned out that it wasn't needed for that effort.
However it may be useful in the future so I am posting it.