### PR TITLE
[travis] Remove lit-cpuid workaround

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,6 @@ addons:
      - llvm-10-tools
      - libclang-10-dev
      - clang-10
-     # TODO: This is required for lit-cpuid, which is exported from
-     # LLVMConfig.cmake, but shipped with LLDB.
-     - lldb-10
 
 before_install:
  # Install a supported cmake version (>= 3.4.3)


### PR DESCRIPTION
`lit-cpuid` is no longer part of the LLVM cmake modules, so we don't need to spend time installing lldb for it to work.