### PR TITLE
Fix final class forward-declaration bug

### DIFF
--- a/iwyu_output.cc
+++ b/iwyu_output.cc
@@ -452,10 +452,20 @@ string MungedForwardDeclareLineForTemplates(const TemplateDecl* decl) {
   line = Split(line, " :", 2)[0];
   // Get rid of the template body, if any (true if no superclasses).
   line = Split(line, " {", 2)[0];
+
+  // Remove "final" specifier which isn't needed for forward
+  // declarations.
+  const char kFinalSpecifier[] = " final ";
+  string::size_type final_pos = line.find(kFinalSpecifier);
+  if (final_pos != string::npos) {
+    line.replace(final_pos, sizeof(kFinalSpecifier), " ");
+  }
+
   // The template name is now the last word on the line.  Replace it
   // by its fully-qualified form.
   const string::size_type name = line.rfind(' ');
   CHECK_(name != string::npos && "Unexpected printable template-type");
+
   return PrintForwardDeclare(decl, line.substr(0, name), GlobalFlags().cxx17ns);
 }
 

--- a/run_iwyu_tests.py
+++ b/run_iwyu_tests.py
@@ -151,6 +151,7 @@ class OneIwyuTest(unittest.TestCase):
       'forward_declare_in_macro.cc': ['.'],
       'fullinfo_for_templates.cc': ['.'],
       'fwd_decl_class_template.cc': ['.'],
+      'fwd_decl_final.cc': ['.'],
       'fwd_decl_static_member.cc': ['.'],
       'fwd_decl_with_instantiation.cc': ['.'],
       'header_in_subdir.cc': ['.'],

--- a/tests/cxx/fwd_decl_final-d1.h
+++ b/tests/cxx/fwd_decl_final-d1.h
@@ -1,0 +1,19 @@
+//===--- fwd_decl_final-d1.h - test input file for iwyu -------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_FWD_DECL_FINAL_D1_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_FWD_DECL_FINAL_D1_H_
+
+
+template <typename T>
+class FinalTemplate final {};
+
+class FinalClass final {};
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_FWD_DECL_FINAL_D1_H_

--- a/tests/cxx/fwd_decl_final.cc
+++ b/tests/cxx/fwd_decl_final.cc
@@ -1,0 +1,31 @@
+//===--- fwd_decl_final.cc - test input file for iwyu ---------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/fwd_decl_final.h"
+
+void FwdDeclFinal::testFinalTemplate(FinalTemplate<int>* finalTemplate) {
+}
+
+void FwdDeclFinal::testFinalClass(FinalClass* finalClass) {
+}
+
+/**** IWYU_SUMMARY
+
+tests/cxx/fwd_decl_final.cc should add these lines:
+class FinalClass;
+template <typename T> class FinalTemplate;
+
+tests/cxx/fwd_decl_final.cc should remove these lines:
+
+The full include-list for tests/cxx/fwd_decl_final.cc:
+#include "tests/cxx/fwd_decl_final.h"
+class FinalClass;
+template <typename T> class FinalTemplate;
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/fwd_decl_final.h
+++ b/tests/cxx/fwd_decl_final.h
@@ -1,0 +1,36 @@
+//===--- fwd_decl_final.h - test input file for iwyu ----------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_FWD_DECL_FINAL_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_FWD_DECL_FINAL_H_
+
+#include "tests/cxx/fwd_decl_final-d1.h"
+
+class FwdDeclFinal {
+public:
+  void testFinalTemplate(FinalTemplate<int>* finalTemplate);
+  void testFinalClass(FinalClass* finalClass);
+};
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_FWD_DECL_FINAL_H_
+
+/**** IWYU_SUMMARY
+
+tests/cxx/fwd_decl_final.h should add these lines:
+class FinalClass;
+template <typename T> class FinalTemplate;
+
+tests/cxx/fwd_decl_final.h should remove these lines:
+- #include "tests/cxx/fwd_decl_final-d1.h"  // lines XX-XX
+
+The full include-list for tests/cxx/fwd_decl_final.h:
+class FinalClass;
+template <typename T> class FinalTemplate;
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
According to C++ standard, forward declaration of a final class [shouldn't have "final" specifier](https://en.cppreference.com/w/cpp/language/class).

IWYU didn't correctly handle this case for template classes and generated the following invalid code:
```c++
template<typename T> class final A;
```

This pull request fixes the issue by adjusting template name deduction logic in `MungedForwardDeclareLineForTemplates` function.