### PR TITLE
Handle template specializations like classes

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -721,6 +721,12 @@ class BaseAstVisitor : public RecursiveASTVisitor<Derived> {
     return true;
   }
 
+  bool TraverseClassTemplateSpecializationDecl(
+      clang::ClassTemplateSpecializationDecl* decl) {
+    if (!Base::TraverseClassTemplateSpecializationDecl(decl)) return false;
+    return TraverseCXXRecordDecl(decl);
+  }
+
   //------------------------------------------------------------
   // (5) Add TraverseImplicitDestructorCall and HandleFunctionCall.
 

--- a/tests/cxx/template_specialization.cc
+++ b/tests/cxx/template_specialization.cc
@@ -11,6 +11,7 @@
 // it to the right location.
 
 #include "tests/cxx/template_specialization-d1.h"
+#include "tests/cxx/direct.h"
 
 template<typename T> class Foo;
 
@@ -38,18 +39,30 @@ TplTplStruct<> tts;
 TplTplStruct<Foo> tts2;
 
 
+template<typename T>
+struct Specialized;
+
+template<>
+// IWYU: IndirectClass is...*indirect.h
+struct Specialized<int> : IndirectClass {};
+
+
 /**** IWYU_SUMMARY
 
 tests/cxx/template_specialization.cc should add these lines:
+#include "tests/cxx/indirect.h"
 #include "tests/cxx/template_specialization-i1.h"
 #include "tests/cxx/template_specialization-i2.h"
 
 tests/cxx/template_specialization.cc should remove these lines:
+- #include "tests/cxx/direct.h"  // lines XX-XX
 - #include "tests/cxx/template_specialization-d1.h"  // lines XX-XX
 - template <typename T> class Foo;  // lines XX-XX
 
 The full include-list for tests/cxx/template_specialization.cc:
+#include "tests/cxx/indirect.h"  // for IndirectClass
 #include "tests/cxx/template_specialization-i1.h"  // for Foo
 #include "tests/cxx/template_specialization-i2.h"  // for Foo
+template <typename T> struct Specialized;  // lines XX-XX+1
 
 ***** IWYU_SUMMARY */


### PR DESCRIPTION
Class template specializations were not being traversed in the same way as regular classes (specifically, `CXXRecordDecl`s).  But they should be essentially equivalent.  Add a `TraverseClassTemplateSpecializationDecl` which forwards to `TraverseCXXRecordDecl` to make this so.

In particular, this means that base classes of template specializations will be recorded as uses now, where previously they were not.

I suspect that there is a similar problem with partial specializations, but I'm not trying to fix that here.

I was somewhat surprised that such a simple solution would work, but it didn't break any other tests, so I'm cautiously optimistic.