### PR TITLE
Relative includes and mappings

### DIFF
--- a/iwyu_include_picker.cc
+++ b/iwyu_include_picker.cc
@@ -1376,18 +1376,19 @@ vector<string> IncludePicker::GetCandidateHeadersForSymbolUsedFrom(
 vector<MappedInclude> IncludePicker::GetCandidateHeadersForFilepath(
     const string& filepath, const string& including_filepath) const {
   CHECK_(has_called_finalize_added_include_lines_ && "Must finalize includes");
+  string absolute_quoted_header = ConvertToQuotedInclude(filepath);
+  vector<MappedInclude> retval =
+      GetPublicValues(filepath_include_map_, absolute_quoted_header);
+
+  // We also need to consider the header itself.  Make that an option if it's
+  // public or there's no other option.
   string quoted_header;
   if (including_filepath.empty()) {
-    quoted_header = ConvertToQuotedInclude(filepath);
+    quoted_header = absolute_quoted_header;
   } else {
     quoted_header = ConvertToQuotedInclude(
         filepath, MakeAbsolutePath(GetParentPath(including_filepath)));
   }
-  vector<MappedInclude> retval =
-      GetPublicValues(filepath_include_map_, quoted_header);
-
-  // We also need to consider the header itself.  Make that an option if it's
-  // public or there's no other option.
   MappedInclude default_header(quoted_header, filepath);
   if (retval.empty() || GetVisibility(default_header, kPublic) == kPublic) {
     // Insert at front so it's the preferred option

--- a/iwyu_include_picker.h
+++ b/iwyu_include_picker.h
@@ -136,7 +136,14 @@ class IncludePicker {
   // important (which is why we return a vector, not a set): all else
   // being equal, the first element of the vector is the "best" (or
   // most standard) header for the symbol.
-  vector<string> GetCandidateHeadersForSymbol(const string& symbol) const;
+  vector<MappedInclude> GetCandidateHeadersForSymbol(
+      const string& symbol) const;
+
+  // As above, but given a specific including header it is possible to convert
+  // mapped includes to quoted include strings (because we can for example know
+  // the correct relative path for ""-style includes).
+  vector<string> GetCandidateHeadersForSymbolUsedFrom(
+      const string& symbol, const string& including_filepath) const;
 
   // Returns the set of all public header files that a given header
   // file -- specified as a full path -- would map to, as a set of
@@ -233,6 +240,11 @@ class IncludePicker {
   // "" if it's not found for some reason.
   string MaybeGetIncludeNameAsWritten(const string& includer_filepath,
                                       const string& includee_filepath) const;
+
+  // Given a collection of MappedIncludes, and a path that might include them,
+  // choose the best quoted include form for each MappedInclude.
+  vector<string> BestQuotedIncludesForIncluder(
+      const vector<MappedInclude>&, const string& including_filepath) const;
 
   // From symbols to includes.
   IncludeMap symbol_include_map_;

--- a/iwyu_include_picker.h
+++ b/iwyu_include_picker.h
@@ -67,10 +67,15 @@ struct IncludeMapEntry;
 
 enum IncludeVisibility { kUnusedVisibility, kPublic, kPrivate };
 
+// When a symbol or file is mapped to an include, that include is represented
+// by this struct.  It always has a quoted_include and may also have a path
+// (depending on its origin).
 struct MappedInclude {
-  explicit MappedInclude(const string& quoted_include);
+  explicit MappedInclude(const string& quoted_include,
+                         const string& path = {});
 
   string quoted_include;
+  string path;
 };
 
 class IncludePicker {
@@ -140,6 +145,8 @@ class IncludePicker {
   // not when #included from "qux/quux.h".  In the common case there's
   // no special-casing, and this falls back on
   // GetCandidateHeadersForFilepath().
+  // Furthermore, knowing the including file allows use to convert each
+  // MappedInclude in the result to a simple string (quoted include).
   vector<string> GetCandidateHeadersForFilepathIncludedFrom(
       const string& included_filepath, const string& including_filepath) const;
 

--- a/iwyu_include_picker.h
+++ b/iwyu_include_picker.h
@@ -84,6 +84,11 @@ class IncludePicker {
   // lists of candidate public headers to include for symbol or quoted include.
   typedef map<string, vector<MappedInclude>> IncludeMap;
 
+  // Used to track visibility as specified either in mapping files or via
+  // pragmas.  The keys are quoted includes.  The values are the
+  // visibility of the respective files.
+  typedef map<string, IncludeVisibility> VisibilityMap;
+
   explicit IncludePicker(bool no_default_mappings);
 
   // ----- Routines to dynamically modify the include-picker
@@ -101,7 +106,7 @@ class IncludePicker {
 
   // Indicate that the given quoted include should be considered
   // a "private" include.  If possible, we use the include-picker
-  // mappings to map such includes to public (not-private) includs.
+  // mappings to map such includes to public (not-private) includes.
   void MarkIncludeAsPrivate(const string& quoted_include);
 
   // Add this to say that "any file whose name matches the
@@ -196,8 +201,8 @@ class IncludePicker {
   // seen by iwyu.
   void ExpandRegexes();
 
-  // Adds an entry to filepath_visibility_map_, with error checking.
-  void MarkVisibility(const string& quoted_filepath_pattern,
+  // Adds an entry to the given VisibilityMap, with error checking.
+  void MarkVisibility(VisibilityMap* map, const string& key,
                       IncludeVisibility visibility);
 
   // Parse visibility from a string. Returns kUnusedVisibility if
@@ -233,7 +238,7 @@ class IncludePicker {
 
   // A map of all quoted-includes to whether they're public or private.
   // Quoted-includes that are not present in this map are assumed public.
-  map<string, IncludeVisibility> filepath_visibility_map_;
+  VisibilityMap include_visibility_map_;
 
   // All the includes we've seen so far, to help with globbing and
   // other dynamic mapping.  For each file, we list who #includes it.

--- a/iwyu_include_picker.h
+++ b/iwyu_include_picker.h
@@ -76,6 +76,8 @@ struct MappedInclude {
 
   string quoted_include;
   string path;
+
+  bool HasAbsoluteQuotedInclude() const;
 };
 
 class IncludePicker {
@@ -85,7 +87,7 @@ class IncludePicker {
   typedef map<string, vector<MappedInclude>> IncludeMap;
 
   // Used to track visibility as specified either in mapping files or via
-  // pragmas.  The keys are quoted includes.  The values are the
+  // pragmas.  The keys are quoted includes or paths.  The values are the
   // visibility of the respective files.
   typedef map<string, IncludeVisibility> VisibilityMap;
 
@@ -108,6 +110,11 @@ class IncludePicker {
   // a "private" include.  If possible, we use the include-picker
   // mappings to map such includes to public (not-private) includes.
   void MarkIncludeAsPrivate(const string& quoted_include);
+
+  // Indicate that the given path should be considered
+  // a "private" include.  If possible, we use the include-picker
+  // mappings to map such includes to public (not-private) includes.
+  void MarkPathAsPrivate(const string& path);
 
   // Add this to say that "any file whose name matches the
   // friend_regex is allowed to include includee_filepath".  The regex
@@ -209,10 +216,10 @@ class IncludePicker {
   // string is not recognized.
   IncludeVisibility ParseVisibility(const string& visibility) const;
 
-  // Return the visibility of a given quoted_include if known, else
+  // Return the visibility of a given mapped include if known, else
   // kUnusedVisibility.
   IncludeVisibility GetVisibility(
-      const string& quoted_include,
+      const MappedInclude&,
       IncludeVisibility default_value = kUnusedVisibility) const;
 
   // For the given key, return the vector of values associated with
@@ -239,8 +246,15 @@ class IncludePicker {
   IncludeMap filepath_include_map_;
 
   // A map of all quoted-includes to whether they're public or private.
-  // Quoted-includes that are not present in this map are assumed public.
+  // Files whose visibility cannot be determined by this map nor the one
+  // below are assumed public.
   VisibilityMap include_visibility_map_;
+
+  // A map of paths to whether they're public or private.
+  // Files whose visibility cannot be determined by this map nor the one
+  // above are assumed public.
+  // The include_visibility_map_ takes priority over this one.
+  VisibilityMap path_visibility_map_;
 
   // All the includes we've seen so far, to help with globbing and
   // other dynamic mapping.  For each file, we list who #includes it.

--- a/iwyu_include_picker.h
+++ b/iwyu_include_picker.h
@@ -211,7 +211,9 @@ class IncludePicker {
 
   // Return the visibility of a given quoted_include if known, else
   // kUnusedVisibility.
-  IncludeVisibility GetVisibility(const string& quoted_include) const;
+  IncludeVisibility GetVisibility(
+      const string& quoted_include,
+      IncludeVisibility default_value = kUnusedVisibility) const;
 
   // For the given key, return the vector of values associated with
   // that key, or an empty vector if the key does not exist in the

--- a/iwyu_output.cc
+++ b/iwyu_output.cc
@@ -1257,13 +1257,14 @@ void ProcessFullUse(OneUse* use,
     // mapping to choose, and it's important we use the one that iwyu
     // will pick later).  TODO(csilvers): figure out that case too.
     const IncludePicker& picker = GlobalIncludePicker();
-    const vector<string>& method_dfn_files =
+    const vector<MappedInclude>& method_dfn_files =
         picker.GetCandidateHeadersForFilepath(GetFilePath(decl_file_entry));
-    const vector<string>& parent_dfn_files =
+    const vector<MappedInclude>& parent_dfn_files =
         picker.GetCandidateHeadersForFilepath(GetFilePath(parent_file_entry));
     bool same_file;
     if (method_dfn_files.size() == 1 && parent_dfn_files.size() == 1) {
-      same_file = (method_dfn_files[0] == parent_dfn_files[0]);
+      same_file = (method_dfn_files[0].quoted_include ==
+          parent_dfn_files[0].quoted_include);
     } else {
       // Fall back on just checking the filenames: can't figure out public.
       same_file = (decl_file_entry == parent_file_entry);
@@ -2082,7 +2083,8 @@ void IwyuFileInfo::HandlePreprocessingDone() {
         ERRSYM(file_) << "Mark " << quoted_file_
                       << " as public header for " << private_include
                       << " because used macro is defined by includer.\n";
-        MutableGlobalIncludePicker()->AddMapping(private_include, quoted_file_);
+        MutableGlobalIncludePicker()->AddMapping(private_include,
+                                                 MappedInclude(quoted_file_));
         MutableGlobalIncludePicker()->MarkIncludeAsPrivate(private_include);
       }
     }

--- a/iwyu_output.cc
+++ b/iwyu_output.cc
@@ -295,11 +295,13 @@ void OneUse::SetPublicHeaders() {
   // who we map to.
   CHECK_(suggested_header_.empty() && "Should not need a public header here");
   const IncludePicker& picker = GlobalIncludePicker();   // short alias
+  const string use_path = GetFilePath(use_loc_);
   // If the symbol has a special mapping, use it, otherwise map its file.
-  public_headers_ = picker.GetCandidateHeadersForSymbol(symbol_name_);
+  public_headers_ = picker.GetCandidateHeadersForSymbolUsedFrom(
+      symbol_name_, use_path);
   if (public_headers_.empty())
     public_headers_ = picker.GetCandidateHeadersForFilepathIncludedFrom(
-        decl_filepath_, GetFilePath(use_loc_));
+        decl_filepath_, use_path);
   if (public_headers_.empty())
     public_headers_.push_back(ConvertToQuotedInclude(decl_filepath_));
 }

--- a/iwyu_output.cc
+++ b/iwyu_output.cc
@@ -2083,8 +2083,8 @@ void IwyuFileInfo::HandlePreprocessingDone() {
         ERRSYM(file_) << "Mark " << quoted_file_
                       << " as public header for " << private_include
                       << " because used macro is defined by includer.\n";
-        MutableGlobalIncludePicker()->AddMapping(private_include,
-                                                 MappedInclude(quoted_file_));
+        MutableGlobalIncludePicker()->AddMapping(
+            private_include, MappedInclude(quoted_file_, GetFilePath(file_)));
         MutableGlobalIncludePicker()->MarkIncludeAsPrivate(private_include);
       }
     }

--- a/iwyu_preprocessor.cc
+++ b/iwyu_preprocessor.cc
@@ -410,13 +410,14 @@ void IwyuPreprocessorInfo::MaybeProtectInclude(
              LineHasText(includer_loc, "/* IWYU pragma: export") ||
              HasOpenBeginExports(includer)) {
     protect_reason = "pragma_export";
-    const string quoted_includer =
-        ConvertToQuotedInclude(GetFilePath(includer));
-    MutableGlobalIncludePicker()->AddMapping(include_name_as_written,
-                                             MappedInclude(quoted_includer));
+    const string includer_path = GetFilePath(includer);
+    const string quoted_includer = ConvertToQuotedInclude(includer_path);
+    MutableGlobalIncludePicker()->AddMapping(
+        include_name_as_written,
+        MappedInclude(quoted_includer, includer_path));
     ERRSYM(includer) << "Adding pragma-export mapping: "
-                     << include_name_as_written << " -> " << quoted_includer
-                     << "\n";
+                     << include_name_as_written << " -> "
+                     << quoted_includer << "\n";
 
   // We also always keep #includes of .c files: iwyu doesn't touch those.
   // TODO(csilvers): instead of IsHeaderFile, check if the file has

--- a/iwyu_preprocessor.cc
+++ b/iwyu_preprocessor.cc
@@ -238,11 +238,10 @@ void IwyuPreprocessorInfo::HandlePragmaComment(SourceRange comment_range) {
   }
 
   if (MatchOneToken(tokens, "private", 1, begin_loc)) {
-    const string quoted_this_file
-        = ConvertToQuotedInclude(GetFilePath(begin_loc));
-    MutableGlobalIncludePicker()->MarkIncludeAsPrivate(quoted_this_file);
-    ERRSYM(this_file_entry) << "Adding private include: "
-                                    << quoted_this_file << "\n";
+    const string path_this_file = GetFilePath(begin_loc);
+    MutableGlobalIncludePicker()->MarkPathAsPrivate(path_this_file);
+    ERRSYM(this_file_entry) << "Adding private path: "
+                            << path_this_file << "\n";
     return;
   }
 

--- a/iwyu_preprocessor.cc
+++ b/iwyu_preprocessor.cc
@@ -228,7 +228,8 @@ void IwyuPreprocessorInfo::HandlePragmaComment(SourceRange comment_range) {
 
     const string quoted_this_file
         = ConvertToQuotedInclude(GetFilePath(begin_loc));
-    MutableGlobalIncludePicker()->AddMapping(quoted_this_file, suggested);
+    MutableGlobalIncludePicker()->AddMapping(quoted_this_file,
+                                             MappedInclude(suggested));
     MutableGlobalIncludePicker()->MarkIncludeAsPrivate(quoted_this_file);
     ERRSYM(this_file_entry) << "Adding private pragma-mapping: "
                             << quoted_this_file << " -> "
@@ -343,8 +344,8 @@ void IwyuPreprocessorInfo::ProcessHeadernameDirectivesInFile(
     for (string& public_include : public_includes) {
       StripWhiteSpace(&public_include);
       const string quoted_header_name = "<" + public_include + ">";
-      MutableGlobalIncludePicker()->AddMapping(quoted_private_include,
-                                               quoted_header_name);
+      MutableGlobalIncludePicker()->AddMapping(
+          quoted_private_include, MappedInclude(quoted_header_name));
       MutableGlobalIncludePicker()->MarkIncludeAsPrivate(
           quoted_private_include);
       ERRSYM(GetFileEntry(current_loc)) << "Adding @headername mapping: "
@@ -412,7 +413,7 @@ void IwyuPreprocessorInfo::MaybeProtectInclude(
     const string quoted_includer =
         ConvertToQuotedInclude(GetFilePath(includer));
     MutableGlobalIncludePicker()->AddMapping(include_name_as_written,
-                                             quoted_includer);
+                                             MappedInclude(quoted_includer));
     ERRSYM(includer) << "Adding pragma-export mapping: "
                      << include_name_as_written << " -> " << quoted_includer
                      << "\n";
@@ -847,12 +848,13 @@ void IwyuPreprocessorInfo::PopulateIntendsToProvideMap() {
   map<const FileEntry*, set<const FileEntry*>> private_headers_behind;
   for (const auto& fileinfo : iwyu_file_info_map_) {
     const FileEntry* header = fileinfo.first;
-    const vector<string> public_headers_for_header =
+    const vector<MappedInclude> public_headers_for_header =
         GlobalIncludePicker().GetCandidateHeadersForFilepath(
             GetFilePath(header));
-    for (const string& pub : public_headers_for_header) {
-      if (const FileEntry* public_file
-          = GetOrDefault(include_to_fileentry_map_, pub, nullptr)) {
+    for (const MappedInclude& pub : public_headers_for_header) {
+      if (const FileEntry* public_file =
+          GetOrDefault(include_to_fileentry_map_, pub.quoted_include,
+                       nullptr)) {
         CHECK_(ContainsKey(iwyu_file_info_map_, public_file));
         if (public_file != header)  // no credit for mapping to yourself :-)
           private_headers_behind[public_file].insert(header);

--- a/run_iwyu_tests.py
+++ b/run_iwyu_tests.py
@@ -88,6 +88,8 @@ class OneIwyuTest(unittest.TestCase):
       'prefix_header_includes_remove.cc': ['--prefix_header_includes=remove'],
       'prefix_header_operator_new.cc': ['--prefix_header_includes=remove'],
       'quoted_includes_first.cc': ['--pch_in_code', '--quoted_includes_first'],
+      'relative_exported_mapped_include.cc':
+          [self.MappingFile('relative_exported_mapped_include.imp')],
       'cxx17ns.cc': ['--cxx17ns'],
     }
     prefix_headers = [self.Include('prefix_header_includes-d1.h'),
@@ -184,6 +186,7 @@ class OneIwyuTest(unittest.TestCase):
       'range_for.cc': ['.'],
       're_fwd_decl.cc': ['.'],
       'redecls.cc': ['.'],
+      'relative_exported_mapped_include.cc': ['tests/cxx/subdir'],
       'remove_fwd_decl_when_including.cc': ['.'],
       'self_include.cc': ['.'],
       'sizeof_reference.cc': ['.'],

--- a/tests/cxx/export_near.h
+++ b/tests/cxx/export_near.h
@@ -1,0 +1,20 @@
+//===--- export_near.h - test input file for iwyu -------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// This file is meant to be a generic exporting header.  Similarly to
+// direct_near.h, it includes indirect.h.  However, unlike that file, this one
+// exports indirect.h, and therefore is a valid file to include to access
+// IndirectClass.
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_EXPORT_NEAR_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_EXPORT_NEAR_H_
+
+#include "indirect.h" // IWYU pragma: export
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_EXPORT_NEAR_H_

--- a/tests/cxx/export_private_near.h
+++ b/tests/cxx/export_private_near.h
@@ -1,0 +1,20 @@
+//===--- export_private_near.h - test input file for iwyu -----------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// This file is meant to be a generic exporting header.  Similarly to
+// export_near.h, it exports another header.  However, unlike that file, this
+// one exports private.h, which is marked private, and therefore IWYU should
+// not allow you to directly include private.h.
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_EXPORT_PRIVATE_NEAR_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_EXPORT_PRIVATE_NEAR_H_
+
+#include "private.h" // IWYU pragma: export
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_EXPORT_PRIVATE_NEAR_H_

--- a/tests/cxx/private.h
+++ b/tests/cxx/private.h
@@ -1,0 +1,22 @@
+//===--- private.h - test input file for iwyu -----------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// This file is meant to be #included by "export_private_near.h".  The pragmas
+// in these two headers mean that export_private.h is the normal header to
+// include to access PrivateClass, rather than including this file directly.
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_PRIVATE_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_PRIVATE_H_
+
+// IWYU pragma: private
+
+class PrivateClass {
+};
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_PRIVATE_H_

--- a/tests/cxx/relative_exported_mapped_include-d1.h
+++ b/tests/cxx/relative_exported_mapped_include-d1.h
@@ -1,0 +1,15 @@
+//===--- relative_exported_mapped_include-d1.h - test input file for iwyu -===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_RELATIVE_EXPORTED_MAPPED_INCLUDE_D1_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_RELATIVE_EXPORTED_MAPPED_INCLUDE_D1_H_
+
+#include <relative_exported_mapped_include-i1.h> // IWYU pragma: export
+
+#endif // INCLUDE_WHAT_YOU_USE_TESTS_CXX_RELATIVE_EXPORTED_MAPPED_INCLUDE_D1_H_

--- a/tests/cxx/relative_exported_mapped_include.cc
+++ b/tests/cxx/relative_exported_mapped_include.cc
@@ -1,0 +1,22 @@
+//===--- relative_exported_mapped_include.cc - test input file for iwyu ---===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// Ensure that when an include is added which is the public mapping of a
+// symbol, that header can be added as a relative include rather than using a
+// full path.
+
+#include "relative_exported_mapped_include-d1.h"
+
+MappedToExportedHeader x;
+
+/**** IWYU_SUMMARY
+
+(tests/cxx/relative_exported_mapped_include.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/relative_exported_mapped_include.imp
+++ b/tests/cxx/relative_exported_mapped_include.imp
@@ -1,0 +1,3 @@
+[
+    { symbol: ["MappedToExportedHeader", "private", "<relative_exported_mapped_include-i1.h>", "public"] },
+]

--- a/tests/cxx/relative_include_of_double_export-d1.h
+++ b/tests/cxx/relative_include_of_double_export-d1.h
@@ -1,0 +1,15 @@
+//===--- relative_include_of_double_export-d1.h - test input file for iwyu ===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_RELATIVE_INCLUDE_OF_DOUBLE_EXPORT_D1_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_RELATIVE_INCLUDE_OF_DOUBLE_EXPORT_D1_H_
+
+#include "export_private_near.h" // IWYU pragma: export
+
+#endif // INCLUDE_WHAT_YOU_USE_TESTS_CXX_RELATIVE_INCLUDE_OF_DOUBLE_EXPORT_D1_H_

--- a/tests/cxx/relative_include_of_double_export.cc
+++ b/tests/cxx/relative_include_of_double_export.cc
@@ -1,0 +1,23 @@
+//===--- relative_include_of_double_export.cc - test input file for iwyu --===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// The purpose of this test is to ensure that the following relative include
+// (i.e. using "" to include something at a location relative to this file)
+// remains a relative include rather than being replaced by a different path.
+#include "relative_include_of_double_export-d1.h"
+
+// This class is defined two layers deep within an export double header
+// included via the above.
+PrivateClass x;
+
+/**** IWYU_SUMMARY
+
+(tests/cxx/relative_include_of_double_export.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/relative_include_of_export.cc
+++ b/tests/cxx/relative_include_of_export.cc
@@ -1,0 +1,21 @@
+//===--- relative_include_of_export-d1.h - test input file for iwyu -------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// The purpose of this test is to ensure that the following relative include
+// (i.e. using "" to include something at a location relative to this file)
+// remains a relative include rather than being replaced by a different path.
+#include "export_near.h"
+
+IndirectClass x;
+
+/**** IWYU_SUMMARY
+
+(tests/cxx/relative_include_of_export.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/relative_include_of_export_added-d1.h
+++ b/tests/cxx/relative_include_of_export_added-d1.h
@@ -1,0 +1,15 @@
+//===--- relative_include_of_export_added-d1.h - test input file for iwyu -===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_RELATIVE_INCLUDE_OF_EXPORT_ADDED_D1_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_RELATIVE_INCLUDE_OF_EXPORT_ADDED_D1_H_
+
+#include "export_private_near.h"
+
+#endif // INCLUDE_WHAT_YOU_USE_TESTS_CXX_RELATIVE_INCLUDE_OF_EXPORT_ADDED_D1_H_

--- a/tests/cxx/relative_include_of_export_added.cc
+++ b/tests/cxx/relative_include_of_export_added.cc
@@ -1,0 +1,29 @@
+//===--- relative_include_of_export_added.cc - test input file for iwyu ---===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// The purpose of this test is to ensure that when an include is added which is
+// the public counterpart to a private header, that header can be added as a
+// relative include rather than using a full path.
+#include "relative_include_of_export_added-d1.h"
+
+// IWYU: PrivateClass is...*"export_private_near.h"
+PrivateClass x;
+
+/**** IWYU_SUMMARY
+
+tests/cxx/relative_include_of_export_added.cc should add these lines:
+#include "export_private_near.h"
+
+tests/cxx/relative_include_of_export_added.cc should remove these lines:
+- #include "relative_include_of_export_added-d1.h"  // lines XX-XX
+
+The full include-list for tests/cxx/relative_include_of_export_added.cc:
+#include "export_private_near.h"  // for PrivateClass
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/subdir/relative_exported_mapped_include-i1.h
+++ b/tests/cxx/subdir/relative_exported_mapped_include-i1.h
@@ -1,0 +1,15 @@
+//===--- relative_exported_mapped_include-i1.h - test input file for iwyu ===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_RELATIVE_EXPORTED_MAPPED_INCLUDE_I1_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_RELATIVE_EXPORTED_MAPPED_INCLUDE_I1_H_
+
+enum MappedToExportedHeader {};
+
+#endif // INCLUDE_WHAT_YOU_USE_TESTS_CXX_RELATIVE_EXPORTED_MAPPED_INCLUDE_I1_H_


### PR DESCRIPTION
This PR tackles a variety of problems that arise from the interaction of relative includes (by which I mean "" includes which are found relative to the including file) and mappings within IWYU.

Fundamentally, the issue is that quoted includes are used as keys for headers within IWYU.  This works well for system headers, but can break down for local headers used via relative includes. In particular, the IWYU `ConvertToQuotedInclude` method can return different results depending on the including file passed as the second parameter.

The problems manifest in one of two ways:
* Pragmas in headers sometimes appear to have no effect because they were not matched up correctly to a different quoted include for the same header at a different place in the code.
* IWYU suggests `#include`s using the full absolute path to a header, rather than the more logical relative include, because the ultimate includer was not known at the time the quoted include was computed.

The changes here include:
* Add a new visibility map, based on paths rather than quoted includes.  Use it for `IWYU pragma: private` (but not for `IWYU pragma: private, include ...`; see below).
* The targets of mappings (both symbol and include mappings) are now a new `MappedInclude` object rather than simply a quoted include.  The `MappedInclude` contains a quoted include, and sometimes also a path (the path will be used for mappings derived from pragmas, but not mapping files).
* When computing candidate headers, take greater care to avoid includes of absolute paths.
* Use the same canonicalization code for computing candidate headers from both include mappings and symbol mappings; previously they were implemented differently.
* Tests for all the above.

I got a little bit sucked down a rabbit hole with this branch.  But test cases I added to understand one bug kept revealing new bugs, so they are all rather intertwined.  So I think it's reasonable to look at the changes all together.  I claim that much of the code is tidier now than it was; for example there is now less confusion between symbols and quoted includes in some maps.

There are still corner cases I know of that can go wrong; to fix those would require adding a new `IncludeMap` keyed by paths rather than quoted includes.  The lack of that is why I didn't change the behaviour of `IWYU pragma: private, include ...` so the two sorts of private pragma are now inconsistent, which is unfortunate.  However, I think these corner cases are less likely to arise in practice, and I wanted to stop this PR growing any further.

I also happened to notice while working on this that symbol mappings don't respect friend headers properly, but that's definitely a separate issue.

I imagine you'll want the commits squashed or otherwise tidied up before this is merged, but I wanted to get it out for review first.