### PR TITLE
Simplify handling of defined() operator

### DIFF
--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -424,10 +424,6 @@ string PrintableLoc(SourceLocation loc) {
   }
 }
 
-string PrintableSourceRange(SourceRange range) {
-  return PrintableLoc(range.getBegin()) + " - " + PrintableLoc(range.getEnd());
-}
-
 string PrintableDecl(const Decl* decl, bool terse/*=true*/) {
   // Use the terse flag to limit the level of output to one line.
   clang::PrintingPolicy policy = decl->getASTContext().getPrintingPolicy();

--- a/iwyu_ast_util.h
+++ b/iwyu_ast_util.h
@@ -428,7 +428,6 @@ const clang::DeclContext* GetDeclContext(const ASTNode* ast_node);
 // --- Printers.
 
 string PrintableLoc(clang::SourceLocation loc);
-string PrintableSourceRange(clang::SourceRange range);
 string PrintableDecl(const clang::Decl* decl, bool terse=true);
 string PrintableStmt(const clang::Stmt* stmt);
 string PrintableType(const clang::Type* type);

--- a/iwyu_lexer_utils.h
+++ b/iwyu_lexer_utils.h
@@ -11,7 +11,6 @@
 #define INCLUDE_WHAT_YOU_USE_IWYU_LEXER_UTILS_H_
 
 #include <string>                       // for string
-#include <vector>                       // for vector
 
 #include "clang/Basic/SourceLocation.h"
 
@@ -23,7 +22,6 @@ class Token;
 namespace include_what_you_use {
 
 using std::string;
-using std::vector;
 
 // For a particular source line that source_location points to,
 // returns true if the given text occurs on the line.
@@ -69,13 +67,6 @@ clang::SourceLocation GetLocationAfter(
 // If include_loc points to the second INC, we'll return '<stdio.h>'.
 string GetIncludeNameAsWritten(
     clang::SourceLocation include_loc,
-    const CharacterDataGetterInterface& data_getter);
-
-// Given the range of an #if or #elif statement, determine the
-// symbols which are arguments to "defined". This allows iwyu to
-// treat these symbols as if #ifdef was used instead.
-vector<clang::Token> FindArgumentsToDefined(
-    clang::SourceRange range,
     const CharacterDataGetterInterface& data_getter);
 
 // Get the text of a given token.

--- a/iwyu_preprocessor.h
+++ b/iwyu_preprocessor.h
@@ -177,18 +177,17 @@ class IwyuPreprocessorInfo : public clang::PPCallbacks,
   // Not needed for iwyu:
   // virtual void MacroUndefined(const clang::Token&, const clang::MacroInfo*);
 
-  void If(clang::SourceLocation loc,
-          clang::SourceRange condition_range,
-          ConditionValueKind condition_value) override;
-  void Elif(clang::SourceLocation loc,
-            clang::SourceRange condition_range,
-            ConditionValueKind condition_value,
-            clang::SourceLocation if_loc) override;
   void Ifdef(clang::SourceLocation loc, const clang::Token& id,
              const clang::MacroDefinition& definition) override;
   void Ifndef(clang::SourceLocation loc, const clang::Token& id,
               const clang::MacroDefinition& definition) override;
+  void Defined(const clang::Token& id,
+               const clang::MacroDefinition& definition,
+               clang::SourceRange range) override;
+
   // Not needed for iwyu:
+  // virtual void If();
+  // virtual void Elif();
   // virtual void Else();
   // virtual void Endif();
 
@@ -269,8 +268,6 @@ class IwyuPreprocessorInfo : public clang::PPCallbacks,
 
   // As above, but get the definition location from macros_definition_loc_.
   void FindAndReportMacroUse(const string& name, clang::SourceLocation loc);
-
-  void CheckIfOrElif(clang::SourceRange range);
 
   // Final-processing routines done after all header files have been read.
   void DoFinalMacroChecks();


### PR DESCRIPTION
Clang r350891 changed the raw lexer so it asserts for IWYU's use
case.

Instead of re-lexing to catch symbols inside defined(), use a
PPCallbacks::Defined override to capture the tokens directly
(presumably, Defined did not exist when the open-coded parser was
added).

This removes a lot of code, including the PPCallbacks for If and Elif,
which are no longer necessary.

No functional change.