### PR TITLE
[iwyu_tool] Case-insensitive path match on Windows

### DIFF
--- a/iwyu_tool.py
+++ b/iwyu_tool.py
@@ -89,6 +89,37 @@ FORMATTERS = {
 }
 
 
+if sys.platform.startswith('win'):
+    # Case-insensitive match on Windows
+    def normcase(s):
+        return s.lower()
+else:
+    def normcase(s):
+        return s
+
+
+def is_subpath_of(path, parent):
+    """ Return True if path is equal to or fully contained within parent.
+
+    Assumes both paths are canonicalized with os.path.realpath.
+    """
+    parent = normcase(parent)
+    path = normcase(path)
+
+    if path == parent:
+        return True
+
+    if not path.startswith(parent):
+        return False
+
+    # Now we know parent is a prefix of path, but they only share lineage if the
+    # difference between them starts with a path separator, e.g. /a/b/c/file
+    # is not a parent of /a/b/c/file.cpp, but /a/b/c and /a/b/c/ are.
+    parent = parent.rstrip(os.path.sep)
+    suffix = path[len(parent):]
+    return suffix.startswith(os.path.sep)
+
+
 def find_include_what_you_use():
     """ Find IWYU executable and return its full pathname. """
     if 'IWYU_BINARY' in os.environ:
@@ -220,12 +251,12 @@ def slice_compilation_db(compilation_db, selection):
             print('WARNING: \'%s\' not found on disk.' % path)
             continue
 
-        matches = [e for e in compilation_db if e['file'].startswith(path)]
-        if not matches:
+        found = [e for e in compilation_db if is_subpath_of(e['file'], path)]
+        if not found:
             print('WARNING: \'%s\' not found in compilation database.' % path)
             continue
 
-        new_db.extend(matches)
+        new_db.extend(found)
 
     return new_db
 

--- a/iwyu_tool_test.py
+++ b/iwyu_tool_test.py
@@ -8,7 +8,7 @@
 # License. See LICENSE.TXT for details.
 #
 ##===----------------------------------------------------------------------===##
-
+import sys
 import time
 import random
 import unittest
@@ -101,6 +101,26 @@ class IWYUToolTests(unittest.TestCase):
         self._execute(invocations, jobs=1)
         self.assertEqual(['BAR%d' % n for n in range(100)],
                          self.stdout_stub.getvalue().splitlines())
+
+    @unittest.skipIf(sys.platform.startswith('win'), "POSIX only")
+    def test_is_subpath_of_posix(self):
+        self.assertTrue(iwyu_tool.is_subpath_of('/a/b/c.c', '/a/b'))
+        self.assertTrue(iwyu_tool.is_subpath_of('/a/b/c.c', '/a/b/'))
+        self.assertTrue(iwyu_tool.is_subpath_of('/a/b/c.c', '/a/b/c.c'))
+        self.assertFalse(iwyu_tool.is_subpath_of('/a/b/c.c', '/a/b/c'))
+        self.assertFalse(iwyu_tool.is_subpath_of('/a/b/c.c', '/a/x'))
+        # No case-insensitive match.
+        self.assertFalse(iwyu_tool.is_subpath_of('/A/Bee/C.c', '/a/BEE'))
+
+    @unittest.skipIf(not sys.platform.startswith('win'), "Windows only")
+    def test_is_subpath_of_windows(self):
+        self.assertTrue(iwyu_tool.is_subpath_of('\\a\\b\\c.c', '\\a\\b'))
+        self.assertTrue(iwyu_tool.is_subpath_of('\\a\\b\\c.c', '\\a\\b\\'))
+        self.assertTrue(iwyu_tool.is_subpath_of('\\a\\b\\c.c', '\\a\\b\\c.c'))
+        self.assertFalse(iwyu_tool.is_subpath_of('\\a\\b\\c.c', '\\a\\b\\c'))
+        self.assertFalse(iwyu_tool.is_subpath_of('\\a\\b\\c.c', '\\a\\x'))
+        # Case-insensitive match.
+        self.assertTrue(iwyu_tool.is_subpath_of('C:\\Bee\\C.c', 'c:\\BEE'))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
User-provided paths are now matched case-insensitively.

Also fix a bug where /a/b/partial would match partial filenames. The new
implementation is stricter and only matches proper directory prefixes or
the full path name.

Add tests.

Closes bug #582.