### PR TITLE
Handle builtin templates which have a CXXRecordDecl child properly

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -3353,8 +3353,10 @@ class InstantiatedTemplateVisitor
     if (class_decl == nullptr) {
       // If the template specialization decl is not sugar for a class, we
       // expect it to be another kind of template decl, like a built-in.
-      CHECK_(llvm::isa<clang::TemplateDecl>(named_decl))
-          << "TemplateSpecializationType has no decl of type TemplateDecl?";
+      // Also in some rare cases named_decl can be a record decl (e.g. when using
+      // the built-in __type_pack_element).
+      CHECK_(llvm::isa<clang::TemplateDecl>(named_decl) || llvm::isa<clang::RecordDecl>(named_decl))
+          << "TemplateSpecializationType has no decl of type TemplateDecl or RecordDecl?";
       return true;
     }
 

--- a/tests/cxx/built_ins_template.cc
+++ b/tests/cxx/built_ins_template.cc
@@ -14,6 +14,8 @@ __type_pack_element<0, int> tp;
 template <class T, T...> struct A {};
 __make_integer_seq<A, int, 5> seq;
 
+class Foo {};
+__type_pack_element<0, Foo> foo;
 
 /**** IWYU_SUMMARY
 


### PR DESCRIPTION
TypeToDeclAsWritten prioritizes RecordType to TemplateSpecializationType when it
converts types to decls but in some cases (e.g. when using
\_\_type\_pack_element<0, Foo> where Foo is a non-template class) this could cause
the failing of the assert CHECK_(llvm::isa<clang::TemplateDecl>(named_decl)).

Fixes #698.