### PR TITLE
Fix a link errror by adding libClangSerialization to link

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,7 @@ target_link_libraries(include-what-you-use
   clangSema
   clangFrontend
   clangDriver
+  clangSerialization
   )
 
 # Platform dependencies.


### PR DESCRIPTION
clang::PCHContainerOperations::PCHContainerOperations() moved to this
library with this commit in clang

commit 6be5408471f9a5f03e45f0cfe3c5bcdbfab4d707
Author: Richard Trieu <rtrieu@google.com>
Date:   Wed Dec 12 02:53:59 2018 +0000

    Move PCHContainerOperations from Frontend to Serialization

    Fix a layering violation.  Frontend depends on Serialization, so anything used
    by both should be in Serialization.