### PR TITLE
Correctly handle enums which use typedefed types

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -1800,6 +1800,17 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
     return true;
   }
 
+  bool VisitEnumDecl(clang::EnumDecl* decl) {
+    if (CanIgnoreCurrentASTNode())
+      return true;
+
+    clang::QualType integer_type = decl->getIntegerType();
+    if (const clang::Type* type = integer_type.getTypePtrOrNull()) {
+      ReportTypeUse(CurrentLoc(), type);
+    }
+    return Base::VisitEnumDecl(decl);
+  }
+
   // If you say 'typedef Foo Bar', C++ says you just need to
   // forward-declare Foo.  But iwyu would rather you fully define Foo,
   // so all users of Bar don't have to.  We make two exceptions:

--- a/run_iwyu_tests.py
+++ b/run_iwyu_tests.py
@@ -146,6 +146,7 @@ class OneIwyuTest(unittest.TestCase):
       'double_include.cc': ['.'],
       'elaborated_struct.c': ['.'],
       'elaborated_type.cc': ['.'],
+      'enum_base.cc': ['.'],
       'export_nesting.cc': ['.'],
       'external_including_internal.cc': ['.'],
       'forward_declare_in_macro.cc': ['.'],

--- a/tests/cxx/enum_base-d1.h
+++ b/tests/cxx/enum_base-d1.h
@@ -1,0 +1,15 @@
+//===--- enum_base-d1.h - test input file for iwyu ------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_ENUM_BASE_D1_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_ENUM_BASE_D1_H_
+
+#include "tests/cxx/enum_base-i1.h"
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_ENUM_BASE_D1_H_

--- a/tests/cxx/enum_base-i1.h
+++ b/tests/cxx/enum_base-i1.h
@@ -1,0 +1,15 @@
+//===--- enum_base-i1.h - test input file for iwyu ------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_ENUM_BASE_I1_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_ENUM_BASE_I1_H_
+
+using int_t = int;
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_ENUM_BASE_I1_H_

--- a/tests/cxx/enum_base.cc
+++ b/tests/cxx/enum_base.cc
@@ -1,0 +1,29 @@
+//===--- enum_base.cc - test input file for iwyu --------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/enum_base-d1.h"
+
+// IWYU: int_t is...*tests/cxx/enum_base-i1.h
+enum class Test : int_t {
+    VALUE1,
+    VALUE2
+};
+
+/**** IWYU_SUMMARY
+
+tests/cxx/enum_base.cc should add these lines:
+#include "tests/cxx/enum_base-i1.h"
+
+tests/cxx/enum_base.cc should remove these lines:
+- #include "tests/cxx/enum_base-d1.h"  // lines XX-XX
+
+The full include-list for tests/cxx/enum_base.cc:
+#include "tests/cxx/enum_base-i1.h"  // for int_t
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
Previously enum declarations based on integers types weren't traversed by IWYU and it was suggesting to remove header with types definitions:

```cpp
#include <cstdint> // IWYU removed this header

enum class Test : int32_t {
    VALUE1,
    VALUE2
};
```