### PR TITLE
Getopt fixes

### DIFF
--- a/iwyu_globals.cc
+++ b/iwyu_globals.cc
@@ -62,10 +62,6 @@ static void PrintHelp(const char* extra_msg) {
          "        to the default of reporting for the input .cc file and its\n"
          "        associated .h files).  This flag may be specified multiple\n"
          "        times to specify multiple glob patterns.\n"
-         "   --cwd=<dir>: tells iwyu what the current working directory is.\n"
-         "   --howtodebug[=<filename>]: with no arg, prints instructions on\n"
-         "        how to run iwyu under gdb for the input file, and exits.\n"
-         "        With an arg, prints only when input file matches the arg.\n"
          "   --mapping_file=<filename>: gives iwyu a mapping file.\n"
          "   --no_default_mappings: do not add iwyu's default mappings.\n"
          "   --pch_in_code: mark the first include in a translation unit as a\n"
@@ -157,8 +153,7 @@ OptionsParser::~OptionsParser() {
 }
 
 CommandlineFlags::CommandlineFlags()
-    : howtodebug(CommandlineFlags::kUnspecified),
-      transitive_includes_only(false),
+    : transitive_includes_only(false),
       verbose(getenv("IWYU_VERBOSE") ? atoi(getenv("IWYU_VERBOSE")) : 1),
       no_default_mappings(false),
       max_line_length(80),
@@ -173,8 +168,6 @@ CommandlineFlags::CommandlineFlags()
 int CommandlineFlags::ParseArgv(int argc, char** argv) {
   static const struct option longopts[] = {
     {"check_also", required_argument, nullptr, 'c'},  // can be specified >once
-    {"howtodebug", optional_argument, nullptr, 'd'},
-    {"cwd", required_argument, nullptr, 'p'},
     {"transitive_includes_only", no_argument, nullptr, 't'},
     {"verbose", required_argument, nullptr, 'v'},
     {"mapping_file", required_argument, nullptr, 'm'},
@@ -188,12 +181,10 @@ int CommandlineFlags::ParseArgv(int argc, char** argv) {
     {"cxx17ns", no_argument, nullptr, 'C'},
     {nullptr, 0, nullptr, 0}
   };
-  static const char shortopts[] = "d::p:v:c:m:n";
+  static const char shortopts[] = "v:c:m:n";
   while (true) {
     switch (getopt_long(argc, argv, shortopts, longopts, nullptr)) {
       case 'c': AddGlobToReportIWYUViolationsFor(optarg); break;
-      case 'd': howtodebug = optarg ? optarg : ""; break;
-      case 'p': cwd = optarg; break;
       case 't': transitive_includes_only = true; break;
       case 'v': verbose = atoi(optarg); break;
       case 'm': mapping_files.push_back(optarg); break;
@@ -255,11 +246,6 @@ static int ParseInterceptedCommandlineFlags(int argc, char** argv) {
   return optind;  // unreachable
 }
 
-// The default value for the --howtodebug flag.  Indicates that the
-// flag isn't present.  It's a special, reserved value, and a user
-// isn't expected to type it directly.
-const char CommandlineFlags::kUnspecified[] = "<flag-unspecified>";
-
 // Handles all iwyu-specific flags, like --verbose.  Returns the index into
 // argv past all the iwyu commandline flags.
 static int ParseIwyuCommandlineFlags(int argc, char** argv) {
@@ -267,15 +253,6 @@ static int ParseIwyuCommandlineFlags(int argc, char** argv) {
   commandline_flags = new CommandlineFlags;
   const int retval = commandline_flags->ParseArgv(argc, argv);
   SetVerboseLevel(commandline_flags->verbose);
-
-  if (!commandline_flags->cwd.empty()) {
-    printf("-p/--cwd not yet implemented\n");
-    exit(EXIT_INVALIDARGS);
-  }
-  if (commandline_flags->howtodebug != CommandlineFlags::kUnspecified) {
-    printf("-d/--howtodebug not yet implemented\n");
-    exit(EXIT_INVALIDARGS);
-  }
 
   VERRS(4) << "Setting verbose-level to " << commandline_flags->verbose << "\n";
 

--- a/iwyu_globals.cc
+++ b/iwyu_globals.cc
@@ -174,9 +174,9 @@ int CommandlineFlags::ParseArgv(int argc, char** argv) {
     {"no_default_mappings", no_argument, nullptr, 'n'},
     {"prefix_header_includes", required_argument, nullptr, 'x'},
     {"pch_in_code", no_argument, nullptr, 'h'},
-    {"max_line_length", optional_argument, nullptr, 'l'},
-    {"no_comments", optional_argument, nullptr, 'o'},
-    {"no_fwd_decls", optional_argument, nullptr, 'f'},
+    {"max_line_length", required_argument, nullptr, 'l'},
+    {"no_comments", no_argument, nullptr, 'o'},
+    {"no_fwd_decls", no_argument, nullptr, 'f'},
     {"quoted_includes_first", no_argument, nullptr, 'q' },
     {"cxx17ns", no_argument, nullptr, 'C'},
     {nullptr, 0, nullptr, 0}

--- a/iwyu_globals.h
+++ b/iwyu_globals.h
@@ -85,11 +85,8 @@ struct CommandlineFlags {
   enum PrefixHeaderIncludePolicy { kAdd, kKeep, kRemove };
   CommandlineFlags();                     // sets flags to default values
   int ParseArgv(int argc, char** argv);   // parses flags from argv
-  static const char kUnspecified[];  // for -d, which takes an optional arg
 
   set<string> check_also;  // -c: globs to report iwyu violations for
-  string howtodebug;       // -d: file to print gdb-invoking instruction for
-  string cwd;              // -p: what directory was iwyu invoked from?
   bool transitive_includes_only;   // -t: don't add 'new' #includes to files
   int verbose;             // -v: how much information to emit as we parse
   vector<string> mapping_files; // -m: mapping files


### PR DESCRIPTION
Fix issue #663 by correctly marking options as `required_argument` and `no_argument` respectively.

Also remove unused and never-implemented switches `--how_to_debug` and `--cwd`.