### PR TITLE
Fix handling of alias templates

### DIFF
--- a/iwyu_ast_util.h
+++ b/iwyu_ast_util.h
@@ -744,6 +744,16 @@ const clang::Type* RemovePointersAndReferences(const clang::Type* type);
 // this function returns nullptr.
 const clang::NamedDecl* TypeToDeclAsWritten(const clang::Type* type);
 
+// This is similar to TypeToDeclAsWritten, but in this case we are less
+// interested in how the type was written; we want the Decl which we can
+// explore the contents of, for example to determine which of its template
+// arguments are used in a manner that constitutes a full use.
+//
+// The difference arises particularly for type aliases, where
+// TypeToDeclAsWritten returns the Decl for the alias, whereas
+// TypeToDeclForContent returns the underlying aliased Decl.
+const clang::NamedDecl* TypeToDeclForContent(const clang::Type* type);
+
 // Returns true if it's possible to implicitly convert a value of a
 // different type to 'type' via an implicit constructor.
 bool HasImplicitConversionConstructor(const clang::Type* type);

--- a/tests/cxx/alias_template_use-d1.h
+++ b/tests/cxx/alias_template_use-d1.h
@@ -1,0 +1,10 @@
+//===--- alias_template_use-d1.h - test input file for iwyu ---------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "alias_template_use-i1.h"

--- a/tests/cxx/alias_template_use-i1.h
+++ b/tests/cxx/alias_template_use-i1.h
@@ -1,0 +1,14 @@
+//===--- alias_template_use-i1.h - test input file for iwyu ---------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "alias_template_use-i2.h"
+
+template<typename T>
+using AliasTemplate = AliasedTemplate<T>;
+

--- a/tests/cxx/alias_template_use-i2.h
+++ b/tests/cxx/alias_template_use-i2.h
@@ -1,0 +1,11 @@
+//===--- alias_template_use-i2.h - test input file for iwyu ---------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+template<typename T>
+class AliasedTemplate {};

--- a/tests/cxx/alias_template_use.cc
+++ b/tests/cxx/alias_template_use.cc
@@ -1,0 +1,35 @@
+//===--- alias_template_use.cc - test input file for iwyu -----------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// Tests that use of template aliases is assigned to the header defining the
+// alias, rather than the underlying type.
+
+#include "alias_template_use-d1.h"
+
+template<typename T>
+class A {
+};
+
+class B {
+  // IWYU: AliasTemplate is...*alias_template_use-i1.h
+  A<AliasTemplate<int>> a;
+};
+
+/**** IWYU_SUMMARY
+
+tests/cxx/alias_template_use.cc should add these lines:
+#include "alias_template_use-i1.h"
+
+tests/cxx/alias_template_use.cc should remove these lines:
+- #include "alias_template_use-d1.h"  // lines XX-XX
+
+The full include-list for tests/cxx/alias_template_use.cc:
+#include "alias_template_use-i1.h"  // for AliasTemplate
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
When an alias template was used, IWYU would resolve it to the underlying aliased type rather than the template for the purposes of determining what header was required.  This led to incorrect header removals in some cases.  The test added in this PR demonstrates such a situation.

Fixes #703.

Fix that by splitting the `TypeToDeclAsWritten` into two functions: `TypeToDeclAsWritten` and `TypeToDeclForContent`.  The former is used for determining uses of the `Decl` itself, the latter is used for determining uses of the arguments passed to the template.

`TypeToDeclForContent` has the old behaviour of `TypeToDeclAsWritten` wheras the new `TypeToDeclAsWritten` prefers to report the alias template rather than the underlying `Decl`.

I only switched one call location to `TypeToDeclForContent`.  It's possible more should be changed, but this was the only one required to make the tests pass.  If you'd like me to try to review the other call sites then I can do so.