### PR TITLE
Add missing handling of ElaboratedTypes in VisitMemberExpr

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -2167,6 +2167,7 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
         = expr->isArrow() ? RemovePointerFromType(base_type) : base_type;
     if (CanIgnoreType(base_type) && CanIgnoreType(deref_base_type))
       return true;
+    deref_base_type = RemoveElaboration(deref_base_type);
     if (const TypedefType* typedef_type = DynCastFrom(deref_base_type)) {
       deref_base_type = DesugarDependentTypedef(typedef_type);
     }

--- a/tests/cxx/member_expr-elaborated.h
+++ b/tests/cxx/member_expr-elaborated.h
@@ -1,0 +1,13 @@
+//===--- member_expr-elaborated.h - test input file for iwyu --------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+template<class T>
+struct Typedef {
+  typedef T type;
+};

--- a/tests/cxx/member_expr.cc
+++ b/tests/cxx/member_expr.cc
@@ -11,6 +11,8 @@
 
 #include "tests/cxx/member_expr-d1.h"
 #include "tests/cxx/direct.h"
+#include "tests/cxx/member_expr-elaborated.h"
+#include "tests/cxx/struct-with-member.h"
 
 // IWYU: IndirectClass needs a declaration
 int RefFn(const IndirectClass& ic) {
@@ -31,6 +33,16 @@ int PtrFn(const IndirectClass* ic) {
 void StaticFn() {
   // IWYU: IndirectClass is...*indirect.h
   IndirectClass::StaticMethod();
+}
+
+struct StructWithMember;
+
+// Typedef<T>::type is T
+Typedef<StructWithMember>::type FnReturningElaboratedType();
+
+void ThroughElaboratedType() {
+  // Full-use of StructWithMember
+  void* unused = FnReturningElaboratedType().member;
 }
 
 // IWYU: IndirectClass needs a declaration
@@ -63,9 +75,12 @@ tests/cxx/member_expr.cc should add these lines:
 
 tests/cxx/member_expr.cc should remove these lines:
 - #include "tests/cxx/direct.h"  // lines XX-XX
+- struct StructWithMember;  // lines XX-XX
 
 The full include-list for tests/cxx/member_expr.cc:
 #include "tests/cxx/indirect.h"  // for IndirectClass
 #include "tests/cxx/member_expr-d1.h"  // for CALL_METHOD, IC, IC_CALL_METHOD
+#include "tests/cxx/member_expr-elaborated.h"  // for Typedef, Typedef<>::type
+#include "tests/cxx/struct-with-member.h"  // for StructWithMember
 
 ***** IWYU_SUMMARY */

--- a/tests/cxx/struct-with-member.h
+++ b/tests/cxx/struct-with-member.h
@@ -1,0 +1,12 @@
+//===--- struct-with-member.h - test input file for iwyu ------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+struct StructWithMember {
+  void* member;
+};


### PR DESCRIPTION
IWYU missed the use of typedefs, if they were 'hidden' behind elaborated types.