### PR TITLE
Inherit the symbol uses of included files

### DIFF
--- a/tests/c/symbol_uses.c
+++ b/tests/c/symbol_uses.c
@@ -1,0 +1,22 @@
+//===--- symbol_uses.c - test input file for iwyu -------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// Tests if macro used in a header has it's defining header included
+#include "symbol_uses_b.h"
+#include "symbol_uses_a.h"
+
+void t() {
+	int a = A;
+}
+
+/**** IWYU_SUMMARY
+
+(tests/c/symbol_uses.c has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/c/symbol_uses_a.h
+++ b/tests/c/symbol_uses_a.h
@@ -1,0 +1,10 @@
+//===--- symbol_uses_a.h - test input file for iwyu -----------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+static inline int foo(int a) { return a + B; }
+#define A 1

--- a/tests/c/symbol_uses_b.h
+++ b/tests/c/symbol_uses_b.h
@@ -1,0 +1,9 @@
+//===--- symbol_uses_b.h - test input file for iwyu -----------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+#define B 10


### PR DESCRIPTION
See the posted test.
iwyu fails to include another includes dependencies.

There are two problems.
1. uses are ignored if they don't happen in the main files.
2. adding an include to the main file does not also add the include files dependencies.

This change fixes these problem but break many of the regression tests.
Which isn't surprising because removing includes has become more restrictive.

I believe this would be solved in a cleaner fashion if iwyu did multiple runs overs the source and modified source until a stable, compilable version was heuristically settled on.   This is a big job so it was not what i used.  If there is an interest, i'll give a try.
