### PR TITLE
Ignore tags file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,7 @@ __pycache__
 
 .gdb_history
 compile_commands.json
+tags
+TAGS
 
 /build


### PR DESCRIPTION
Add `tags` to `.gitignore`.

Tags files (a la [ctags](https://en.wikipedia.org/wiki/Ctags)) ought to be common enough that this is a reasonable entry to have.  In particular, I find them useful.