### PR TITLE
Clean up travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,6 @@ before_install:
  - PREFIX_PATH=`llvm-config-$VERSION --prefix`
  - BIN_PATH=`llvm-config-$VERSION --bindir`
 
- # TODO: Remove these hacky fixups
- - (cd $PREFIX_PATH/lib && sudo ln -rsf libclang-cpp.so.1 libclang-cpp-$VERSION.so.1)
-
 script:
 # Build IWYU
  - mkdir build

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,9 @@ addons:
        key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
     packages:
      - ninja-build
-     # TODO: These should really be the snapshots packages, but they are currently
-     # broken. Remove the version suffix once they get fixed (see issue #642 for
-     # more info)
-     - llvm-11-dev
-     - llvm-11-tools
-     - libclang-11-dev
-     - clang-11
+     - llvm-dev
+     - libclang-dev
+     - clang
 
 before_install:
  # Install a supported cmake version (>= 3.4.3)


### PR DESCRIPTION
We had a number of workarounds for broken upstream packaging.

Those problems have since been fixed, so these commits should close #642 and #691. 
