### PR TITLE
Convert CreateCompilerInstance function to IwyuDriver class

### DIFF
--- a/iwyu_driver.h
+++ b/iwyu_driver.h
@@ -10,15 +10,40 @@
 #ifndef INCLUDE_WHAT_YOU_USE_IWYU_DRIVER_H_
 #define INCLUDE_WHAT_YOU_USE_IWYU_DRIVER_H_
 
+#include <memory>
+#include "llvm/Option/ArgList.h"
+
+namespace llvm {
+  namespace opt {
+    class InputArgList;
+  }
+}
 namespace clang {
-class CompilerInstance;
+  class CompilerInstance;
+  namespace driver {
+    class Compilation;
+    class Driver;
+  }
 }
 
 namespace include_what_you_use {
 
-// Creates a CompilerInstance object based on the commandline
-// arguments, or NULL if there's an error of some sort.
-clang::CompilerInstance* CreateCompilerInstance(int argc, const char **argv);
+class IwyuDriver {
+public:
+  IwyuDriver(int argc, const char **argv);
+  ~IwyuDriver();
+  std::shared_ptr<clang::CompilerInstance> getCompilerInstance();
+  std::shared_ptr<clang::driver::Compilation> getCompilation();
+  const llvm::opt::ArgList & getArgs();
+  private:
+  // Creates a CompilerInstance object based on the commandline
+  // arguments, or NULL if there's an error of some sort.
+  void CreateCompilerInstance(int argc, const char **argv);
+  std::shared_ptr<clang::CompilerInstance> compilerInstance;
+  std::shared_ptr<clang::driver::Compilation> compilation;
+  std::shared_ptr<clang::driver::Driver> driver;
+  std::shared_ptr<llvm::opt::InputArgList> Args;
+};
 
 }  // namespace include_what_you_use
 

--- a/iwyu_globals.cc
+++ b/iwyu_globals.cc
@@ -18,6 +18,7 @@
 #include <utility>                      // for make_pair, pair
 
 #include "iwyu_cache.h"
+#include "iwyu_driver.h"
 #include "iwyu_include_picker.h"
 #include "iwyu_getopt.h"
 #include "iwyu_lexer_utils.h"
@@ -32,6 +33,7 @@
 #include "clang/AST/PrettyPrinter.h"
 #include "clang/Basic/FileManager.h"
 #include "clang/Basic/Version.h"
+#include "clang/Driver/Compilation.h"
 #include "clang/Lex/HeaderSearch.h"
 
 using clang::DirectoryEntry;
@@ -315,7 +317,10 @@ void InitGlobals(clang::SourceManager* sm, clang::HeaderSearch* header_search) {
   vector<HeaderSearchPath> search_paths =
       ComputeHeaderSearchPaths(header_search);
   SetHeaderSearchPaths(search_paths);
-  include_picker = new IncludePicker(GlobalFlags().no_default_mappings);
+  include_picker = new IncludePicker(GlobalFlags().no_default_mappings,
+                                     iwyuDriver->getCompilation()->
+                                     getDefaultToolChain(),
+                                     iwyuDriver->getArgs());
   function_calls_full_use_cache = new FullUseCache;
   class_members_full_use_cache = new FullUseCache;
 
@@ -408,7 +413,10 @@ void InitGlobalsAndFlagsForTesting() {
   commandline_flags = new CommandlineFlags;
   source_manager = nullptr;
   data_getter = nullptr;
-  include_picker = new IncludePicker(GlobalFlags().no_default_mappings);
+  include_picker = new IncludePicker(GlobalFlags().no_default_mappings,
+                                     iwyuDriver->getCompilation()->
+                                     getDefaultToolChain(),
+                                     iwyuDriver->getArgs());
   function_calls_full_use_cache = new FullUseCache;
   class_members_full_use_cache = new FullUseCache;
 

--- a/iwyu_globals.h
+++ b/iwyu_globals.h
@@ -14,6 +14,7 @@
 #include <set>                          // for set
 #include <string>                       // for string
 #include <vector>                       // for vector
+#include <memory>
 
 namespace clang {
 class FileEntry;
@@ -36,9 +37,11 @@ static const int EXIT_SUCCESS_OFFSET = 2;
 using std::set;
 using std::string;
 using std::vector;
+using std::unique_ptr;
 
 class FullUseCache;
 class IncludePicker;
+class IwyuDriver;
 class SourceManagerCharacterDataGetter;
 
 // To set up the global state you need to parse options with OptionsParser when
@@ -134,6 +137,8 @@ bool ShouldReportIWYUViolationsFor(const clang::FileEntry* file);
 void AddGlobToKeepIncludes(const string& glob);
 bool ShouldKeepIncludeFor(const clang::FileEntry* file);
 
+// For holding the driver
+extern std::shared_ptr<include_what_you_use::IwyuDriver> iwyuDriver;
 }  // namespace include_what_you_use
 
 #endif  // INCLUDE_WHAT_YOU_USE_IWYU_GLOBALS_H_

--- a/iwyu_include_picker.cc
+++ b/iwyu_include_picker.cc
@@ -22,6 +22,8 @@
 #include <utility>                      // for pair, make_pair
 #include <vector>                       // for vector, vector<>::iterator
 
+#include "iwyu_globals.h"
+#include "iwyu_driver.h"
 #include "iwyu_location_util.h"
 #include "iwyu_path_util.h"
 #include "iwyu_stl_util.h"
@@ -30,6 +32,7 @@
 #include "port.h"  // for CHECK_
 
 #include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/Triple.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/ErrorOr.h"
 #include "llvm/Support/FileSystem.h"
@@ -39,6 +42,8 @@
 #include "llvm/Support/YAMLParser.h"
 #include "llvm/Support/raw_ostream.h"
 #include "clang/Basic/FileManager.h"
+#include "clang/Driver/Driver.h"
+#include "clang/Driver/Options.h"
 
 using std::find;
 using std::make_pair;
@@ -1034,11 +1039,49 @@ string FindFileInSearchPath(const vector<string>& search_path,
 
 }  // anonymous namespace
 
-IncludePicker::IncludePicker(bool no_default_mappings)
-    : has_called_finalize_added_include_lines_(false) {
+IncludePicker::IncludePicker(bool no_default_mappings,
+                             const clang::driver::ToolChain &TC,
+                             const llvm::opt::ArgList &Args)
+  : has_called_finalize_added_include_lines_(false) {
+
   if (!no_default_mappings) {
-    AddDefaultMappings();
+    if (!AddToolChainMappings(TC, Args))
+      AddDefaultMappings();
   }
+}
+
+bool IncludePicker::AddToolChainMappings(const clang::driver::ToolChain &TC,
+                                         const llvm::opt::ArgList &Args) {
+  bool TargetHandled = false;
+  bool LibCxxHandled = false;
+  if (!(Args.hasArg(clang::driver::options::OPT_nostdinc) ||
+        Args.hasArg(clang::driver::options::OPT_nostdlibinc))) {
+    // Triple specific libc
+    const llvm::Triple &Triple = TC.getTriple();
+    if (Triple.isOSLinux()) {
+      TargetHandled = true;
+    } else if (Triple.isOSFreeBSD()) {
+      TargetHandled = true;
+    }
+    if (!Args.hasArg(clang::driver::options::OPT_nostdincxx)) {
+      auto Type = TC.GetCXXStdlibType(Args);
+      switch (Type) {
+      case clang::driver::ToolChain::CST_Libcxx:
+        LibCxxHandled = true;
+        break;
+      case clang::driver::ToolChain::CST_Libstdcxx:
+        LibCxxHandled = true;
+        break;
+      }
+    } else {
+      LibCxxHandled = true;
+    }
+  } else {
+    // Set handled to true so the default mapper will not be used.
+    TargetHandled = true;
+    LibCxxHandled = true;
+  }
+  return false; // Hard code false so default mapper is still called.
 }
 
 void IncludePicker::AddDefaultMappings() {
@@ -1526,7 +1569,7 @@ void IncludePicker::AddMappingsFromFile(const string& filename,
 
         // Add the path of the file we're currently processing
         // to the search path. Allows refs to be relative to referrer.
-        vector<string> extended_search_path = 
+        vector<string> extended_search_path =
             ExtendMappingFileSearchPath(search_path,
                                         GetParentPath(absolute_path));
 

--- a/iwyu_include_picker.h
+++ b/iwyu_include_picker.h
@@ -49,18 +49,28 @@
 #include <string>                       // for string
 #include <utility>                      // for pair
 #include <vector>                       // for vector
+#include <memory>
 
 namespace clang {
 class FileEntry;
+ namespace driver {
+   class Compilation;
+   class ToolChain;
+ }
 }  // namespace clang
 
+namespace llvm {
+  namespace opt {
+    class ArgList;
+  }
+}
 namespace include_what_you_use {
 
 using std::map;
 using std::pair;
 using std::set;
+using std::shared_ptr;
 using std::string;
-
 using std::vector;
 
 struct IncludeMapEntry;
@@ -71,7 +81,9 @@ class IncludePicker {
  public:
   typedef map<string, vector<string>> IncludeMap;  // map_from to <map_to,...>
 
-  explicit IncludePicker(bool no_default_mappings);
+  explicit IncludePicker(bool no_default_mappings,
+			 const clang::driver::ToolChain &TC,
+			 const llvm::opt::ArgList &Args);
 
   // ----- Routines to dynamically modify the include-picker
 
@@ -153,6 +165,10 @@ class IncludePicker {
   // search path incrementally.
   void AddMappingsFromFile(const string& filename,
                            const vector<string>& search_path);
+
+  // Adds mapping based on Toolchain and the input Args.
+  bool AddToolChainMappings(const clang::driver::ToolChain &TC,
+                            const llvm::opt::ArgList &Args);
 
   // Adds all hard-coded default mappings.
   void AddDefaultMappings();


### PR DESCRIPTION
Show use of compile state with compile specific stub method.
IncludePicker::AddTooChainMappings.  This method is where
triple specific libc mappings and libc++ vs libstdcpp mappings
will be done.

This is part 2 of issue 
https://github.com/include-what-you-use/include-what-you-use/issues/669
