### PR TITLE
Compile with LLVM v9.0.1

### DIFF
--- a/iwyu_driver.cc
+++ b/iwyu_driver.cc
@@ -206,7 +206,10 @@ CompilerInstance* CreateCompilerInstance(int argc, const char **argv) {
   // Initialize a compiler invocation object from the clang (-cc1) arguments.
   const ArgStringList &cc_arguments = command.getArguments();
   std::shared_ptr<CompilerInvocation> invocation(new CompilerInvocation);
-  CompilerInvocation::CreateFromArgs(*invocation, cc_arguments, diagnostics);
+  CompilerInvocation::CreateFromArgs((*invocation),
+                                     &(cc_arguments.front()),
+                                     &(cc_arguments.back()),
+                                     diagnostics);
   invocation->getFrontendOpts().DisableFree = false;
 
   // Use libc++ headers bundled with Xcode.app on macOS.

--- a/iwyu_preprocessor.cc
+++ b/iwyu_preprocessor.cc
@@ -34,7 +34,7 @@
 #include "clang/Lex/MacroInfo.h"
 
 using clang::FileEntry;
-using clang::FileEntryRef;
+// using clang::FileEntryRef;
 using clang::FileID;
 using clang::MacroDefinition;
 using clang::MacroDirective;
@@ -695,7 +695,7 @@ void IwyuPreprocessorInfo::FileChanged(SourceLocation loc,
 // Called when we see an #include, but decide we don't need to
 // actually read it because it's already been #included (and is
 // protected by a header guard).
-void IwyuPreprocessorInfo::FileSkipped(const FileEntryRef& file,
+void IwyuPreprocessorInfo::FileSkipped(const FileEntry& file,
                                        const Token &filename,
                                        SrcMgr::CharacteristicKind file_type) {
   CHECK_(include_filename_loc_.isValid() &&
@@ -706,11 +706,11 @@ void IwyuPreprocessorInfo::FileSkipped(const FileEntryRef& file,
       GetInstantiationLoc(filename.getLocation());
   ERRSYM(GetFileEntry(include_loc))
       << "[ (#include)  ] " << include_name_as_written
-      << " (" << GetFilePath(&file.getFileEntry()) << ")\n";
+      << " (" << GetFilePath(&file) << ")\n";
 
-  AddDirectInclude(include_loc, &file.getFileEntry(), include_name_as_written);
-  if (ShouldReportIWYUViolationsFor(&file.getFileEntry())) {
-    files_to_report_iwyu_violations_for_.insert(&file.getFileEntry());
+  AddDirectInclude(include_loc, &file, include_name_as_written);
+  if (ShouldReportIWYUViolationsFor(&file)) {
+    files_to_report_iwyu_violations_for_.insert(&file);
   }
 }
 

--- a/iwyu_preprocessor.h
+++ b/iwyu_preprocessor.h
@@ -204,7 +204,7 @@ class IwyuPreprocessorInfo : public clang::PPCallbacks,
   void FileChanged(clang::SourceLocation loc, FileChangeReason reason,
                    clang::SrcMgr::CharacteristicKind file_type,
                    clang::FileID exiting_from_id) override;
-  void FileSkipped(const clang::FileEntryRef& file, const clang::Token &filename,
+  void FileSkipped(const clang::FileEntry& file, const clang::Token &filename,
                    clang::SrcMgr::CharacteristicKind file_type) override;
   // FileChanged is actually a multi-plexer for 4 different callbacks.
   void FileChanged_EnterFile(clang::SourceLocation file_beginning);


### PR DESCRIPTION
I made a few changes to get IWYU to get compiled with LLVM 9.0.1 (the latest shipped version on arch).

I tried to build using `-DCMAKE_PREFIX_PATH` but it was ignored so I went ahead and made the changes to compile against just v9.0.1