### PR TITLE
Copy clang builtin headers to build directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,10 +55,10 @@ add_llvm_executable(include-what-you-use
   )
 
 if (IWYU_IN_TREE)
-  # Add a dependency on clang-headers to ensure the builtin headers are
+  # Add a dependency on clang-resource-headers to ensure the builtin headers are
   # available when IWYU is executed from the build dir.
-  # The clang-headers target is only available in in-tree builds.
-  add_dependencies(include-what-you-use clang-headers)
+  # The clang-resource-headers target is only available in in-tree builds.
+  add_dependencies(include-what-you-use clang-resource-headers)
 endif()
 
 if (MINGW)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,12 +54,35 @@ add_llvm_executable(include-what-you-use
   iwyu_verrs.cc
   )
 
-if (IWYU_IN_TREE)
-  # Add a dependency on clang-resource-headers to ensure the builtin headers are
-  # available when IWYU is executed from the build dir.
-  # The clang-resource-headers target is only available in in-tree builds.
-  add_dependencies(include-what-you-use clang-resource-headers)
+# Synthesize a clang-resource-headers target for out-of-tree builds (in-tree
+# already has it available by default)
+if (NOT IWYU_IN_TREE)
+  # Use only major.minor.patch for the resource directory structure; some
+  # platforms include suffix in LLVM_VERSION.
+  set(llvm_ver ${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR}.${LLVM_VERSION_PATCH})
+  set(clang_headers_src ${CMAKE_PREFIX_PATH}/lib/clang/${llvm_ver}/include)
+  set(clang_headers_dst ${CMAKE_BINARY_DIR}/lib/clang/${llvm_ver}/include)
+
+  file(GLOB_RECURSE in_files RELATIVE ${clang_headers_src} ${clang_headers_src}/*)
+
+  set(out_files)
+  foreach (file ${in_files})
+    set(src ${clang_headers_src}/${file})
+    set(dst ${clang_headers_dst}/${file})
+
+    add_custom_command(OUTPUT ${dst}
+      DEPENDS ${src}
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different ${src} ${dst}
+      COMMENT "Copying clang's ${file}...")
+    list(APPEND out_files ${dst})
+  endforeach()
+
+  add_custom_target(clang-resource-headers ALL DEPENDS ${out_files})
 endif()
+
+# Add a dependency on clang-resource-headers to ensure the builtin headers are
+# available when IWYU is executed from the build dir.
+add_dependencies(include-what-you-use clang-resource-headers)
 
 if (MINGW)
   # Work around 'too many sections' error with MINGW/GCC


### PR DESCRIPTION
This is a second step for issue #100. It doesn't solve anything on its own, but here's some rationale:

* After IWYU is built to $build/bin, it can't be used on any interesting source files
* The reason is that it searches for the Clang builtin headers (`stddef.h`, `stdarg.h`, etc) in $build/lib/clang/<clang version>/include (this is imposed by the Clang libraries)
* In order to make IWYU fully usable, we need to make those headers available on that particular path

In 99f2eab, I added a build dependency on the `clang-headers` target, which copies the right headers into the build directory. Unfortunately that target is not exported in the Clang packages, and only available in the (unsupported) in-tree build.

Clang subsequently renamed the target to `clang-resource-headers`.

This PR takes care of both the new name, and puts in a home-brewn `clang-resource-headers` target for out-of-tree builds. With some tacit knowledge, we can collect the right files into the build directory.

I chose not to include the headers in the install target, because I think IWYU packaging should depend on Clang, and always be installed to the same prefix.

But for now, merging this PR will make the build directory self-consistent and usable for both in-tree and out-of-tree builds. This is a great win!