### PR TITLE
Ignore compile_commands.json, .gdb_history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ __pycache__
 
 # Visual Studio Code
 .vscode
+
+.gdb_history
+compile_commands.json


### PR DESCRIPTION
Add a couple of convenient things to `.gitignore`.

* `.gdb_history`, the command history file for gdb (which gets put in $PWD when enabled).
* `compile_commands.json`, which needs to be in the source dir for some tools to find it automatically.