### PR TITLE
Use new behavior for CMake policy CMP0077

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,10 @@ endif()
 
 if (NOT IWYU_IN_TREE)
   cmake_policy(SET CMP0048 NEW)
+  if (POLICY CMP0077)
+    cmake_policy(SET CMP0077 NEW)
+  endif()
+
   project(include-what-you-use)
 
   find_package(LLVM CONFIG REQUIRED)


### PR DESCRIPTION
This follows the LLVM default and suppresses a warning from CMake when
building with llvm-11.