### PR TITLE
[Iwyu_tool] Remove -Xiwyu implicit prefix

### DIFF
--- a/iwyu_tool.py
+++ b/iwyu_tool.py
@@ -381,8 +381,8 @@ def main(compilation_db_path, source_files, verbose, formatter, jobs,
     return execute(invocations, verbose, formatter, jobs)
 
 
-def _bootstrap():
-    """ Parse arguments and dispatch to main(). """
+def _bootstrap(sys_argv):
+    """ Parse sys_argv arguments and dispatch to main(). """
 
     # This hackery is necessary to add the forwarded IWYU args to the
     # usage and help strings.
@@ -433,11 +433,13 @@ def _bootstrap():
             return argv[:double_dash], argv[double_dash+1:]
         except ValueError:
             return argv, []
-    argv, extra_args = partition_args(sys.argv[1:])
+    argv, extra_args = partition_args(sys_argv[1:])
     args = parser.parse_args(argv)
-    sys.exit(main(args.dbpath, args.source, args.verbose,
-                  FORMATTERS[args.output_format], args.jobs, extra_args))
+    main(
+        args.dbpath, args.source, args.verbose,
+        FORMATTERS[args.output_format], args.jobs, extra_args
+        )
 
 
 if __name__ == '__main__':
-    _bootstrap()
+    sys.exit(_bootstrap(sys.argv))

--- a/iwyu_tool.py
+++ b/iwyu_tool.py
@@ -362,7 +362,7 @@ def execute(invocations, verbose, formatter, jobs):
 
 
 def main(compilation_db_path, source_files, verbose, formatter, jobs,
-         iwyu_args):
+         extra_args):
     """ Entry point. """
 
     try:
@@ -375,7 +375,7 @@ def main(compilation_db_path, source_files, verbose, formatter, jobs,
 
     # Transform compilation db entries into a list of IWYU invocations.
     invocations = [
-        Invocation.from_compile_command(e, iwyu_args) for e in compilation_db
+        Invocation.from_compile_command(e, extra_args) for e in compilation_db
     ]
 
     return execute(invocations, verbose, formatter, jobs)
@@ -433,10 +433,10 @@ def _bootstrap():
             return argv[:double_dash], argv[double_dash+1:]
         except ValueError:
             return argv, []
-    argv, iwyu_args = partition_args(sys.argv[1:])
+    argv, extra_args = partition_args(sys.argv[1:])
     args = parser.parse_args(argv)
     sys.exit(main(args.dbpath, args.source, args.verbose,
-                  FORMATTERS[args.output_format], args.jobs, iwyu_args))
+                  FORMATTERS[args.output_format], args.jobs, extra_args))
 
 
 if __name__ == '__main__':

--- a/iwyu_tool.py
+++ b/iwyu_tool.py
@@ -329,12 +329,6 @@ def _bootstrap():
             return argv, []
     argv, iwyu_args = partition_args(sys.argv[1:])
     args = parser.parse_args(argv)
-
-    # Force -Xiwyu prefix to iwyu_args so users don't have to provide prefix
-    # explicitly.
-    prefixes = ['-Xiwyu'] * len(iwyu_args)
-    iwyu_args = list(sum(zip(prefixes, iwyu_args), ()))
-
     sys.exit(main(args.dbpath, args.source, args.verbose,
                   FORMATTERS[args.output_format], args.jobs, iwyu_args))
 

--- a/iwyu_tool_test.py
+++ b/iwyu_tool_test.py
@@ -283,5 +283,16 @@ class BootstrapTests(unittest.TestCase):
         iwyu_call_args = self.iwyu_tool_main_mock.get_call_args()
         self.assertIn(["arg1", "-Xiwyu", "arg2", "--iwyu_opt", "arg3"], iwyu_call_args)        
 
+    def test_argument_parser_uses_the_first_separator_for_splitting_arguments(self):
+        """ Check that in case of using several '--' separator, the first one is used for separating
+        the iwyu_tool arguments from those of iwyu.
+        """
+        argv_stub = StubSysArgv(["iwyu_tool.py", "-p", "ccom_db_path", "source_dir_1", "source_dir_2", "--", "arg1", "--", "another_arg1"])
+        iwyu_tool._bootstrap()
+        iwyu_call_args = self.iwyu_tool_main_mock.get_call_args()
+        self.assertIn('ccom_db_path', iwyu_call_args)                   # ccom_db_path
+        self.assertIn(["source_dir_1", "source_dir_2"], iwyu_call_args) # source code directories
+        self.assertIn(["arg1", "--", "another_arg1"], iwyu_call_args)   # ccom_db_path
+
 if __name__ == '__main__':
     unittest.main()

--- a/iwyu_tool_test.py
+++ b/iwyu_tool_test.py
@@ -123,13 +123,13 @@ class IWYUToolTests(unittest.TestCase):
         iwyu_tool.sys.stdout = self.stdout_stub
 
     def test_from_compile_command(self):
-        iwyu_args = ['-foo']
+        extra_args = ['-foo']
         invocation = iwyu_tool.Invocation.from_compile_command(
             {
                 'directory': '/home/user/llvm/build',
                 'command': '/usr/bin/clang++ -Iinclude file.cc',
                 'file': 'file.cc'
-            }, iwyu_args)
+            }, extra_args)
         self.assertEqual(
             invocation.command,
             [iwyu_tool.IWYU_EXECUTABLE, '-foo', '-Iinclude', 'file.cc'])
@@ -282,7 +282,7 @@ class BootstrapTests(unittest.TestCase):
         argv_stub = StubSysArgv(['iwyu_tool.py', '-p', '.', '--', 'arg1'])
         iwyu_tool._bootstrap()
         call_args = self.iwyu_tool_main_mock.get_call_args()
-        self.assertEqual(['arg1'], call_args['iwyu_args'])
+        self.assertEqual(['arg1'], call_args['extra_args'])
 
     def test_argument_parser_does_include_iwyu_flags(self):
         """ Check that arguments that appear after the '--' delimiter are 
@@ -297,7 +297,7 @@ class BootstrapTests(unittest.TestCase):
         iwyu_tool._bootstrap()
         call_args = self.iwyu_tool_main_mock.get_call_args()
         self.assertEqual(['-Xiwyu', 'arg1', '-Xiwyu', '--arg2',\
-                         '-non-iwyu-arg'], call_args['iwyu_args'])
+                         '-non-iwyu-arg'], call_args['extra_args'])
 
     def test_argument_parser_uses_the_first_separator_for_splitting_args(self):
         """ Check that in case of using several '--' separator, the first one
@@ -316,7 +316,7 @@ class BootstrapTests(unittest.TestCase):
                         call_args['source_files'])
         # iwyu arguments
         self.assertEqual(['arg1', '--', 'another_arg1'],\
-                        call_args['iwyu_args'])
+                        call_args['extra_args'])
 
 if __name__ == '__main__':
     unittest.main()

--- a/iwyu_tool_test.py
+++ b/iwyu_tool_test.py
@@ -57,7 +57,7 @@ class StubSysExit(object):
     """ Provides an object that configures an stub behaviour of
         the sys.exit method. It is possible to modify the value that
         will be returned
-    """    
+    """
     def __init__(self):
         self.real_sys_exit = sys.exit
         sys.exit = lambda x: self._will_return
@@ -67,15 +67,17 @@ class StubSysExit(object):
         sys.exit = self.real_sys_exit
 
     def will_return(self, content):
-        self._will_return = content   
+        self._will_return = content
 
 class StubSysArgv(object):
     """ Provides an object that configures an stub behaviour of
         the sys.argv method. It is possible to modify the set of
         values that sys.argv provides.
-    """  
-    def __init__(self, values=[]):
+    """
+    def __init__(self, values=None):
         self.real_sys_argv = sys.argv
+        if values is None:
+            values = []
         sys.argv = values
 
     def reset(self):
@@ -85,7 +87,7 @@ class MockIwyuToolMain(object):
     """ Provides an object that configures a mock'd behaviour
         of the iwyu_tool.main method, being possible to obtain
         the arguments used in the called within the section tested.
-    """     
+    """
     def __init__(self):
         self._iwyu_tool_main_args = inspect.getargspec(iwyu_tool.main).args
         self.real_iwyu_tool_main = iwyu_tool.main
@@ -101,11 +103,10 @@ class MockIwyuToolMain(object):
         """ Returns a dictionary built with the iwyu_tool.main API keys filled
             with the arguments used in the last call.
         """
-        return self._call_args   
+        return self._call_args
 
     def _iwyu_tool_main_mock(self, *args, **kwargs):
         assert len(args) + len(kwargs) <= self._iwyu_tool_main_args
-        index = 0
         for idx, arg in enumerate(args):
             key_idx = self._iwyu_tool_main_args[idx]
             self._call_args[key_idx] = arg
@@ -269,7 +270,7 @@ class WinSplitTests(unittest.TestCase):
 
 class BootstrapTests(unittest.TestCase):
     def setUp(self):
-        self.iwyu_tool_main_mock =  MockIwyuToolMain()
+        self.iwyu_tool_main_mock = MockIwyuToolMain()
         self.sys_exit_stub = StubSysExit()
         self.sys_exit_stub.will_return(0)
 
@@ -285,9 +286,9 @@ class BootstrapTests(unittest.TestCase):
         self.assertEqual(['arg1'], call_args['extra_args'])
 
     def test_argument_parser_does_include_iwyu_flags(self):
-        """ Check that arguments that appear after the '--' delimiter are 
-        injected as they are considering the case of being preceeded by -Xiwyu 
-        special delimiter and in the form of --arg or arg as well as being 
+        """ Check that arguments that appear after the '--' delimiter are
+        injected as they are considering the case of being preceeded by -Xiwyu
+        special delimiter and in the form of --arg or arg as well as being
         a non -Xiwyu preceeded argument
         """
         argv_stub = StubSysArgv(['iwyu_tool.py', '-p', '.', '--',\

--- a/iwyu_tool_test.py
+++ b/iwyu_tool_test.py
@@ -38,9 +38,6 @@ class MockProcess(object):
 
 
 class MockInvocation(iwyu_tool.Invocation):
-    """ Provides a stub object to be used for a non-real
-        sys.exit call. 
-    """    
     def __init__(self, command=None, cwd=''):
         iwyu_tool.Invocation.__init__(self, command or [], cwd)
         self._will_return = ''

--- a/iwyu_tool_test.py
+++ b/iwyu_tool_test.py
@@ -228,11 +228,11 @@ class BootstrapTests(unittest.TestCase):
 
     @mock.patch('sys.exit')
     def test_argument_parser_does_include_xiwyu_flag(self, sys_exit):
-        """ Check that -Xiwyu argument is passed to the iwyu call. """
+        """ Check that -Xiwyu and --iwyu_opt arguments are passed to the iwyu call. """
         sys_exit.return_value = 0
-        with mock.patch.object(sys, 'argv', ["iwyu_tool.py", "-p", ".", "--", "arg1", "-Xiwyu", "arg2"]):
+        with mock.patch.object(sys, 'argv', ["iwyu_tool.py", "-p", ".", "--", "arg1", "-Xiwyu", "arg2", "--iwyu_opt", "arg3"]):
             iwyu_tool._bootstrap()
-        self.assertIn(["arg1", "-Xiwyu", "arg2"], iwyu_tool.main.call_args[0])
+        self.assertIn(["arg1", "-Xiwyu", "arg2", "--iwyu_opt", "arg3"], iwyu_tool.main.call_args[0])
 
     @mock.patch('argparse.ArgumentParser.parse_args')
     @mock.patch('sys.exit')

--- a/iwyu_tool_test.py
+++ b/iwyu_tool_test.py
@@ -292,7 +292,7 @@ class BootstrapTests(unittest.TestCase):
         iwyu_call_args = self.iwyu_tool_main_mock.get_call_args()
         self.assertIn('ccom_db_path', iwyu_call_args)                   # ccom_db_path
         self.assertIn(["source_dir_1", "source_dir_2"], iwyu_call_args) # source code directories
-        self.assertIn(["arg1", "--", "another_arg1"], iwyu_call_args)   # ccom_db_path
+        self.assertIn(["arg1", "--", "another_arg1"], iwyu_call_args)   # iwyu arguments
 
 if __name__ == '__main__':
     unittest.main()

--- a/iwyu_tool_test.py
+++ b/iwyu_tool_test.py
@@ -53,36 +53,6 @@ class MockInvocation(iwyu_tool.Invocation):
     def start(self, verbose):
         return MockProcess(self._will_block, self._will_return)
 
-class StubSysExit(object):
-    """ Provides an object that configures an stub behaviour of
-        the sys.exit method. It is possible to modify the value that
-        will be returned
-    """
-    def __init__(self):
-        self.real_sys_exit = sys.exit
-        sys.exit = lambda x: self._will_return
-        self._will_return = 0
-
-    def reset(self):
-        sys.exit = self.real_sys_exit
-
-    def will_return(self, content):
-        self._will_return = content
-
-class StubSysArgv(object):
-    """ Provides an object that configures an stub behaviour of
-        the sys.argv method. It is possible to modify the set of
-        values that sys.argv provides.
-    """
-    def __init__(self, values=None):
-        self.real_sys_argv = sys.argv
-        if values is None:
-            values = []
-        sys.argv = values
-
-    def reset(self):
-        sys.argv = self.real_sys_argv
-
 class MockIwyuToolMain(object):
     """ Provides an object that configures a mock'd behaviour
         of the iwyu_tool.main method, being possible to obtain
@@ -271,17 +241,14 @@ class WinSplitTests(unittest.TestCase):
 class BootstrapTests(unittest.TestCase):
     def setUp(self):
         self.iwyu_tool_main_mock = MockIwyuToolMain()
-        self.sys_exit_stub = StubSysExit()
-        self.sys_exit_stub.will_return(0)
 
     def tearDown(self):
         self.iwyu_tool_main_mock.reset()
-        self.sys_exit_stub.reset()
 
     def test_argument_parser_sets_argument_correctly(self):
         """ Check that arguments are injected verbatim to iwyu. """
-        argv_stub = StubSysArgv(['iwyu_tool.py', '-p', '.', '--', 'arg1'])
-        iwyu_tool._bootstrap()
+        sys_args = ['iwyu_tool.py', '-p', '.', '--', 'arg1']
+        iwyu_tool._bootstrap(sys_args)
         call_args = self.iwyu_tool_main_mock.get_call_args()
         self.assertEqual(['arg1'], call_args['extra_args'])
 
@@ -291,11 +258,9 @@ class BootstrapTests(unittest.TestCase):
         special delimiter and in the form of --arg or arg as well as being
         a non -Xiwyu preceeded argument
         """
-        argv_stub = StubSysArgv(['iwyu_tool.py', '-p', '.', '--',\
-                                 '-Xiwyu', 'arg1',\
-                                 '-Xiwyu', '--arg2',\
-                                 '-non-iwyu-arg'])
-        iwyu_tool._bootstrap()
+        sys_args = ['iwyu_tool.py', '-p', '.', '--','-Xiwyu', 'arg1',\
+                    '-Xiwyu', '--arg2', '-non-iwyu-arg']
+        iwyu_tool._bootstrap(sys_args)
         call_args = self.iwyu_tool_main_mock.get_call_args()
         self.assertEqual(['-Xiwyu', 'arg1', '-Xiwyu', '--arg2',\
                          '-non-iwyu-arg'], call_args['extra_args'])
@@ -304,10 +269,9 @@ class BootstrapTests(unittest.TestCase):
         """ Check that in case of using several '--' separator, the first one
          is used for separating the iwyu_tool arguments from those of iwyu.
         """
-        argv_stub = StubSysArgv(['iwyu_tool.py', '-p', 'ccom_db_path',\
-                                 'source_dir_1', 'source_dir_2', '--', 'arg1',\
-                                 '--', 'another_arg1'])
-        iwyu_tool._bootstrap()
+        sys_args = ['iwyu_tool.py', '-p', 'ccom_db_path', 'source_dir_1',\
+                    'source_dir_2', '--', 'arg1', '--', 'another_arg1']
+        iwyu_tool._bootstrap(sys_args)
         call_args = self.iwyu_tool_main_mock.get_call_args()
         # ccom_db_path
         self.assertEqual('ccom_db_path',\

--- a/iwyu_tool_test.py
+++ b/iwyu_tool_test.py
@@ -14,8 +14,10 @@ import random
 import unittest
 import iwyu_tool
 
-import mock
-
+try:
+    from unittest.mock import patch, MagicMock
+except ImportError:
+    from mock import patch, MagicMock
 try:
     from cStringIO import StringIO
 except ImportError:
@@ -213,50 +215,50 @@ class WinSplitTests(unittest.TestCase):
 class BootstrapTests(unittest.TestCase):
     def setUp(self):
         self.main = iwyu_tool.main
-        iwyu_tool.main =  mock.MagicMock()
+        iwyu_tool.main =  MagicMock()
 
     def tearDown(self):
         iwyu_tool.main = self.main
 
-    @mock.patch('sys.exit')
+    @patch('sys.exit')
     def test_argument_parser_sets_argument_correctly(self, sys_exit):
         """ Check that arguments are verbatim injected to iwyu. """
         sys_exit.return_value = 0
-        with mock.patch.object(sys, 'argv', ["iwyu_tool.py", "-p", ".", "--", "arg1"]):
+        with patch.object(sys, 'argv', ["iwyu_tool.py", "-p", ".", "--", "arg1"]):
             iwyu_tool._bootstrap()
         self.assertIn(["arg1"], iwyu_tool.main.call_args[0])
 
-    @mock.patch('sys.exit')
+    @patch('sys.exit')
     def test_argument_parser_does_include_xiwyu_flag(self, sys_exit):
         """ Check that -Xiwyu and --iwyu_opt arguments are passed to the iwyu call. """
         sys_exit.return_value = 0
-        with mock.patch.object(sys, 'argv', ["iwyu_tool.py", "-p", ".", "--", "arg1", "-Xiwyu", "arg2", "--iwyu_opt", "arg3"]):
+        with patch.object(sys, 'argv', ["iwyu_tool.py", "-p", ".", "--", "arg1", "-Xiwyu", "arg2", "--iwyu_opt", "arg3"]):
             iwyu_tool._bootstrap()
         self.assertIn(["arg1", "-Xiwyu", "arg2", "--iwyu_opt", "arg3"], iwyu_tool.main.call_args[0])
 
-    @mock.patch('argparse.ArgumentParser.parse_args')
-    @mock.patch('sys.exit')
+    @patch('argparse.ArgumentParser.parse_args')
+    @patch('sys.exit')
     def test_argument_parser_is_created_and_adequatelly_called(self, sys_exit, parse_args):
         """ Check that parser is created with all the arguments provided when called. """
         sys_exit.return_value = 0
-        _parse_args = mock.MagicMock()
+        _parse_args = MagicMock()
         parse_args.return_value = _parse_args
         _parse_args.output_format = iwyu_tool.DEFAULT_FORMAT
-        with mock.patch.object(sys, 'argv', ["iwyu_tool.py", "-p", ".", "--", "arg1"]):
+        with patch.object(sys, 'argv', ["iwyu_tool.py", "-p", ".", "--", "arg1"]):
             iwyu_tool._bootstrap()
         parse_args.assert_called_with(["-p", "."])
 
-    @mock.patch('argparse.ArgumentParser.parse_args')
-    @mock.patch('sys.exit')
+    @patch('argparse.ArgumentParser.parse_args')
+    @patch('sys.exit')
     def test_argument_parser_uses_the_first_separator_for_splitting_arguments(self, sys_exit, parse_args):
         """ Check that in case of using several '--' separator, the first one is used for separating
         the iwyu_tool arguments from those of iwyu.
         """
         sys_exit.return_value = 0
-        _parse_args = mock.MagicMock()
+        _parse_args = MagicMock()
         parse_args.return_value = _parse_args
         _parse_args.output_format = iwyu_tool.DEFAULT_FORMAT
-        with mock.patch.object(sys, 'argv', ["iwyu_tool.py", "-p", ".", "--", "arg1", "--", "another_arg1"]):
+        with patch.object(sys, 'argv', ["iwyu_tool.py", "-p", ".", "--", "arg1", "--", "another_arg1"]):
             iwyu_tool._bootstrap()
         parse_args.assert_called_with(["-p", "."])
         self.assertIn(["arg1", "--", "another_arg1"], iwyu_tool.main.call_args[0])

--- a/iwyu_tool_test.py
+++ b/iwyu_tool_test.py
@@ -13,7 +13,6 @@ import time
 import random
 import unittest
 import iwyu_tool
-import sys
 
 import mock
 
@@ -214,31 +213,53 @@ class WinSplitTests(unittest.TestCase):
 class BootstrapTests(unittest.TestCase):
     def setUp(self):
         self.main = iwyu_tool.main
-        self.argparse = iwyu_tool.argparse
         iwyu_tool.main =  mock.MagicMock()
 
     def tearDown(self):
         iwyu_tool.main = self.main
-        iwyu_tool.argparse = self.argparse
 
     @mock.patch('sys.exit')
     def test_argument_parser_sets_argument_correctly(self, sys_exit):
+        """ Check that arguments are verbatim injected to iwyu. """
         sys_exit.return_value = 0
         with mock.patch.object(sys, 'argv', ["iwyu_tool.py", "-p", ".", "--", "arg1"]):
             iwyu_tool._bootstrap()
-        iwyu_tool.main.assert_called_with(".", mock.ANY, mock.ANY, mock.ANY , mock.ANY, ["arg1"])
-    
+        self.assertIn(["arg1"], iwyu_tool.main.call_args[0])
+
+    @mock.patch('sys.exit')
+    def test_argument_parser_does_include_xiwyu_flag(self, sys_exit):
+        """ Check that -Xiwyu argument is passed to the iwyu call. """
+        sys_exit.return_value = 0
+        with mock.patch.object(sys, 'argv', ["iwyu_tool.py", "-p", ".", "--", "arg1", "-Xiwyu", "arg2"]):
+            iwyu_tool._bootstrap()
+        self.assertIn(["arg1", "-Xiwyu", "arg2"], iwyu_tool.main.call_args[0])
+
     @mock.patch('argparse.ArgumentParser.parse_args')
     @mock.patch('sys.exit')
-    def test_argument_parser_is_created(self, sys_exit, parse_args):
+    def test_argument_parser_is_created_and_adequatelly_called(self, sys_exit, parse_args):
+        """ Check that parser is created with all the arguments provided when called. """
         sys_exit.return_value = 0
         _parse_args = mock.MagicMock()
         parse_args.return_value = _parse_args
         _parse_args.output_format = iwyu_tool.DEFAULT_FORMAT
-        with mock.patch.object(sys, 'argv', ["iwyu_tool.py", "-p", ".",]):
+        with mock.patch.object(sys, 'argv', ["iwyu_tool.py", "-p", ".", "--", "arg1"]):
             iwyu_tool._bootstrap()
-            parse_args.assert_called_with(["-p", "."])
+        parse_args.assert_called_with(["-p", "."])
 
+    @mock.patch('argparse.ArgumentParser.parse_args')
+    @mock.patch('sys.exit')
+    def test_argument_parser_uses_the_first_separator_for_splitting_arguments(self, sys_exit, parse_args):
+        """ Check that in case of using several '--' separator, the first one is used for separating
+        the iwyu_tool arguments from those of iwyu.
+        """
+        sys_exit.return_value = 0
+        _parse_args = mock.MagicMock()
+        parse_args.return_value = _parse_args
+        _parse_args.output_format = iwyu_tool.DEFAULT_FORMAT
+        with mock.patch.object(sys, 'argv', ["iwyu_tool.py", "-p", ".", "--", "arg1", "--", "another_arg1"]):
+            iwyu_tool._bootstrap()
+        parse_args.assert_called_with(["-p", "."])
+        self.assertIn(["arg1", "--", "another_arg1"], iwyu_tool.main.call_args[0])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
# What?

iwyu_tool included `-Xiwyu` prefix to all those arguments comming after the separator `--`. While this had the advantage of not requiring users to provide this flag explicitely, the assumption was that all those arguments were `iwyu` arguments. 

Considering the current iwyu interface 

```
include-what-you-use [-Xiwyu --iwyu_opt]... <clang opts> <source file>
```

The change purposed here goes in the direction of removing this implicitely setting in favor of being able to provide also other type of arguments that iwyu support like `<clang opts>` 

Issue: iwyu_tool.py does not attend to clang flags #612

# How?

The previous implicit handling of the arguments

```
    # Force -Xiwyu prefix to iwyu_args so users don't have to provide prefix
    # explicitly.
    prefixes = ['-Xiwyu'] * len(iwyu_args)
    iwyu_args = list(sum(zip(prefixes, iwyu_args), ()))
```

has been removed so that `iwyu_args` are passed verbatim

Additional tests covering how the argumentes are processed have been also included