### PR TITLE
Let C structs be potential forward-declarations

### DIFF
--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -954,7 +954,7 @@ bool IsExplicitInstantiation(const clang::Decl* decl) {
 }
 
 bool IsForwardDecl(const NamedDecl* decl) {
-  if (const auto* record_decl = dyn_cast<CXXRecordDecl>(decl)) {
+  if (const auto* record_decl = dyn_cast<RecordDecl>(decl)) {
 
     return (!record_decl->getName().empty() &&
             !record_decl->isCompleteDefinition() &&

--- a/tests/c/elaborated_struct.c
+++ b/tests/c/elaborated_struct.c
@@ -21,6 +21,11 @@ typedef struct TypedeffedStruct TypedeffedStruct;  // No diagnostic expected.
 // that an explicit forward declaration would be better.
 int UseStruct(struct Struct* s);
 
+// If an existing forward-declaration is available, make sure we don't suggest
+// adding it twice (see issue #682).
+struct ForwardDeclared;
+void UseForwardDeclared(struct ForwardDeclared*);
+
 /**** IWYU_SUMMARY
 
 tests/c/elaborated_struct.c should add these lines:
@@ -30,6 +35,7 @@ tests/c/elaborated_struct.c should remove these lines:
 - #include "tests/c/elaborated_struct-d1.h"  // lines XX-XX
 
 The full include-list for tests/c/elaborated_struct.c:
+struct ForwardDeclared;  // lines XX-XX
 struct Struct;
 
 ***** IWYU_SUMMARY */


### PR DESCRIPTION
Commit 0d0832fee7adffd7ead9e5c90683e403de5e9b2b accidentally constrained
IsForwardDecl to CXXRecordDecls, i.e. C++ structs/classes.

This led to forward-declarations being missed when source files were
parsed in C mode.

Issue #682 captures this nicely -- fix by allowing all RecordDecls to be
potential forward-declarations and add a test.