### PR TITLE
Fix wrong suggestions with --no_fwd_decls

### DIFF
--- a/tests/cxx/no_fwd_decls.cc
+++ b/tests/cxx/no_fwd_decls.cc
@@ -29,6 +29,10 @@ IndirectClass* global;
 class LocalFwd;
 void ForwardDeclareUse(const LocalFwd*);
 
+// IWYU must not remove the forward declaration of this class even though its
+// definition can be found in the same file but after the use
+class LocalFwd {};
+
 // A forward-declare that also exists in an included header can be removed.
 // Normally IWYU would optimize for fewer includes, but in --no_fwd_decls mode
 // we optimize for fewer redeclarations instead.


### PR DESCRIPTION
This fixes 2 specific issues only happening with `--no_fwd_decls`:

* Removal of needed forward declaration from an associated header, when the
definition is in the source file. (Fixes #702)

* Replacing an include in an associated header file, containing a forward
declaration, with a local forward declaration, if the definition can be found in
the header.

Example:
```
// header.hpp
#pragma once

class Foo;

// test.hpp
#pragma once

#include "header.hpp"

Foo *foo;

class Foo {};

// test.cpp
#include "test.hpp"
```
IWYU suggests to replace `#include header.hpp` with `class Foo`. However, I think the correct suggestion (with --no_fwd_decls) would be to keep the include.