### PR TITLE
In fix_includes, treat associated headers as main-CU headers for sorting

### DIFF
--- a/fix_includes.py
+++ b/fix_includes.py
@@ -126,6 +126,9 @@ _HEADER_GUARD_RE = re.compile(r'$.HEADER_GUARD_RE')
 # know the previous line was a header-guard line, we're not that picky
 # about this one.
 _HEADER_GUARD_DEFINE_RE = re.compile(r'\s*#\s*define\s+')
+# Pragma to mark the associated header (for use when it cannot be deduced from
+# the filename)
+_IWYU_PRAGMA_ASSOCIATED_RE = re.compile(r'IWYU\s*pragma:\s*associated')
 
 # We annotate every line in the source file by the re it matches, or None.
 # Note that not all of the above RE's are represented here; for instance,
@@ -1548,6 +1551,8 @@ def _IsMainCUInclude(line_info, filename):
   """
   if line_info.type != _INCLUDE_RE or _IsSystemInclude(line_info):
     return False
+  if _IWYU_PRAGMA_ASSOCIATED_RE.search(line_info.line):
+    return True
   # First, normalize the includee by getting rid of -inl.h and .h
   # suffixes (for the #include) and the "'s around the #include line.
   canonical_include = re.sub(r'(-inl\.h|\.h|\.H)$',

--- a/fix_includes_test.py
+++ b/fix_includes_test.py
@@ -3637,6 +3637,26 @@ The full include-list for barrier_includes.h:
                          self.actual_after_contents)
     self.assertEqual(1, num_files_modified)
 
+  def testSortingMainCUIncludeViaPragma(self):
+    """Check that we treat (potentially multiple) associated headers as
+    main-cu #includes."""
+    infile = """\
+#include <stdio.h>
+#include "other/dir/bar.h" // IWYU pragma: associated
+#include "other/baz.h" // IWYU pragma: associated
+"""
+    expected_output = """\
+#include "other/baz.h" // IWYU pragma: associated
+#include "other/dir/bar.h" // IWYU pragma: associated
+#include <stdio.h>
+"""
+    self.RegisterFileContents({'me/subdir0/foo.cc': infile})
+    num_files_modified = fix_includes.SortIncludesInFiles(
+        ['me/subdir0/foo.cc'], self.flags)
+    self.assertListEqual(expected_output.strip().split('\n'),
+                         self.actual_after_contents)
+    self.assertEqual(1, num_files_modified)
+
   def testSortingMainCUIncludeWithUpperCaseH(self):
     """Check that we identify when first .H file is a main-cu #include."""
     infile = """\


### PR DESCRIPTION
`fix_includes.py`, when sorting headers, will put main-CU #include lines first.

It should respect `IWYU pragma: associated` as a way for the user to specify what the main-CU files are when its heuristics fail (this pragma is [already defined](https://github.com/include-what-you-use/include-what-you-use/blob/master/docs/IWYUPragmas.md#iwyu-pragma-associated) by IWYU for this purpose).

Make it so, and add a test.