### PR TITLE
Support make test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ __pycache__
 
 .gdb_history
 compile_commands.json
+
+/build

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,10 +40,10 @@ script:
  - mkdir build
  - cd build
  - cmake -GNinja -DCMAKE_PREFIX_PATH=$ROOT_PATH -DCMAKE_C_COMPILER=$BIN_PATH/clang -DCMAKE_CXX_COMPILER=$BIN_PATH/clang++ -DCMAKE_INSTALL_PREFIX=./ ../
- - ninja install
+ - ninja
 
 # Test IWYU
- - cd ..
- - python run_iwyu_tests.py -- build/bin/include-what-you-use
- - python fix_includes_test.py
- - python iwyu_tool_test.py
+ - CTEST_OUTPUT_ON_FAILURE=1 ninja test
+
+# Test install
+ - ninja install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,3 +125,17 @@ install(PROGRAMS fix_includes.py iwyu_tool.py DESTINATION bin)
 # Install mapping files
 file(GLOB MAPPING_FILES *.imp)
 install(FILES ${MAPPING_FILES} DESTINATION share/include-what-you-use)
+
+find_package(PythonInterp)
+if(PYTHONINTERP_FOUND)
+  enable_testing()
+  add_test(NAME iwyu_tests
+    COMMAND ${PYTHON_EXECUTABLE} run_iwyu_tests.py -- $<TARGET_FILE:include-what-you-use>
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+  add_test(NAME fix_includes_test
+    COMMAND ${PYTHON_EXECUTABLE} fix_includes_test.py
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+  add_test(NAME iwyu_tool_test
+    COMMAND ${PYTHON_EXECUTABLE} iwyu_tool_test.py
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+endif()


### PR DESCRIPTION
After taking a break for a while from IWYU I struggled again to find what to do to execute the tests and `make test` failed with inexisting target.

I therefore added the necessary CMake commands to create such a target and use them in the travis file.

This is tested with the clang/llvm packages ('out-of-tree configuration') and should work for 'in-tree configuration'  too.

Note:
- You can start individual tests with `ctest -R IWYU_Tests`
- To show output on failure use `ctest --output-on-failure`
- To show all output use `ctest --extra-verbose`