### PR TITLE
Stop ignoring uses for builtins with mappings

### DIFF
--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -39,6 +39,7 @@
 #include "clang/AST/TemplateName.h"
 #include "clang/AST/Type.h"
 #include "clang/AST/TypeLoc.h"
+#include "clang/Basic/Builtins.h"
 #include "clang/Basic/SourceLocation.h"
 #include "clang/Basic/SourceManager.h"
 
@@ -1077,6 +1078,15 @@ bool DeclsAreInSameClass(const Decl* decl1, const Decl* decl2) {
   if (decl1->getDeclContext() != decl2->getDeclContext())
     return false;
   return decl1->getDeclContext()->isRecord();
+}
+
+bool IsBuiltinFunction(const clang::NamedDecl* decl,
+                       const std::string& symbol_name) {
+  if (const clang::IdentifierInfo* iden = decl->getIdentifier()) {
+    return iden->getBuiltinID() != 0 &&
+           !clang::Builtin::Context::isBuiltinFunc(symbol_name.c_str());
+  }
+  return false;
 }
 
 // --- Utilities for Type.

--- a/iwyu_ast_util.h
+++ b/iwyu_ast_util.h
@@ -655,6 +655,10 @@ const clang::NamedDecl* GetNonfriendClassRedecl(const clang::NamedDecl* decl);
 // same, and it's a class (or struct).
 bool DeclsAreInSameClass(const clang::Decl* decl1, const clang::Decl* decl2);
 
+// Returns true if the given decl/name is a builtin function
+bool IsBuiltinFunction(const clang::NamedDecl* decl,
+                       const std::string& symbol_name);
+
 // --- Utilities for Type.
 
 const clang::Type* GetTypeOf(const clang::Expr* expr);

--- a/iwyu_output.cc
+++ b/iwyu_output.cc
@@ -1188,14 +1188,11 @@ void ProcessFullUse(OneUse* use,
     return;
   }
   // A compiler builtin without a predefined header file (e.g. __builtin_..)
-  if (const clang::IdentifierInfo* iden = use->decl()->getIdentifier()) {
-    if (iden->getBuiltinID() != 0 &&
-        !clang::Builtin::Context::isBuiltinFunc(use->symbol_name().c_str())) {
-      VERRS(6) << "Ignoring use of " << use->symbol_name()
-               << " (" << use->PrintableUseLoc() << "): built-in function\n";
-      use->set_ignore_use();
-      return;
-    }
+  if (IsBuiltinFunction(use->decl(), use->symbol_name()) {
+    VERRS(6) << "Ignoring use of " << use->symbol_name()
+             << " (" << use->PrintableUseLoc() << "): built-in function\n";
+    use->set_ignore_use();
+    return;
   }
   // Special case for operators new/delete: Only treated as built-in if they
   // are the default, non-placement versions.

--- a/run_iwyu_tests.py
+++ b/run_iwyu_tests.py
@@ -63,6 +63,7 @@ class OneIwyuTest(unittest.TestCase):
     flags_map = {
       'backwards_includes.cc': [self.CheckAlsoExtension('-d*.h')],
       'badinc.cc': [self.MappingFile('badinc.imp')],
+      'built_ins_with_mapping.cc': [self.MappingFile('built_ins_with_mapping.imp')],
       'check_also.cc': [self.CheckAlsoExtension('-d1.h')],
       'implicit_ctor.cc': [self.CheckAlsoExtension('-d1.h')],
       'iwyu_stricter_than_cpp.cc': [self.CheckAlsoExtension('-autocast.h'),
@@ -125,6 +126,7 @@ class OneIwyuTest(unittest.TestCase):
       'backwards_includes.cc': ['.'],
       'badinc.cc': ['.'],
       'badinc-extradef.cc': ['.'],
+      'built_ins_with_mapping.cc': ['.'],
       'funcptrs.cc': ['.'],
       'casts.cc': ['.'],
       'catch.cc': ['.'],

--- a/tests/cxx/built_ins_with_mapping-d1.h
+++ b/tests/cxx/built_ins_with_mapping-d1.h
@@ -1,0 +1,15 @@
+//===--- built_ins_with_mapping-d1.h - test input file for iwyu -----------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_BUILT_INS_WITH_MAPPING_D1_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_BUILT_INS_WITH_MAPPING_D1_H_
+
+int i = __builtin_expect(0, 0);
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_BUILT_INS_WITH_MAPPING_D1_H_

--- a/tests/cxx/built_ins_with_mapping.cc
+++ b/tests/cxx/built_ins_with_mapping.cc
@@ -1,0 +1,40 @@
+//===--- built_ins_with_mapping.cc - test input file for iwyu -------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/built_ins_with_mapping.h"
+#include "tests/cxx/built_ins_with_mapping-d1.h"
+
+// Normally if we use a builtin function IWYU will ignore uses of it.
+// However, if there is a mapping defined for that builtin then it should be
+// respected.
+// Clang considers the definition of a builtin to be at its first use, so we
+// have two test cases:
+
+// First test case for a builtin which was already used in a header we included
+// IWYU: __builtin_expect is defined in...*which isn't directly #included.
+int j = __builtin_expect(i, 0);
+// Second test case for a first use of a builtin
+// IWYU: __builtin_strlen is defined in...*which isn't directly #included.
+int k = __builtin_strlen("");
+
+/**** IWYU_SUMMARY
+
+tests/cxx/built_ins_with_mapping.cc should add these lines:
+#include "tests/cxx/built_ins_with_mapping-d2.h"
+#include "tests/cxx/built_ins_with_mapping-d3.h"
+
+tests/cxx/built_ins_with_mapping.cc should remove these lines:
+
+The full include-list for tests/cxx/built_ins_with_mapping.cc:
+#include "tests/cxx/built_ins_with_mapping.h"
+#include "tests/cxx/built_ins_with_mapping-d1.h"  // for i
+#include "tests/cxx/built_ins_with_mapping-d2.h"  // for __builtin_expect
+#include "tests/cxx/built_ins_with_mapping-d3.h"  // for __builtin_strlen
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/built_ins_with_mapping.h
+++ b/tests/cxx/built_ins_with_mapping.h
@@ -1,0 +1,34 @@
+//===--- built_ins_with_mapping.h - test input file for iwyu --------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_BUILT_INS_WITH_MAPPING_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_BUILT_INS_WITH_MAPPING_H_
+
+// This is to simulate the situation where a builtin exists on some compilers,
+// and not others, so we need a mapping.  However, we need to check that the
+// header mapped to (this header, in this case) is not forced to include itself
+// if it uses that builtin.
+
+void __builtin_invented_for_test();
+
+inline void f()
+{
+  // A regular function mapped to this file
+  __builtin_invented_for_test();
+  // A builtin mapped to this file
+  __builtin_strcmp("", "");
+}
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_BUILT_INS_WITH_MAPPING_H_
+
+/**** IWYU_SUMMARY
+
+(tests/cxx/built_ins_with_mapping.h has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/built_ins_with_mapping.imp
+++ b/tests/cxx/built_ins_with_mapping.imp
@@ -1,0 +1,9 @@
+# Header mappings for IWYU tests.
+# Note that some headers listed here don't actually exist; we just want
+# IWYU to suggest using them
+[
+  { symbol: ["__builtin_expect", "private", "\"tests/cxx/built_ins_with_mapping-d2.h\"", "public"] },
+  { symbol: ["__builtin_strlen", "private", "\"tests/cxx/built_ins_with_mapping-d3.h\"", "public"] },
+  { symbol: ["__builtin_strcmp", "private", "\"tests/cxx/built_ins_with_mapping.h\"", "public"] },
+  { symbol: ["__builtin_invented_for_test", "private", "\"tests/cxx/built_ins_with_mapping.h\"", "public"] },
+]


### PR DESCRIPTION
Currently IWYU will ignore all uses of buitlins.

This makes sense normally.  However, when a symbol has an explicit mapping defined, we should not ignore uses of it.

In particular, for example, one might require a particular header to be included when certain builtins are used, and this change allows that by defining a mapping for that builtin (whereas before all uses of builtins were ignored).

This change is originally inspired by the fact that some `cmath` functions (`std::pow`, `std::round`, perhaps more) are considered a builtin by clang with certain compiler settings, and IWYU was suggesting removing the include of `cmath`, which breaks the build.  I wanted to override this with a mapping, but it did not work.  With this change, that will now work.

Moreover, I think there is wider application to mappings for buitlins.  For example, if a buitin exists on clang but not some other compiler and you have a header which emulates it for that other compiler, you want to make sure that IWYU enforces inclusion of that header, even though it's not needed on clang.

The solution I've implemented affects `ProcessFullUse`, which contains most of the code that will ignore a use under some situation or another.  For three of the situations therein, I make it not ignore the use when the symbol is a builtin that has a mapping to a file that does not (transitively) include the file containing the use.

The three situations are:
* When it's a builtin.
* When it's defined in this file.
* When it's defined in a file including this one.
All three changes are required to make this work for buitins, because clang considers a builtin to be defined at first use, so the second and third cases can apply for uses of builtins.  

This solution does not work for all builtins; some don't get noticed as uses by IWYU at all.  But I think that's a separate issue.

I've only changed builtin functions.  There is also code in `ProcessFullUse` for builtin templates, but I have no idea when those arise, so I'm taking the conservative option and not changing any behaviour for them.

Similarly, there are probably other times when IWYU ignores uses where it might be better to respect a mapping when it exists.  I actually wrote a broader version of this change which would affect some, but I don't really have evidence that it's necessary, so again I'm being conservative and just making the changes needed for builtins.