### PR TITLE
Check for nullptr before calling member function [clang_9.0]

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -326,7 +326,7 @@ class BaseAstVisitor : public RecursiveASTVisitor<Derived> {
   void set_current_ast_node(ASTNode* an) { current_ast_node_ = an; }
 
   bool TraverseDecl(Decl* decl) {
-    if (current_ast_node_->StackContainsContent(decl))
+    if (current_ast_node_ && current_ast_node_->StackContainsContent(decl))
       return true;               // avoid recursion
     ASTNode node(decl, *GlobalSourceManager());
     CurrentASTNodeUpdater canu(&current_ast_node_, &node);
@@ -334,7 +334,7 @@ class BaseAstVisitor : public RecursiveASTVisitor<Derived> {
   }
 
   bool TraverseStmt(Stmt* stmt) {
-    if (current_ast_node_->StackContainsContent(stmt))
+    if (current_ast_node_ && current_ast_node_->StackContainsContent(stmt))
       return true;               // avoid recursion
     ASTNode node(stmt, *GlobalSourceManager());
     CurrentASTNodeUpdater canu(&current_ast_node_, &node);
@@ -345,7 +345,7 @@ class BaseAstVisitor : public RecursiveASTVisitor<Derived> {
     if (qualtype.isNull())
       return Base::TraverseType(qualtype);
     const Type* type = qualtype.getTypePtr();
-    if (current_ast_node_->StackContainsContent(type))
+    if (current_ast_node_ && current_ast_node_->StackContainsContent(type))
       return true;               // avoid recursion
     ASTNode node(type, *GlobalSourceManager());
     CurrentASTNodeUpdater canu(&current_ast_node_, &node);
@@ -369,7 +369,7 @@ class BaseAstVisitor : public RecursiveASTVisitor<Derived> {
     if (typeloc.getAs<QualifiedTypeLoc>()) {
       typeloc = typeloc.getUnqualifiedLoc();
     }
-    if (current_ast_node_->StackContainsContent(&typeloc))
+    if (current_ast_node_ && current_ast_node_->StackContainsContent(&typeloc))
       return true;               // avoid recursion
     ASTNode node(&typeloc, *GlobalSourceManager());
     CurrentASTNodeUpdater canu(&current_ast_node_, &node);


### PR DESCRIPTION
Calling a member function on a nullpointer object is Undefined
Behaviour. When IWYU was compiled with -Os it crashed with a segmentation
fault due to the compiler exploiting this UB for performance reasons.

This patch simply checks current_ast_node_ for nullptr before calling
member functions.

Backported from 147c2b3.