### PR TITLE
[iwyu_tool] Fold consecutive whitespace in command strings

### DIFF
--- a/iwyu_tool.py
+++ b/iwyu_tool.py
@@ -165,9 +165,11 @@ def win_split(cmdline):
             elif c in (' ', '\t') and not in_quotes:
                 # MSDN: Arguments are delimited by white space, which is either
                 # a space or a tab [but only outside of a string].
+                # Flush backslashes and return arg bufferd so far, unless empty.
                 arg += '\\' * backslashes
-                yield arg
-                arg = ''
+                if arg:
+                    yield arg
+                    arg = ''
                 backslashes = 0
             else:
                 # Flush buffered backslashes and append.

--- a/iwyu_tool_test.py
+++ b/iwyu_tool_test.py
@@ -200,6 +200,14 @@ class WinSplitTests(unittest.TestCase):
         self.assert_win_split(r'clang -Idir\using\os\seps f.cc',
                               ['clang', r'-Idir\using\os\seps', 'f.cc'])
 
+    def test_consecutive_spaces(self):
+        """ Consecutive spaces outside of quotes should be folded. """
+        self.assert_win_split('clang  -I.      -A',
+                              ['clang', '-I.', '-A'])
+
+        self.assert_win_split('clang  -I. \t     -A',
+                              ['clang', '-I.', '-A'])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fix bug where every additional whitespace character would turn into an
empty argument in argument list.