### PR TITLE
Add associated headers' glob to report violations for.

### DIFF
--- a/iwyu_preprocessor.cc
+++ b/iwyu_preprocessor.cc
@@ -531,6 +531,8 @@ void IwyuPreprocessorInfo::AddDirectInclude(
         ->AddAssociatedHeader(GetFromFileInfoMap(includee));
     VERRS(4) << "Marked " << GetFilePath(includee)
              << " as associated header of " << GetFilePath(includer) << ".\n";
+
+    AddGlobToReportIWYUViolationsFor(GetFilePath(includee));
   }
 
   // Besides marking headers as "associated header" with heuristics, the user

--- a/tests/cxx/associated_include_roundabout.cc
+++ b/tests/cxx/associated_include_roundabout.cc
@@ -1,0 +1,33 @@
+//===--- associated_include_roundabout.cc - test input file for iwyu ------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// Tests that is we include headers that include our associated header, we still
+// record it as belonging to the main compilation unit. In this case, our first
+// header includes our associated header. Related issue:
+// https://github.com/include-what-you-use/include-what-you-use/issues/738
+
+#include "tests/cxx/associated_include_roundabout_1.h"
+#include "tests/cxx/associated_include_roundabout.h"
+
+namespace hfile {
+AssociatedIncludeClass aic;
+AnotherOne ao;
+}
+
+/**** IWYU_SUMMARY
+
+tests/cxx/associated_include.cc should add these lines:
+
+tests/cxx/associated_include.cc should remove these lines:
+
+The full include-list for tests/cxx/associated_include.cc:
+#include "tests/cxx/associated_include_roundabout.h"
+#include "tests/cxx/associated_include_roundabout_1.h"
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/associated_include_roundabout.h
+++ b/tests/cxx/associated_include_roundabout.h
@@ -1,0 +1,24 @@
+//===--- associated_include_roundabout.h - test input file for iwyu -------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+namespace hfile {
+class AssociatedIncludeClass { };
+}
+
+/**** IWYU_SUMMARY
+
+tests/cxx/associated_include_roundabout.h should add these lines:
+
+tests/cxx/associated_include_roundabout.h should remove these lines:
+
+The full include-list for tests/cxx/associated_include_roundabout.h:
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/associated_include_roundabout_1.h
+++ b/tests/cxx/associated_include_roundabout_1.h
@@ -1,0 +1,28 @@
+//===--- associated_include.h - test input file for iwyu ------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "tests/cxx/associated_include_roundabout.h"
+
+namespace hfile {
+class AnotherOne { AssociatedIncludeClass aic; };
+}
+
+/**** IWYU_SUMMARY
+
+tests/cxx/associated_include.h should add these lines:
+
+tests/cxx/associated_include.h should remove these lines:
+- #include "tests/cxx/indirect.h"  // lines XX-XX
+
+The full include-list for tests/cxx/associated_include.h:
+#include "tests/cxx/associated_include-i1.h"  // for AssociatedIncludeClass
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
See github issue #738.

One block below, the same call exists to `AddGlobToReportIWYUViolationsFor`. It seems to have been forgotten in this branch. 