### PR TITLE
POC to preserve the original include order

### DIFF
--- a/iwyu_output.h
+++ b/iwyu_output.h
@@ -170,6 +170,26 @@ class OneIncludeOrForwardDeclareLine {
             this->end_linenum_ == that.end_linenum_);
   }
 
+  bool operator<(const OneIncludeOrForwardDeclareLine &RHS) const {
+    if (IsIncludeLine() && RHS.IsIncludeLine()) {
+      return *included_file_ < *RHS.included_file_;
+    }
+    return false;
+  }
+  bool operator>(const OneIncludeOrForwardDeclareLine &RHS) const {
+    if (IsIncludeLine() && RHS.IsIncludeLine()) {
+      return *RHS.included_file_ < *included_file_;
+    }
+    return false;
+  }
+  bool operator==(const OneIncludeOrForwardDeclareLine &RHS) const {
+    if (IsIncludeLine() && RHS.IsIncludeLine()) {
+      return !((*RHS.included_file_ < *included_file_) ||
+              (*included_file_ < *RHS.included_file_));
+    }
+    return false;
+  }
+
  private:
   string line_;                     // '#include XXX' or 'class YYY;'
   int start_linenum_;

--- a/tests/c/include_order.c
+++ b/tests/c/include_order.c
@@ -1,0 +1,28 @@
+//===--- include_order.c - test input file for iwyu -----------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+#include "include_order_c.h"
+void foo() {
+  int t = a + B;
+}
+
+/**** IWYU_SUMMARY
+
+include_order.c should add these lines:
+#include "include_order_b.h"  // for B
+#include "include_order_a.h"  // for a
+
+include_order.c should remove these lines:
+- #include "include_order_c.h"  // lines 1-1
+
+The full include-list for include_order.c:
+#include "include_order_b.h"  // for B
+#include "include_order_a.h"  // for a
+
+***** IWYU_SUMMARY */
+

--- a/tests/c/include_order_a.h
+++ b/tests/c/include_order_a.h
@@ -1,0 +1,10 @@
+//===--- include_order_a.h - test input file for iwyu ---------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+const int a = B + 5;
+

--- a/tests/c/include_order_b.h
+++ b/tests/c/include_order_b.h
@@ -1,0 +1,9 @@
+//===--- include_order_b.h - test input file for iwyu ---------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+#define B 5

--- a/tests/c/include_order_c.h
+++ b/tests/c/include_order_c.h
@@ -1,0 +1,10 @@
+//===--- include_order_c.h - test input file for iwyu ---------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+#include "include_order_b.h"
+#include "include_order_a.h"


### PR DESCRIPTION
Once a working list of includes if found both iwyu and fix_includes
reorders the list in roughly alpha order.

Reording is wrong.

This change preserves the original order.