### PR TITLE
Re-export types to overridden method signatures

### DIFF
--- a/iwyu_ast_util.h
+++ b/iwyu_ast_util.h
@@ -207,6 +207,17 @@ class ASTNode {
     return false;
   }
 
+  template <typename To>
+  const To* GetAncestorOfType() const {
+    const ASTNode* ast_node = this;
+    for (; ast_node != nullptr; ast_node = ast_node->parent()) {
+      if (const To* to = ast_node->GetAs<To>()) {
+        return to;
+      }
+    }
+    return nullptr;
+  }
+
   template<typename To> const To* GetParentAs() const {
     return GetAncestorAs<To>(1);
   }

--- a/iwyu_output.cc
+++ b/iwyu_output.cc
@@ -1560,6 +1560,17 @@ void IwyuFileInfo::CalculateIwyuViolations(vector<OneUse>* uses) {
   VERRS(6) << "--- Calculating IWYU violations for "
            << GetFilePath(file_) << " ---\n";
 
+  // Remove any uses part of an override decl -- they are covered for by the
+  // base class from where they were overridden, and the header for the base
+  // class must already be included because we derive from it.
+  for (OneUse& use : *uses) {
+    if (use.flags() & UF_OverrideDecl) {
+      VERRS(6) << "Ignoring use of " << use.symbol_name() << " ("
+               << use.PrintableUseLoc() << "): re-exported from base class\n";
+      use.set_ignore_use();
+    }
+  }
+
   // We have to do the steps in order, because a forward-declare use may
   // turn into a full use, and need to be processed in the full-use step
   // too.

--- a/iwyu_use_flags.h
+++ b/iwyu_use_flags.h
@@ -19,6 +19,7 @@ const UseFlags UF_None = 0;
 const UseFlags UF_InCxxMethodBody = 1;       // use is inside a C++ method body
 const UseFlags UF_FunctionDfn = 2;           // use is a function being defined
 const UseFlags UF_ExplicitInstantiation = 4; // use targets an explicit instantiation
+const UseFlags UF_OverrideDecl = 8;          // use is part of an override decl
 }
 
 #endif

--- a/run_iwyu_tests.py
+++ b/run_iwyu_tests.py
@@ -184,6 +184,7 @@ class OneIwyuTest(unittest.TestCase):
       'non_transitive_include.cc': ['.'],
       'operator_new.cc': ['.'],
       'overloaded_class.cc': ['.'],
+      'reexport_overridden.cc': ['.'],
       'pch_in_code.cc': ['.'],
       'pointer_arith.cc': ['.'],
       'placement_new.cc': ['.'],

--- a/tests/cxx/reexport_overridden-d1.h
+++ b/tests/cxx/reexport_overridden-d1.h
@@ -1,0 +1,22 @@
+//===--- reexport_overridden-d1.h - test input file for iwyu --------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/indirect.h"
+
+// From override_reexport-indirect.h
+class FwdRetType;
+
+class Base {
+ public:
+  virtual IndirectClass GetIndirect();
+  virtual FwdRetType ReturnType();
+  virtual FwdRetType ReturnTypeUnusedInBody();
+  virtual void ArgumentUnused(const IndirectClass& x);
+  virtual void ArgumentUnusedInline(const IndirectClass&);
+};

--- a/tests/cxx/reexport_overridden-d2.h
+++ b/tests/cxx/reexport_overridden-d2.h
@@ -1,0 +1,10 @@
+//===--- reexport_overridden-d2.h - test input file for iwyu --------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/reexport_overridden-indirect.h"

--- a/tests/cxx/reexport_overridden-indirect.h
+++ b/tests/cxx/reexport_overridden-indirect.h
@@ -1,0 +1,10 @@
+//===--- reexport_overridden-indirect.h - test input file for iwyu --------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+class FwdRetType {};

--- a/tests/cxx/reexport_overridden.cc
+++ b/tests/cxx/reexport_overridden.cc
@@ -1,0 +1,62 @@
+//===--- reexport_overridden.cc - test input file for iwyu ----------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU has a special rule for overridden method declarations: any types in the
+// signature should be ignored for IWYU's purposes, because the derived
+// declaration must include the base header, and thereby all its types.
+//
+// However, *other* uses, such as in the method definition (both signature and
+// body), still need to fend for themselves.
+
+#include "tests/cxx/reexport_overridden.h"
+#include "tests/cxx/direct.h"
+#include "tests/cxx/reexport_overridden-d2.h"
+
+// IndirectClass is reexported from Base to the Derived
+IndirectClass Derived::GetIndirect() {
+  // IWYU: IndirectClass is...*indirect.h
+  return IndirectClass();
+}
+
+// Similarly for FwdRetType -- Base reexports its forward declarations
+FwdRetType Derived::ReturnType() {
+  // IWYU: FwdRetType is...*reexport_overridden-indirect.h
+  return FwdRetType();
+}
+
+// Even if the return type is not mentioned in the body, the compiler requires
+// the complete type for the method definition.
+
+// Simulate abort().
+__attribute__((__noreturn__)) void abort();
+
+FwdRetType Derived::ReturnTypeUnusedInBody() {
+  abort();
+}
+
+// No diagnostic expected for unused arguments.
+void Derived::ArgumentUnused(const IndirectClass&) {
+}
+
+/**** IWYU_SUMMARY
+
+tests/cxx/reexport_overridden.cc should add these lines:
+#include "tests/cxx/indirect.h"
+#include "tests/cxx/reexport_overridden-indirect.h"
+
+tests/cxx/reexport_overridden.cc should remove these lines:
+- #include "tests/cxx/direct.h"  // lines XX-XX
+- #include "tests/cxx/reexport_overridden-d2.h"  // lines XX-XX
+
+The full include-list for tests/cxx/reexport_overridden.cc:
+#include "tests/cxx/reexport_overridden.h"
+#include "tests/cxx/indirect.h"  // for IndirectClass
+#include "tests/cxx/reexport_overridden-indirect.h"  // for FwdRetType
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/reexport_overridden.h
+++ b/tests/cxx/reexport_overridden.h
@@ -1,0 +1,37 @@
+//===--- reexport_overridden.h - test input file for iwyu -----------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// In order for a method to be overridden, its base class must already be
+// included, which must in itself be self-sufficient. Thus, the function
+// signature types should not trigger IWYU warnings here.
+
+#include "tests/cxx/reexport_overridden-d1.h"
+
+class Derived : public Base {
+ public:
+  // Return type fully defined in Base.
+  IndirectClass GetIndirect() override;
+
+  // Return types forward-declared in Base.
+  FwdRetType ReturnType() override;
+  FwdRetType ReturnTypeUnusedInBody() override;
+
+  // Unused argument available from Base.
+  void ArgumentUnused(const IndirectClass& x) override;
+
+  // Unused argument available from Base, in inline method.
+  void ArgumentUnusedInline(const IndirectClass& x) override {
+  }
+};
+
+/**** IWYU_SUMMARY
+
+(tests/cxx/reexport_overridden.h has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
When a method overrides a virtual method in a base class, all types
mentioned in the signature will already be covered for by the base's
header.

As we must derive from a base to override methods, and derivation
requires a complete type, we already know that we've included the base
header to be able to override a method.

Exploit this and ignore all uses in overridden method signatures as they
must already be satisifed for the code to compile.

For example:

    // base.h
    #include <string>
    struct Base {
      std::string method() const;
    };

    // derived.h
    #include "base.h"
    struct Derived : public Base {
      // No warning about <string> here.
      std::string method();
    };

But this does not extend to the all uses of the type. For example, if we
use the type in the body of an overridden method, the definition file
must still include the type:

    // derived.cc
    #include "derived.h"

    // This mention of std::string is ignored, as above.
    std::string Derived::method() {
      // But this requires <string>.
      return std::string("abc");
    }

This reduces the number of required includes in headers significantly.