### PR TITLE
Disable forward-declares for decls in inline namespaces

### DIFF
--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -953,6 +953,16 @@ bool IsExplicitInstantiation(const clang::Decl* decl) {
          kind == clang::TSK_ExplicitInstantiationDefinition;
 }
 
+bool IsInInlineNamespace(const Decl* decl) {
+  const DeclContext* dc = decl->getDeclContext();
+  for (; dc; dc = dc->getParent()) {
+    if (dc->isInlineNamespace())
+      return true;
+  }
+
+  return false;
+}
+
 bool IsForwardDecl(const NamedDecl* decl) {
   if (const auto* record_decl = dyn_cast<RecordDecl>(decl)) {
 

--- a/iwyu_ast_util.h
+++ b/iwyu_ast_util.h
@@ -597,6 +597,9 @@ bool IsFriendDecl(const clang::Decl* decl);
 // or definition.
 bool IsExplicitInstantiation(const clang::Decl* decl);
 
+// Returns true if this decl is nested inside an inline namespace.
+bool IsInInlineNamespace(const clang::Decl* decl);
+
 // Returns true if a named decl looks like a forward-declaration of a
 // class (rather than a definition, a friend declaration, or an 'in
 // place' declaration like 'struct Foo' in 'void MyFunc(struct Foo*);'

--- a/iwyu_output.cc
+++ b/iwyu_output.cc
@@ -716,6 +716,10 @@ static void LogIncludeMapping(const string& reason, const OneUse& use) {
 namespace internal {
 
 bool DeclCanBeForwardDeclared(const Decl* decl) {
+  // Nothing inside an inline namespace can be forward-declared.
+  if (IsInInlineNamespace(decl))
+    return false;
+
   // Class templates can always be forward-declared.
   if (isa<ClassTemplateDecl>(decl))
     return true;

--- a/iwyu_output.cc
+++ b/iwyu_output.cc
@@ -348,20 +348,6 @@ string PrintablePtr(const void* ptr) {
 //       `-- TagDecl           (class, struct, union, enum)
 //           `-- RecordDecl    (class, struct, union)
 
-// Determines if a NamedDecl has any parent namespace, which is anonymous.
-bool HasAnonymousNamespace(const NamedDecl* decl) {
-  for (const DeclContext* ctx = decl->getDeclContext();
-       ctx && isa<NamedDecl>(ctx); ctx = ctx->getParent()) {
-    if (const NamespaceDecl* ns = DynCastFrom(ctx)) {
-      if (ns->isAnonymousNamespace()) {
-        return true;
-      }
-    }
-  }
-
-  return false;
-}
-
 // Given a NamedDecl that presents a (possibly template) record
 // (i.e. class, struct, or union) type declaration, and the print-out
 // of its (possible) template parameters and kind (e.g. "template
@@ -380,7 +366,7 @@ string PrintForwardDeclare(const NamedDecl* decl,
   std::string fwd_decl = std::string(decl->getName()) + ";";
   bool seen_namespace = false;
   // Anonymous namespaces are not using the more concise syntax.
-  bool concat_namespaces = cxx17ns && !HasAnonymousNamespace(decl);
+  bool concat_namespaces = cxx17ns && !decl->isInAnonymousNamespace();
   for (const DeclContext* ctx = decl->getDeclContext();
        ctx && isa<NamedDecl>(ctx); ctx = ctx->getParent()) {
     if (const RecordDecl* rec = DynCastFrom(ctx)) {

--- a/run_iwyu_tests.py
+++ b/run_iwyu_tests.py
@@ -158,6 +158,7 @@ class OneIwyuTest(unittest.TestCase):
       'implicit_ctor.cc': ['.'],
       'include_cycle.cc': ['.'],
       'include_with_using.cc': ['.'],
+      'inline_namespace.cc': ['.'],
       'internal/internal_files.cc': ['.'],
       'iwyu_stricter_than_cpp.cc': ['.'],
       'keep_includes.c': ['.'],

--- a/tests/cxx/inline_namespace-d1.h
+++ b/tests/cxx/inline_namespace-d1.h
@@ -1,0 +1,15 @@
+//===--- inline_namespace-d1.h - test input file for iwyu -----------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_INLINE_NAMESPACE_D1_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_INLINE_NAMESPACE_D1_H_
+
+#include "tests/cxx/inline_namespace-i1.h"
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_INLINE_NAMESPACE_D1_H_

--- a/tests/cxx/inline_namespace-i1.h
+++ b/tests/cxx/inline_namespace-i1.h
@@ -1,0 +1,24 @@
+//===--- inline_namespace-i1.h - test input file for iwyu -----------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_INLINE_NAMESPACE_I1_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_INLINE_NAMESPACE_I1_H_
+
+namespace xyz {
+inline namespace v1 {
+
+struct Foo {
+  int value;
+};
+
+}  // namespace v1
+}  // namespace xyz
+
+#endif // INCLUDE_WHAT_YOU_USE_TESTS_CXX_INLINE_NAMESPACE_I1_H_
+

--- a/tests/cxx/inline_namespace.cc
+++ b/tests/cxx/inline_namespace.cc
@@ -1,0 +1,26 @@
+//===--- inline_namespace.cc - test input file for iwyu -------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// Tests that IWYU never considers a decl inside an inline namespace
+// forward-declarable, and that diagnostics never mention the inline namespace
+// name (xyz::v1).
+
+#include "tests/cxx/inline_namespace.h"
+
+// IWYU: xyz::Foo is...*inline_namespace-i1.h
+int Function(const xyz::Foo& foo) {
+  // IWYU: xyz::Foo is...*inline_namespace-i1.h
+  return foo.value;
+}
+
+/**** IWYU_SUMMARY
+
+(tests/cxx/inline_namespace.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/inline_namespace.h
+++ b/tests/cxx/inline_namespace.h
@@ -1,0 +1,35 @@
+//===--- inline_namespace.h - test input file for iwyu --------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_INLINE_NAMESPACE_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_INLINE_NAMESPACE_H_
+
+#include "tests/cxx/inline_namespace-d1.h"
+
+// A forward-declare would typically be enough here, but the presence of the
+// inline namespace xyz::v1 disqualifies forward declaration, and promotes it to
+// a full use.
+
+// IWYU: xyz::Foo is...*inline_namespace-i1.h
+int Function(const xyz::Foo& foo);
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_INLINE_NAMESPACE_H_
+
+/**** IWYU_SUMMARY
+
+tests/cxx/inline_namespace.h should add these lines:
+#include "tests/cxx/inline_namespace-i1.h"
+
+tests/cxx/inline_namespace.h should remove these lines:
+- #include "tests/cxx/inline_namespace-d1.h"  // lines XX-XX
+
+The full include-list for tests/cxx/inline_namespace.h:
+#include "tests/cxx/inline_namespace-i1.h"  // for Foo
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
See commit message for details.

Add a small commit to remove a method that already exists in the Clang API, to trade for the new `IsInInlineNamespace`.