### PR TITLE
Travis build fixup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,14 @@ before_install:
  - ROOT_PATH=`llvm-config-$VERSION --prefix`
  - BIN_PATH=`llvm-config-$VERSION --bindir`
 
+ # TODO: Remove this as soon as humanly possible.
+ # Patch Clang CMake config to remove 'clang_shared' target which is
+ # currently broken in the Debian packaging.
+ - sudo sed -i -e 's/clang-refactor clang_shared clangApplyReplacements/clang-refactor clangApplyReplacements/' $ROOT_PATH/lib/cmake/clang/ClangTargets.cmake
+ - sudo sed -i -e '/clang_shared/d' $ROOT_PATH/lib/cmake/clang/ClangTargets.cmake
+ - sudo sed -i -e '/IMPORTED_SONAME_RELWITHDEBINFO.*libclang_shared\.so/,+1 d' $ROOT_PATH/lib/cmake/clang/ClangTargets-relwithdebinfo.cmake
+ - sudo sed -i -e '/clang_shared/d' $ROOT_PATH/lib/cmake/clang/ClangTargets-relwithdebinfo.cmake
+
 script:
 # Build IWYU
  - mkdir build

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ addons:
 
 before_install:
  # Install a supported cmake version (>= 3.4.3)
- - wget -O cmake.sh https://cmake.org/files/v3.10/cmake-3.10.0-rc1-Linux-x86_64.sh 
+ - wget -O cmake.sh https://cmake.org/files/v3.10/cmake-3.10.0-Linux-x86_64.sh 
  - sudo sh cmake.sh --skip-license --exclude-subdir --prefix=/usr/local
 
  # Extract the version number from the most-recently installed LLVM

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 
+dist: xenial
 language: cpp
 
 addons:
   apt:
     sources:
-     - ubuntu-toolchain-r-test
-     - llvm-toolchain-trusty
+     - sourceline: 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial main'
+       key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
     packages:
      - ninja-build
      # TODO: These should really be the snapshots packages, but they are currently
@@ -39,7 +40,7 @@ script:
 # Build IWYU
  - mkdir build
  - cd build
- - cmake -GNinja -DLLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN=yes -DCMAKE_PREFIX_PATH=$ROOT_PATH -DCMAKE_C_COMPILER=$BIN_PATH/clang -DCMAKE_CXX_COMPILER=$BIN_PATH/clang++ -DCMAKE_INSTALL_PREFIX=./ ../
+ - cmake -GNinja -DCMAKE_PREFIX_PATH=$ROOT_PATH -DCMAKE_C_COMPILER=$BIN_PATH/clang -DCMAKE_CXX_COMPILER=$BIN_PATH/clang++ -DCMAKE_INSTALL_PREFIX=./ ../
  - ninja install
 
 # Test IWYU


### PR DESCRIPTION
Our Travis build has been failing lately.

This is due to a bug in the Debian packaging of LLVM (see the `Horrible patchwork...` commit) that I've managed to work around.

While here, I also decided to bump the base dist of the build environment from the outdated Ubuntu Trusty (14.04) to Xenial, which enabled removal of some older workarounds.