### PR TITLE
Handle binary type traits

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -2224,6 +2224,29 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
     return true;
   }
 
+  bool VisitTypeTraitExpr(clang::TypeTraitExpr* expr) {
+    if (CanIgnoreCurrentASTNode())
+      return true;
+
+    // We assume that all type traits with >= 2 arguments require
+    // full type information even for pointer types. For example,
+    // this is the case for `__is_convertible_to` trait.
+    if (expr == nullptr || expr->getNumArgs() < 2)
+      return true;
+
+    for (const clang::TypeSourceInfo* arg : expr->getArgs()) {
+      clang::QualType qual_type = arg->getType();
+      const Type* type = qual_type.getTypePtr();
+      const Type* deref_type = RemovePointersAndReferencesAsWritten(type);
+
+      if (!CanIgnoreType(deref_type)) {
+        ReportTypeUse(CurrentLoc(), deref_type);
+      }
+    }
+
+    return true;
+  }
+
   // Mark that we need the full type info for the thing we're taking
   // sizeof of.  Sometimes this is double-counting: for
   // sizeof(some_type), RecursiveASTVisitor will visit some_type and

--- a/run_iwyu_tests.py
+++ b/run_iwyu_tests.py
@@ -129,6 +129,7 @@ class OneIwyuTest(unittest.TestCase):
       'backwards_includes.cc': ['.'],
       'badinc.cc': ['.'],
       'badinc-extradef.cc': ['.'],
+      'binary_type_trait.cc': ['.'],
       'builtins_with_mapping.cc': ['.'],
       'funcptrs.cc': ['.'],
       'casts.cc': ['.'],

--- a/tests/cxx/binary_type_trait-d1.h
+++ b/tests/cxx/binary_type_trait-d1.h
@@ -1,0 +1,15 @@
+//===--- binary_type_trait-d1.h - test input file for iwyu ----------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_BINARY_TYPE_TRAIT_D1_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_BINARY_TYPE_TRAIT_D1_H_
+
+#include "tests/cxx/binary_type_trait-i2.h"
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_BINARY_TYPE_TRAIT_D1_H_

--- a/tests/cxx/binary_type_trait-i1.h
+++ b/tests/cxx/binary_type_trait-i1.h
@@ -1,0 +1,15 @@
+//===--- binary_type_trait-i1.h - test input file for iwyu ----------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_BINARY_TYPE_TRAIT_I1_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_BINARY_TYPE_TRAIT_I1_H_
+
+class BinaryTypeTraitBase {};
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_BINARY_TYPE_TRAIT_I1_H_

--- a/tests/cxx/binary_type_trait-i2.h
+++ b/tests/cxx/binary_type_trait-i2.h
@@ -1,0 +1,17 @@
+//===--- binary_type_trait-i2.h - test input file for iwyu ----------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_BINARY_TYPE_TRAIT_I2_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_BINARY_TYPE_TRAIT_I2_H_
+
+#include "tests/cxx/binary_type_trait-i1.h"
+
+class BinaryTypeTraitDerived : public BinaryTypeTraitBase {};
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_BINARY_TYPE_TRAIT_I2_H_

--- a/tests/cxx/binary_type_trait.cc
+++ b/tests/cxx/binary_type_trait.cc
@@ -1,0 +1,48 @@
+//===--- binary_type_trait.cc - test input file for iwyu ------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/binary_type_trait-d1.h"
+
+int main() {
+    // IWYU: BinaryTypeTraitBase is...*binary_type_trait-i1.h
+    // IWYU: BinaryTypeTraitBase needs a declaration
+    // IWYU: BinaryTypeTraitDerived is...*binary_type_trait-i2.h
+    // IWYU: BinaryTypeTraitDerived needs a declaration
+    static_assert(__is_convertible_to(BinaryTypeTraitDerived*, BinaryTypeTraitBase*),
+        "Derived should be convertible to the Base class");
+
+    // IWYU: BinaryTypeTraitBase is...*binary_type_trait-i1.h
+    // IWYU: BinaryTypeTraitBase needs a declaration
+    // IWYU: BinaryTypeTraitDerived is...*binary_type_trait-i2.h
+    // IWYU: BinaryTypeTraitDerived needs a declaration
+    static_assert(!__is_convertible_to(BinaryTypeTraitDerived**, BinaryTypeTraitBase**),
+        "Indirect pointers shouldn't be convertible");
+
+    // IWYU: BinaryTypeTraitBase is...*binary_type_trait-i1.h
+    // IWYU: BinaryTypeTraitBase needs a declaration
+    // IWYU: BinaryTypeTraitDerived is...*tests/cxx/binary_type_trait-i2.h
+    // IWYU: BinaryTypeTraitDerived needs a declaration
+    static_assert(__is_convertible_to(BinaryTypeTraitDerived&, BinaryTypeTraitBase&),
+        "Derived should be convertible to the Base class");
+}
+
+/**** IWYU_SUMMARY
+
+tests/cxx/binary_type_trait.cc should add these lines:
+#include "tests/cxx/binary_type_trait-i1.h"
+#include "tests/cxx/binary_type_trait-i2.h"
+
+tests/cxx/binary_type_trait.cc should remove these lines:
+- #include "tests/cxx/binary_type_trait-d1.h"  // lines XX-XX
+
+The full include-list for tests/cxx/binary_type_trait.cc:
+#include "tests/cxx/binary_type_trait-i1.h"  // for BinaryTypeTraitBase
+#include "tests/cxx/binary_type_trait-i2.h"  // for BinaryTypeTraitDerived
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
Clang has 4 binary type traits

```
__is_base_of
__is_convertible_to
__is_convertible
__is_same
```

and all of them require full type information even for pointers, so the following code would work correctly:

```cpp
#include "Derived.hpp"
#include "Base.hpp"

static_assert(__is_convertible_to(Derived*, Base*), "Should be convertible!");
```

**NOTE:** Replacing includes with forward declarations won't break the build for this case, but will change the behavior: type trait will return `false` instead of `true`.