### PR TITLE
Ignore file extension case when detecting main CU in fix_includes.py

### DIFF
--- a/fix_includes.py
+++ b/fix_includes.py
@@ -1571,8 +1571,8 @@ def _IsMainCUInclude(line_info, filename):
     return True
   # First, normalize the includee by getting rid of -inl.h and .h
   # suffixes (for the #include) and the "'s around the #include line.
-  canonical_include = re.sub(r'(-inl\.h|\.h|\.H|\.hpp)$',
-                             '', line_info.key.replace('"', ''))
+  canonical_include = re.sub(r'(-inl\.h|\.h|\.hpp)$', '',
+                             line_info.key.replace('"', ''), flags=re.I)
   # Then normalize includer by stripping extension and Google's test suffixes.
   canonical_file, _ = os.path.splitext(filename)
   canonical_file = re.sub(r'(_unittest|_regtest|_test)$', '', canonical_file)

--- a/fix_includes_test.py
+++ b/fix_includes_test.py
@@ -3791,6 +3791,24 @@ The full include-list for barrier_includes.h:
                          self.actual_after_contents)
     self.assertEqual(1, num_files_modified)
 
+  def testSortingMainCUIncludeWithMixedCaseInl(self):
+    """Check that we identify when first -inl.hpp file with mixed case
+    is a main-cu #include."""
+    infile = """\
+#include <stdio.h>
+#include "foo-InL.h"
+"""
+    expected_output = """\
+#include "foo-InL.h"
+#include <stdio.h>
+"""
+    self.RegisterFileContents({'foo.cc': infile})
+    num_files_modified = fix_includes.SortIncludesInFiles(
+        ['foo.cc'], self.flags)
+    self.assertListEqual(expected_output.splitlines(True),
+                         self.actual_after_contents)
+    self.assertEqual(1, num_files_modified)
+
   def testSortingMainCUIncludeInSameDirectoryWithInl(self):
     """Check that we identify when first -inl.h file is a main-cu #include."""
     infile = """\


### PR DESCRIPTION
With this approach there's no need in explicitly specifying all cases in a replacement regex `(-inl\.h|\.h)`.