### PR TITLE
iwyu_tool: use directory information from compilation database if pos…

### DIFF
--- a/iwyu_tool.py
+++ b/iwyu_tool.py
@@ -298,6 +298,10 @@ class Invocation(object):
 def fixup_compilation_db(compilation_db):
     """ Canonicalize paths in JSON compilation database. """
     for entry in compilation_db:
+        # Convert relative paths to absolute ones if possible, based on the entry's directory.
+        if 'directory' in entry and not os.path.isabs(entry['file']):
+            entry['file'] = os.path.join(entry['directory'], entry['file'])
+
         # Expand relative paths and symlinks
         entry['file'] = os.path.realpath(entry['file'])
 

--- a/iwyu_tool_test.py
+++ b/iwyu_tool_test.py
@@ -281,7 +281,6 @@ class CompilationDBTests(unittest.TestCase):
         """ Compilation database path canonicalization. """
         compilation_db = [
             {
-                "directory": "/home/user/llvm/build/test",
                 "file": "Test.cpp"
             }
         ]
@@ -291,6 +290,21 @@ class CompilationDBTests(unittest.TestCase):
         # Check that file path is made absolute.
         entry = canonical[0]
         self.assertEqual(os.path.join(self.cwd, 'Test.cpp'), entry['file'])
+
+    def test_fixup_from_entry_dir(self):
+        """ Compilation database abs path is based on an entry's directory. """
+        compilation_db = [
+            {
+                "directory": "/home/user/foobar",
+                "file": "Test.cpp"
+            }
+        ]
+
+        canonical = iwyu_tool.fixup_compilation_db(compilation_db)
+
+        # Check that the file path is relative to the directory entry, not to the current directory.
+        entry = canonical[0]
+        self.assertEqual('/home/user/foobar/Test.cpp', entry['file'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
…sible

If the entry looks like this:

    {
        "arguments": [
            ....
        ],
        "directory": "/path/to/test",
        "file": "Test.cpp"
    },

And we invoked iwyu_tool.py in /path/to, then the constructed abs path was
/path/to/Test.cpp, not /path/to/test/Test.cpp, fix this.

If the change itself makes sense, I'm happy to look at covering this from `iwyu_tool_test.py`. (The above is an autotools project, compilation database generated by bear.)