### PR TITLE
Add license headers to Python scripts

### DIFF
--- a/generate_qt_mappings.py
+++ b/generate_qt_mappings.py
@@ -1,5 +1,14 @@
 #!/usr/bin/env python
 
+##===--- generate_qt_mappings.py - creates .imp files for Qt --------------===##
+#
+#                     The LLVM Compiler Infrastructure
+#
+# This file is distributed under the University of Illinois Open Source
+# License. See LICENSE.TXT for details.
+#
+##===----------------------------------------------------------------------===##
+
 """
 This script generates the Qt mapping file according to given Qt include
 directory

--- a/iwyu_tool.py
+++ b/iwyu_tool.py
@@ -1,4 +1,14 @@
 #!/usr/bin/env python
+
+##===--- iwyu_tool.py - include-what-you-use tooling driver ----------------===##
+#
+#                     The LLVM Compiler Infrastructure
+#
+# This file is distributed under the University of Illinois Open Source
+# License. See LICENSE.TXT for details.
+#
+##===-----------------------------------------------------------------------===##
+
 """ Driver to consume a Clang compilation database and invoke IWYU.
 
 Example usage with CMake:

--- a/scrub-logs.py
+++ b/scrub-logs.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-##===---------- scrub-logs.py - generate README from Wiki sources ---------===##
+##===---------- scrub-logs.py - debugging tool to make logs diffable ------===##
 #
 #                      The LLVM Compiler Infrastructure
 #


### PR DESCRIPTION
Some of the Python scripts (both for development and production) had
fallen behind.