### PR TITLE
Track use of namespace in using directive decl

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -212,6 +212,7 @@ using clang::TypedefNameDecl;
 using clang::TypedefType;
 using clang::UnaryExprOrTypeTraitExpr;
 using clang::UsingDecl;
+using clang::UsingDirectiveDecl;
 using clang::UsingShadowDecl;
 using clang::ValueDecl;
 using clang::VarDecl;
@@ -3797,6 +3798,20 @@ class IwyuAstConsumer
       ReportDeclForwardDeclareUse(CurrentLoc(), specialized_decl);
 
     return Base::VisitClassTemplateSpecializationDecl(decl);
+  }
+
+  // Track use of namespace in using directive decl
+  // a.h:
+  //   namespace a { ... };
+  //
+  // b.cpp:
+  //   include "a.h"
+  //   using namespace a;
+  //   ...
+  bool VisitUsingDirectiveDecl(clang::UsingDirectiveDecl *decl) {
+    if (CanIgnoreCurrentASTNode())  return true;
+    ReportDeclUse(CurrentLoc(), decl->getNominatedNamespaceAsWritten());
+    return Base::VisitUsingDirectiveDecl(decl);
   }
 
   // If you say 'typedef Foo Bar', then clients can use Bar however

--- a/tests/cxx/badinc.cc
+++ b/tests/cxx/badinc.cc
@@ -136,6 +136,7 @@ int i1_macro_symbol_with_value_and_value2_var2;
 // re-opened in many different files.  So let this go, even though all
 // uses of this namespace are in badinc-i1.h; we'll get the iwyu
 // violation later when we try to use symbols from i1_ns2.
+// IWYU: i1_ns2 is defined in...*which isn't directly #included.
 using namespace i1_ns2;
 using i1_ns3::i1_int_global3;
 // IWYU: i1_ns4 is...*badinc-i1.h
@@ -147,6 +148,7 @@ using i1_ns::I1_NamespaceTemplateFn;
 // IWYU: i1_ns::I1_UnusedNamespaceStruct needs a declaration
 using i1_ns::I1_UnusedNamespaceStruct;
 // TODO(csilvers): mark this using statement as redundant and remove it.
+// IWYU: i1_ns5 is defined in...*which isn't directly #included.
 using namespace i1_ns5;
 
 // We do some proper forward-declaring here, and also some unnecessary
@@ -1953,7 +1955,7 @@ The full include-list for tests/cxx/badinc.cc:
 #include <typeinfo>  // for type_info
 #include "tests/cxx/badinc-d1.h"  // for D11, D1CopyClassFn, D1Function, D1_Class, D1_CopyClass, D1_Enum, D1_I1_Typedef, D1_StructPtr, D1_Subclass, D1_TemplateClass, D1_TemplateStructWithDefaultParam, MACRO_CALLING_I4_FUNCTION
 #include "tests/cxx/badinc-d4.h"  // for D4_ClassForOperator, operator<<
-#include "tests/cxx/badinc-i1.h"  // for EmptyDestructorClass, H_Class::H_Class_DefinedInI1, I11, I12, I13, I1_And_I2_OverloadedFunction, I1_Base, I1_Class, I1_Class::NestedStruct, I1_ClassPtr, I1_Enum, I1_Function, I1_FunctionPtr, I1_I2_Class_Typedef, I1_MACRO_LOGGING_CLASS, I1_MACRO_SYMBOL_WITHOUT_VALUE, I1_MACRO_SYMBOL_WITH_VALUE, I1_MACRO_SYMBOL_WITH_VALUE0, I1_MACRO_SYMBOL_WITH_VALUE2, I1_ManyPtrStruct (ptr only), I1_MemberPtr, I1_NamespaceClass, I1_NamespaceStruct, I1_NamespaceTemplateFn, I1_OverloadedFunction, I1_PtrAndUseOnSameLine, I1_PtrDereferenceClass, I1_PtrDereferenceStatic, I1_PtrDereferenceStruct, I1_SiblingClass, I1_StaticMethod, I1_Struct, I1_Subclass, I1_SubclassesI2Class, I1_TemplateClass, I1_TemplateClass<>::I1_TemplateClass_int, I1_TemplateClassFwdDeclaredInD2 (ptr only), I1_TemplateFunction, I1_TemplateMethodOnlyClass, I1_TemplateSubclass, I1_Typedef, I1_TypedefOnly_Class, I1_TypedefOnly_Class<>::i, I1_Union, I1_UnnamedStruct, I1_UnusedNamespaceStruct (ptr only), I1_const_ptr, I2_OperatorDefinedInI1Class::operator<<, MACRO_CALLING_I6_FUNCTION, OperateOn, i1_GlobalFunction, i1_i1_classptr, i1_int, i1_int_global, i1_int_global2, i1_int_global2sub, i1_int_global3, i1_int_global3sub, i1_int_global4, i1_int_global4sub, i1_int_globalsub, i1_ns4, kI1ConstInt, operator==
+#include "tests/cxx/badinc-i1.h"  // for EmptyDestructorClass, H_Class::H_Class_DefinedInI1, I11, I12, I13, I1_And_I2_OverloadedFunction, I1_Base, I1_Class, I1_Class::NestedStruct, I1_ClassPtr, I1_Enum, I1_Function, I1_FunctionPtr, I1_I2_Class_Typedef, I1_MACRO_LOGGING_CLASS, I1_MACRO_SYMBOL_WITHOUT_VALUE, I1_MACRO_SYMBOL_WITH_VALUE, I1_MACRO_SYMBOL_WITH_VALUE0, I1_MACRO_SYMBOL_WITH_VALUE2, I1_ManyPtrStruct (ptr only), I1_MemberPtr, I1_NamespaceClass, I1_NamespaceStruct, I1_NamespaceTemplateFn, I1_OverloadedFunction, I1_PtrAndUseOnSameLine, I1_PtrDereferenceClass, I1_PtrDereferenceStatic, I1_PtrDereferenceStruct, I1_SiblingClass, I1_StaticMethod, I1_Struct, I1_Subclass, I1_SubclassesI2Class, I1_TemplateClass, I1_TemplateClass<>::I1_TemplateClass_int, I1_TemplateClassFwdDeclaredInD2 (ptr only), I1_TemplateFunction, I1_TemplateMethodOnlyClass, I1_TemplateSubclass, I1_Typedef, I1_TypedefOnly_Class, I1_TypedefOnly_Class<>::i, I1_Union, I1_UnnamedStruct, I1_UnusedNamespaceStruct (ptr only), I1_const_ptr, I2_OperatorDefinedInI1Class::operator<<, MACRO_CALLING_I6_FUNCTION, OperateOn, i1_GlobalFunction, i1_i1_classptr, i1_int, i1_int_global, i1_int_global2, i1_int_global2sub, i1_int_global3, i1_int_global3sub, i1_int_global4, i1_int_global4sub, i1_int_globalsub, i1_ns2, i1_ns4, i1_ns5, kI1ConstInt, operator==
 #include "tests/cxx/badinc2.c"
 class D2_Class;
 class D2_ForwardDeclareClass;

--- a/tests/cxx/using_directive_decl.cc
+++ b/tests/cxx/using_directive_decl.cc
@@ -1,0 +1,16 @@
+//===--- using_directive_decl.cc - test input file for iwyu ---------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+#include "using_directive_decl_a.h"
+using namespace a;
+
+/**** IWYU_SUMMARY
+
+(tests/cxx/using_directive_decl.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/using_directive_decl_a.h
+++ b/tests/cxx/using_directive_decl_a.h
@@ -1,0 +1,9 @@
+//===--- using_directive_decl_a.h - test input file for iwyu --------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+namespace a {};


### PR DESCRIPTION
a.h:
namespace a { ... };

b.cpp:
include "a.h"
using namespace a;
...

Add a test that header is not removed because of using directive

Adjust badinc.cc test for new diagnostic output.