### PR TITLE
Don't second-guess template specializations

### DIFF
--- a/iwyu_output.cc
+++ b/iwyu_output.cc
@@ -1389,14 +1389,10 @@ void CalculateIwyuForForwardDeclareUse(
 
   // If this record is defined in one of the desired_includes, mark that
   // fact.  Also if it's defined in one of the actual_includes.
-  const NamedDecl* dfn = GetDefinitionForClass(use->decl());
-  // If we are, ourselves, a template specialization, then the definition
-  // we use is not the definition of the specialization (that's us), but
-  // the definition of the template we're specializing.
-  if (spec_decl && dfn == spec_decl)
-    dfn = GetDefinitionForClass(spec_decl->getSpecializedTemplate());
   bool dfn_is_in_desired_includes = false;
   bool dfn_is_in_actual_includes = false;
+
+  const NamedDecl* dfn = GetDefinitionForClass(use->decl());
   if (dfn) {
     vector<string> headers
       = GlobalIncludePicker().GetCandidateHeadersForFilepathIncludedFrom(

--- a/tests/cxx/specialization_needs_decl-d1.h
+++ b/tests/cxx/specialization_needs_decl-d1.h
@@ -7,6 +7,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "tests/cxx/specialization_needs_decl-i1.h"
+
 template <typename T> struct TplStruct { };
 
 template <> struct TplStruct<float> { };

--- a/tests/cxx/specialization_needs_decl-i1.h
+++ b/tests/cxx/specialization_needs_decl-i1.h
@@ -1,0 +1,18 @@
+//===--- specialization_needs_decl-i1.h - test input file -------*- C++ -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// This is employed to show that when the template specialization is used, the
+// base template is not required in full. Issue #735.
+
+// Base template
+template<typename>
+struct Template;
+
+// Specialization for int
+template<> struct Template<int> { int x; };

--- a/tests/cxx/specialization_needs_decl.cc
+++ b/tests/cxx/specialization_needs_decl.cc
@@ -19,15 +19,26 @@ template<> struct TplStruct<int> { };
 // the definition.
 template<> struct TplStruct<float>;
 
+// Full-using a specialization requires definition of the specialization to be
+// included. Not the base template.
+
+// IWYU: Template needs a declaration
+int f(Template<int>& t) {
+  // IWYU: Template is...*specialization_needs_decl-i1.h
+  return t.x;
+}
+
 /**** IWYU_SUMMARY
 
 tests/cxx/specialization_needs_decl.cc should add these lines:
+#include "tests/cxx/specialization_needs_decl-i1.h"
 template <typename T> struct TplStruct;
 
 tests/cxx/specialization_needs_decl.cc should remove these lines:
 - #include "tests/cxx/specialization_needs_decl-d1.h"  // lines XX-XX
 
 The full include-list for tests/cxx/specialization_needs_decl.cc:
+#include "tests/cxx/specialization_needs_decl-i1.h"  // for Template
 template <typename T> struct TplStruct;
 
 ***** IWYU_SUMMARY */


### PR DESCRIPTION
Before this patch, IWYU would skip past template specializations and go
for the base template when trying to find the definition for a class
template.

This led to misbehavior as reported in issue #735 so that:

    // template.hpp
    template<typename>
    struct T;

    template<> struct T<int> { int x; };

    // source.cpp
    #include "template.hpp"

    int f(T<int>& t) { return t.x; }

would require a forward declaration of the base template in source.cpp.

Remove this step on the basis that we _are_ in fact using the
specialization, and the file containing the specialization will probably
have some declaration (or even definition) of the base template.