### PR TITLE
Remove ".." from normalized file paths

### DIFF
--- a/iwyu_path_util.cc
+++ b/iwyu_path_util.cc
@@ -127,7 +127,7 @@ string GetCanonicalName(string file_path) {
 
 string NormalizeFilePath(const string& path) {
   llvm::SmallString<128> normalized(path);
-  llvm::sys::path::remove_dots(normalized);
+  llvm::sys::path::remove_dots(normalized, /*remove_dot_dot=*/true);
 
 #ifdef _WIN32
   // Canonicalize directory separators (forward slashes considered canonical.)

--- a/run_iwyu_tests.py
+++ b/run_iwyu_tests.py
@@ -140,6 +140,7 @@ class OneIwyuTest(unittest.TestCase):
       'default_template_arg_other_file.cc': ['.'],
       'depopulated_h_file.cc': ['.'],
       'derived_function_tpl_args.cc': ['.'],
+      'dotdot.cc': ['.'],
       'double_include.cc': ['.'],
       'elaborated_struct.c': ['.'],
       'elaborated_type.cc': ['.'],

--- a/tests/cxx/dotdot.cc
+++ b/tests/cxx/dotdot.cc
@@ -1,0 +1,29 @@
+//===--- dotdot.cc - test input file for iwyu -----------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// Tests that IWYU path canonicalization helps understand that
+// "tests/cxx/subdir/../indirect.h" and "tests/cxx/indirect.h" are the same
+// file.
+#include "subdir/dotdot_indirect.h"
+
+// IWYU: IndirectClass is...*indirect.h
+IndirectClass x;
+
+/**** IWYU_SUMMARY
+
+tests/cxx/dotdot.cc should add these lines:
+#include "tests/cxx/indirect.h"
+
+tests/cxx/dotdot.cc should remove these lines:
+- #include "subdir/dotdot_indirect.h"  // lines XX-XX
+
+The full include-list for tests/cxx/dotdot.cc:
+#include "tests/cxx/indirect.h"  // for IndirectClass
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/subdir/dotdot_indirect.h
+++ b/tests/cxx/subdir/dotdot_indirect.h
@@ -1,0 +1,18 @@
+//===--- dotdot_indirect.h - test input file for iwyu ---------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// Include a file using relative path to help test canonicalization when IWYU
+// suggests additions.
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_DOTDOT_INDIRECT_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_DOTDOT_INDIRECT_H_
+
+#include "../indirect.h"
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_DOTDOT_INDIRECT_H_


### PR DESCRIPTION
This fixes a case where IWYU would suggest include paths with ".." where
a simpler non-".." path would suffice. E.g.

    // a.h
    struct Symbol {};

    // foo/b.h
    #include "../a.h"

    // main.c
    #include "foo/b.h"

    Symbol s;

IWYU would suggest we should include "foo/../a.h" from main.c here. This
is correct, but inelegant.

After this patch, we'll suggest "a.h" directly. Unfortunately, this is
broken in the face of symlinks (example cut from bug report) --

    akuli@Akuli-Desktop:~$ ln -s /usr a
    akuli@Akuli-Desktop:~$ file a
    a: symbolic link to /usr
    akuli@Akuli-Desktop:~$ file lib
    lib: cannot open `lib' (No such file or directory)
    akuli@Akuli-Desktop:~$ file a/../lib
    a/../lib: directory
    akuli@Akuli-Desktop:~$

-- but I suspect this is more unusual than relative includes.

Fixes issue 690.

(Please ignore the first few commits, they're part of another PR to rename `subfolder` to `subdir`)