### PR TITLE
Prevent deleting duplicate nested forward decls

### DIFF
--- a/fix_includes_test.py
+++ b/fix_includes_test.py
@@ -2945,6 +2945,34 @@ template <typename T> class B;  // lines 4-5
     self.RegisterFileContents({'dont_remove_template_lines': infile})
     self.ProcessAndTest(iwyu_output)
 
+  def testDontRemoveSimilarNestedDeclarations(self):
+    """Tests we don't accidentally think repeated nested forward declarations
+    are dupes."""
+    infile = """\
+#include <notused.h>  ///-
+
+class A {
+  class Inner;
+};
+
+class B {
+  class Inner;
+};
+"""
+    iwyu_output = """\
+dont_remove_similar_nested should add these lines:
+
+dont_remove_similar_nested should remove these lines:
+- #include <notused.h>  // lines 1-1
+
+The full include-list for dont_remove_similar_nested:
+class A::Inner;  // lines 4-4
+class B::Inner;  // lines 8-8
+---
+"""
+    self.RegisterFileContents({'dont_remove_similar_nested': infile})
+    self.ProcessAndTest(iwyu_output)
+
   def testNestedNamespaces(self):
     infile = """\
 // Copyright 2010


### PR DESCRIPTION
`fix_includes.py` could be over-zealous and delete forward declarations of nested classes if they happened to share a name with another nested class in the same file.  This was because the analysis of top-level spans detected `#ifdef`s and namespaces, but not classes as things which made code non-top-level.

This has probably never been noticed before because it only affects classes declared in the global namespace, which is poor practice, but something I need to deal with, so I hope IWYU can too.

Luckily, the IWYU output makes it obvious when a forward declaration is for a nested class.  Take advantage of that to fix this bug.

Also, add a regression test.