### PR TITLE
 Report expanded loc for uses partially in a macro

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -1391,6 +1391,16 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
     SourceLocation spelling_loc = sm->getSpellingLoc(use_loc);
     SourceLocation expansion_loc = sm->getExpansionLoc(use_loc);
 
+    SourceRange use_range = use_node.GetSourceRange();
+
+    if (use_range.getBegin().isFileID() != use_range.getEnd().isFileID()) {
+      VERRS(4) << "Use of decl '" << PrintableDecl(decl)
+               << "' is partially inside a macro."
+                  " Attributing to expansion location at "
+               << PrintableLoc(expansion_loc) << ".\n";
+      return expansion_loc;
+    }
+
     // If the file defining the macro contains a forward decl, keep it around
     // and treat it as a hint that the expansion loc is responsible for the
     // symbol.

--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -197,6 +197,27 @@ SourceLocation ASTNode::GetLocation() const {
   return retval;
 }
 
+clang::SourceRange ASTNode::GetSourceRange() const {
+  switch (kind_) {
+    case kDeclKind:
+      return as_decl_->getSourceRange();
+    case kStmtKind:
+      return as_stmt_->getSourceRange();
+    case kTypelocKind:
+      return as_typeloc_->getSourceRange();
+    case kNNSLocKind:
+      return as_nnsloc_->getSourceRange();
+    case kTemplateArgumentLocKind:
+      return as_template_argloc_->getSourceRange();
+    case kTypeKind:
+    case kNNSKind:
+    case kTemplateNameKind:
+    case kTemplateArgumentKind:
+      return SourceRange();
+  }
+  CHECK_UNREACHABLE_("Unexpected kind of ASTNode");
+}
+
 bool ASTNode::FillLocationIfKnown(SourceLocation* loc) const {
   using include_what_you_use::GetLocation;
   switch (kind_) {

--- a/iwyu_ast_util.h
+++ b/iwyu_ast_util.h
@@ -140,6 +140,8 @@ class ASTNode {
   // current node knows its location, returns an invalid SourceLocation.
   clang::SourceLocation GetLocation() const;
 
+  clang::SourceRange GetSourceRange() const;
+
   // Returns true if this node points to the exact same
   // decl/typeloc/etc as the one you pass in.  For Decl/Stmt/Type, the
   // pointer is canonical (every instance of type X has the same

--- a/tests/cxx/macro_and_template-d1.h
+++ b/tests/cxx/macro_and_template-d1.h
@@ -1,0 +1,8 @@
+
+// macro_and_template-d1.h
+#define MACRO() MacroClass()
+
+class MacroClass {
+public:
+  template <typename T> T func() { return T(); }
+};

--- a/tests/cxx/macro_and_template-d2.h
+++ b/tests/cxx/macro_and_template-d2.h
@@ -1,0 +1,2 @@
+// macro_and_template-d2.h
+class Test {};

--- a/tests/cxx/macro_and_template.cc
+++ b/tests/cxx/macro_and_template.cc
@@ -1,0 +1,14 @@
+// macro_and_template.cc
+#include "macro_and_template-d1.h"
+#include "macro_and_template-d2.h"
+
+
+void hello() {
+  MACRO().func<Test>();
+}
+
+/**** IWYU_SUMMARY
+
+(tests/cxx/macro_and_template.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
This is a WIP to fix #659 and similar cases.

Not yet completely done, but I wanted to put it out there to a start a discussion and get the general feeling  :)

Some things that I still want to do:
 - [ ] Verify that no macro is expanded throughout the source range, not just at the ends.
 - [ ] Add more complex test scenarios
 - [ ] Check if other open issues would/could be easily fixed by this


