### PR TITLE
Refactor: Rename `built_ins*` to `builtins*`

### DIFF
--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -919,7 +919,7 @@ bool IsDefaultNewOrDelete(const FunctionDecl* decl,
                           const string& decl_loc_as_quoted_include) {
   // Clang will report <new> as the location of the default new and
   // delete operators if <new> is included. Otherwise, it reports the
-  // (fake) file "<built_in>".
+  // (fake) file "<built-in>".
   if (decl_loc_as_quoted_include != "<new>" &&
       !IsBuiltinFile(GetFileEntry(decl)))
     return false;

--- a/run_iwyu_tests.py
+++ b/run_iwyu_tests.py
@@ -63,7 +63,7 @@ class OneIwyuTest(unittest.TestCase):
     flags_map = {
       'backwards_includes.cc': [self.CheckAlsoExtension('-d*.h')],
       'badinc.cc': [self.MappingFile('badinc.imp')],
-      'built_ins_with_mapping.cc': [self.MappingFile('built_ins_with_mapping.imp')],
+      'builtins_with_mapping.cc': [self.MappingFile('builtins_with_mapping.imp')],
       'check_also.cc': [self.CheckAlsoExtension('-d1.h')],
       'implicit_ctor.cc': [self.CheckAlsoExtension('-d1.h')],
       'iwyu_stricter_than_cpp.cc': [self.CheckAlsoExtension('-autocast.h'),
@@ -126,7 +126,7 @@ class OneIwyuTest(unittest.TestCase):
       'backwards_includes.cc': ['.'],
       'badinc.cc': ['.'],
       'badinc-extradef.cc': ['.'],
-      'built_ins_with_mapping.cc': ['.'],
+      'builtins_with_mapping.cc': ['.'],
       'funcptrs.cc': ['.'],
       'casts.cc': ['.'],
       'catch.cc': ['.'],

--- a/tests/cxx/built_ins_with_mapping.imp
+++ b/tests/cxx/built_ins_with_mapping.imp
@@ -1,9 +1,0 @@
-# Header mappings for IWYU tests.
-# Note that some headers listed here don't actually exist; we just want
-# IWYU to suggest using them
-[
-  { symbol: ["__builtin_expect", "private", "\"tests/cxx/built_ins_with_mapping-d2.h\"", "public"] },
-  { symbol: ["__builtin_strlen", "private", "\"tests/cxx/built_ins_with_mapping-d3.h\"", "public"] },
-  { symbol: ["__builtin_strcmp", "private", "\"tests/cxx/built_ins_with_mapping.h\"", "public"] },
-  { symbol: ["__builtin_invented_for_test", "private", "\"tests/cxx/built_ins_with_mapping.h\"", "public"] },
-]

--- a/tests/cxx/builtins_new_included.cc
+++ b/tests/cxx/builtins_new_included.cc
@@ -1,4 +1,4 @@
-//===--- built_ins_new_included.cc - test input file for iwyu -------------===//
+//===--- builtins_new_included.cc - test input file for iwyu --------------===//
 //
 //                     The LLVM Compiler Infrastructure
 //
@@ -21,11 +21,11 @@ void foo() {
 
 /**** IWYU_SUMMARY
 
-tests/cxx/built_ins_new_included.cc should add these lines:
+tests/cxx/builtins_new_included.cc should add these lines:
 
-tests/cxx/built_ins_new_included.cc should remove these lines:
+tests/cxx/builtins_new_included.cc should remove these lines:
 - #include <new>  // lines XX-XX
 
-The full include-list for tests/cxx/built_ins_new_included.cc:
+The full include-list for tests/cxx/builtins_new_included.cc:
 
 ***** IWYU_SUMMARY */

--- a/tests/cxx/builtins_no_includes.cc
+++ b/tests/cxx/builtins_no_includes.cc
@@ -1,4 +1,4 @@
-//===--- built_ins_no_includes.cc - test input file for iwyu --------------===//
+//===--- builtins_no_includes.cc - test input file for iwyu ---------------===//
 //
 //                     The LLVM Compiler Infrastructure
 //
@@ -19,6 +19,6 @@ void foo() {
 
 /**** IWYU_SUMMARY
 
-(tests/cxx/built_ins_no_includes.cc has correct #includes/fwd-decls)
+(tests/cxx/builtins_no_includes.cc has correct #includes/fwd-decls)
 
 ***** IWYU_SUMMARY */

--- a/tests/cxx/builtins_template.cc
+++ b/tests/cxx/builtins_template.cc
@@ -1,4 +1,4 @@
-//===--- built_ins_template.cc - test input file for iwyu -----------------===//
+//===--- builtins_template.cc - test input file for iwyu ------------------===//
 //
 //                     The LLVM Compiler Infrastructure
 //
@@ -17,6 +17,6 @@ __make_integer_seq<A, int, 5> seq;
 
 /**** IWYU_SUMMARY
 
-(tests/cxx/built_ins_template.cc has correct #includes/fwd-decls)
+(tests/cxx/builtins_template.cc has correct #includes/fwd-decls)
 
 ***** IWYU_SUMMARY */

--- a/tests/cxx/builtins_with_mapping-d1.h
+++ b/tests/cxx/builtins_with_mapping-d1.h
@@ -1,4 +1,4 @@
-//===--- built_ins_with_mapping-d1.h - test input file for iwyu -----------===//
+//===--- builtins_with_mapping-d1.h - test input file for iwyu ------------===//
 //
 //                     The LLVM Compiler Infrastructure
 //
@@ -7,9 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_BUILT_INS_WITH_MAPPING_D1_H_
-#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_BUILT_INS_WITH_MAPPING_D1_H_
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_BUILTINS_WITH_MAPPING_D1_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_BUILTINS_WITH_MAPPING_D1_H_
 
 int i = __builtin_expect(0, 0);
 
-#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_BUILT_INS_WITH_MAPPING_D1_H_
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_BUILTINS_WITH_MAPPING_D1_H_

--- a/tests/cxx/builtins_with_mapping.cc
+++ b/tests/cxx/builtins_with_mapping.cc
@@ -1,4 +1,4 @@
-//===--- built_ins_with_mapping.cc - test input file for iwyu -------------===//
+//===--- builtins_with_mapping.cc - test input file for iwyu --------------===//
 //
 //                     The LLVM Compiler Infrastructure
 //
@@ -7,8 +7,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "tests/cxx/built_ins_with_mapping.h"
-#include "tests/cxx/built_ins_with_mapping-d1.h"
+#include "tests/cxx/builtins_with_mapping.h"
+#include "tests/cxx/builtins_with_mapping-d1.h"
 
 // Normally if we use a builtin function IWYU will ignore uses of it.
 // However, if there is a mapping defined for that builtin then it should be
@@ -25,16 +25,16 @@ int k = __builtin_strlen("");
 
 /**** IWYU_SUMMARY
 
-tests/cxx/built_ins_with_mapping.cc should add these lines:
-#include "tests/cxx/built_ins_with_mapping-d2.h"
-#include "tests/cxx/built_ins_with_mapping-d3.h"
+tests/cxx/builtins_with_mapping.cc should add these lines:
+#include "tests/cxx/builtins_with_mapping-d2.h"
+#include "tests/cxx/builtins_with_mapping-d3.h"
 
-tests/cxx/built_ins_with_mapping.cc should remove these lines:
+tests/cxx/builtins_with_mapping.cc should remove these lines:
 
-The full include-list for tests/cxx/built_ins_with_mapping.cc:
-#include "tests/cxx/built_ins_with_mapping.h"
-#include "tests/cxx/built_ins_with_mapping-d1.h"  // for i
-#include "tests/cxx/built_ins_with_mapping-d2.h"  // for __builtin_expect
-#include "tests/cxx/built_ins_with_mapping-d3.h"  // for __builtin_strlen
+The full include-list for tests/cxx/builtins_with_mapping.cc:
+#include "tests/cxx/builtins_with_mapping.h"
+#include "tests/cxx/builtins_with_mapping-d1.h"  // for i
+#include "tests/cxx/builtins_with_mapping-d2.h"  // for __builtin_expect
+#include "tests/cxx/builtins_with_mapping-d3.h"  // for __builtin_strlen
 
 ***** IWYU_SUMMARY */

--- a/tests/cxx/builtins_with_mapping.h
+++ b/tests/cxx/builtins_with_mapping.h
@@ -1,4 +1,4 @@
-//===--- built_ins_with_mapping.h - test input file for iwyu --------------===//
+//===--- builtins_with_mapping.h - test input file for iwyu ---------------===//
 //
 //                     The LLVM Compiler Infrastructure
 //
@@ -7,8 +7,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_BUILT_INS_WITH_MAPPING_H_
-#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_BUILT_INS_WITH_MAPPING_H_
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_BUILTINS_WITH_MAPPING_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_BUILTINS_WITH_MAPPING_H_
 
 // This is to simulate the situation where a builtin exists on some compilers,
 // and not others, so we need a mapping.  However, we need to check that the
@@ -25,10 +25,10 @@ inline void f()
   __builtin_strcmp("", "");
 }
 
-#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_BUILT_INS_WITH_MAPPING_H_
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_BUILTINS_WITH_MAPPING_H_
 
 /**** IWYU_SUMMARY
 
-(tests/cxx/built_ins_with_mapping.h has correct #includes/fwd-decls)
+(tests/cxx/builtins_with_mapping.h has correct #includes/fwd-decls)
 
 ***** IWYU_SUMMARY */

--- a/tests/cxx/builtins_with_mapping.imp
+++ b/tests/cxx/builtins_with_mapping.imp
@@ -1,0 +1,9 @@
+# Header mappings for IWYU tests.
+# Note that some headers listed here don't actually exist; we just want
+# IWYU to suggest using them
+[
+  { symbol: ["__builtin_expect", "private", "\"tests/cxx/builtins_with_mapping-d2.h\"", "public"] },
+  { symbol: ["__builtin_strlen", "private", "\"tests/cxx/builtins_with_mapping-d3.h\"", "public"] },
+  { symbol: ["__builtin_strcmp", "private", "\"tests/cxx/builtins_with_mapping.h\"", "public"] },
+  { symbol: ["__builtin_invented_for_test", "private", "\"tests/cxx/builtins_with_mapping.h\"", "public"] },
+]


### PR DESCRIPTION
I've always found the `built_ins_` spelling to be hard to read, so here's a set of commits to harmonize the spelling of 'builtin' without underscores.