### PR TITLE
Aliases in templates

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -2275,6 +2275,8 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
   bool VisitUnaryExprOrTypeTraitExpr(clang::UnaryExprOrTypeTraitExpr* expr) {
     if (CanIgnoreCurrentASTNode())  return true;
 
+    current_ast_node()->set_in_forward_declare_context(false);
+
     // Calling sizeof on a reference-to-X is the same as calling it on X.
     // If sizeof() takes a type, this is easy to check.  If sizeof()
     // takes an expr, it's hard to tell -- GetTypeOf(expr) 'sees through'

--- a/iwyu.cc
+++ b/iwyu.cc
@@ -3120,6 +3120,11 @@ class InstantiatedTemplateVisitor
       if (ast_node->IsA<TypedefNameDecl>()) {
         return;
       }
+      if (ast_node->IsA<TemplateSpecializationType>()) {
+        // If we hit a template specialization node before the typedef then we
+        // probably still need a full-use, so stop looking.
+        break;
+      }
     }
 
     // sizeof(a reference type) is the same as sizeof(underlying type).

--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -233,6 +233,14 @@ bool IsElaborationNode(const ASTNode* ast_node) {
   return elaborated_type && elaborated_type->getKeyword() != clang::ETK_None;
 }
 
+const ASTNode* MostElaboratedAncestor(const ASTNode* ast_node) {
+  // Read past elaborations like 'class' keyword or namespaces.
+  while (ast_node->ParentIsA<ElaboratedType>()) {
+    ast_node = ast_node->parent();
+  }
+  return ast_node;
+}
+
 bool IsQualifiedNameNode(const ASTNode* ast_node) {
   if (ast_node == nullptr)
     return false;

--- a/iwyu_ast_util.h
+++ b/iwyu_ast_util.h
@@ -376,6 +376,11 @@ class CurrentASTNodeUpdater {
 // uses ElaboratedType for namespaces ('ns::Foo myvar').
 bool IsElaborationNode(const ASTNode* ast_node);
 
+// Walk up to parents of the given node so long as each parent is an
+// elaboration node (in the sense of IsElaborationNode).
+// Can expand from a node representing 'X' to e.g. 'struct X' or 'mylib::X'.
+const ASTNode* MostElaboratedAncestor(const ASTNode* ast_node);
+
 // See if a given ast_node is a qualified name part of an ElaboratedType
 // node (e.g. 'class ns::Foo x', 'class ::Global x' or 'class Outer::Inner x'.)
 bool IsQualifiedNameNode(const ASTNode* ast_node);

--- a/iwyu_ast_util.h
+++ b/iwyu_ast_util.h
@@ -699,6 +699,11 @@ bool IsClassType(const clang::Type* type);
 // However, vector<T> is *not* converted to vector<int>.
 const clang::Type* RemoveSubstTemplateTypeParm(const clang::Type* type);
 
+// Returns true if any type involved (recursively examining template
+// arguments) satisfies the given predicate.
+bool InvolvesTypeForWhich(const clang::Type* type,
+                          std::function<bool(const clang::Type*)> pred);
+
 // Returns true if type is a pointer type (pointer or reference,
 // looking through elaborations like 'class Foo*' (vs 'Foo*'),
 // but *not* following typedefs (which is why we can't just use

--- a/run_iwyu_tests.py
+++ b/run_iwyu_tests.py
@@ -200,6 +200,7 @@ class OneIwyuTest(unittest.TestCase):
       'relative_exported_mapped_include.cc': ['tests/cxx/subdir'],
       'remove_fwd_decl_when_including.cc': ['.'],
       'self_include.cc': ['.'],
+      'sizeof_in_template_arg.cc': ['.'],
       'sizeof_reference.cc': ['.'],
       'specialization_needs_decl.cc': ['.'],
       'system_namespaces.cc': ['.'],

--- a/tests/cxx/alias_template.cc
+++ b/tests/cxx/alias_template.cc
@@ -11,19 +11,19 @@
 
 #include "tests/cxx/direct.h"
 
-template<class T> struct FullUseTemplateArg {
+template<class T> struct FullUseTemplateArgInSizeof {
   char argument[sizeof(T)];
 };
 
 // Test that we go through alias template and handle aliased template
 // specialization.
-template<class T> using Alias = FullUseTemplateArg<T>;
+template<class T> using Alias = FullUseTemplateArgInSizeof<T>;
 // IWYU: IndirectClass needs a declaration
 // IWYU: IndirectClass is...*indirect.h
 Alias<IndirectClass> alias;
 
 // Test following through entire chain of aliases.
-template<class T> using AliasChain1 = FullUseTemplateArg<T>;
+template<class T> using AliasChain1 = FullUseTemplateArgInSizeof<T>;
 template<class T> using AliasChain2 = AliasChain1<T>;
 // IWYU: IndirectClass needs a declaration
 // IWYU: IndirectClass is...*indirect.h
@@ -32,6 +32,18 @@ AliasChain2<IndirectClass> aliasChain;
 // Test the case when aliased type isn't a template specialization.
 template<class T> using Pointer = T*;
 Pointer<int> intPtr;
+
+template <class T>
+struct FullUseTemplateArgAsVar {
+  T t;
+};
+
+// Test the used class being nested deeper in the alias
+template <typename T>
+using AliasNested = FullUseTemplateArgAsVar<FullUseTemplateArgAsVar<T>>;
+// IWYU: IndirectClass needs a declaration
+// IWYU: IndirectClass is...*indirect.h
+AliasNested<IndirectClass> aliasNested;
 
 /**** IWYU_SUMMARY
 

--- a/tests/cxx/alias_template.cc
+++ b/tests/cxx/alias_template.cc
@@ -41,9 +41,16 @@ struct FullUseTemplateArgAsVar {
 // Test the used class being nested deeper in the alias
 template <typename T>
 using AliasNested = FullUseTemplateArgAsVar<FullUseTemplateArgAsVar<T>>;
+
 // IWYU: IndirectClass needs a declaration
 // IWYU: IndirectClass is...*indirect.h
 AliasNested<IndirectClass> aliasNested;
+
+template <typename T>
+using AliasNested2 = FullUseTemplateArgInSizeof<FullUseTemplateArgInSizeof<T>>;
+// IWYU: IndirectClass needs a declaration
+// IWYU: IndirectClass is...*indirect.h
+AliasNested2<IndirectClass> aliasNested2;
 
 /**** IWYU_SUMMARY
 

--- a/tests/cxx/precomputed_tpl_args.cc
+++ b/tests/cxx/precomputed_tpl_args.cc
@@ -61,11 +61,10 @@ std::bitset<5> bitset;
 // for map<T, SpecializationClass>, we should only consider T.
 
 template<typename T> class TemplatedClass {
-  // TODO(csilvers): IWYU: SpecializationClass is...*precomputed_tpl_args-i1.h
-  // TODO(csilvers): IWYU: std::less is...*precomputed_tpl_args-i1.h
+  // IWYU: SpecializationClass is...*precomputed_tpl_args-i1.h
   // IWYU: SpecializationClass needs a declaration
   std::map<SpecializationClass, T> t1;
-  // TODO(csilvers): IWYU: IndirectClass is...*precomputed_tpl_args-i1.h
+  // IWYU: IndirectClass is...*precomputed_tpl_args-i1.h
   // IWYU: IndirectClass needs a declaration
   std::map<T, IndirectClass> t3;
 };

--- a/tests/cxx/sizeof_in_template_arg.cc
+++ b/tests/cxx/sizeof_in_template_arg.cc
@@ -1,0 +1,41 @@
+//===--- sizeof_in_template_arg.cc - test input file for iwyu -------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/direct.h"
+
+// This verifies that using sizeof(...) means that the argument of sizeof
+// doesn't count as being in a forward-declare context.  In particular, when
+// it's used as a template argument.
+
+template <unsigned long Size>
+struct Storage {
+  char storage[Size];
+};
+
+template <typename T>
+struct Public {
+  Storage<sizeof(T)> storage;
+};
+
+// IWYU: IndirectClass is...*indirect.h
+// IWYU: IndirectClass needs a declaration
+Public<IndirectClass> p;
+
+/**** IWYU_SUMMARY
+
+tests/cxx/sizeof_in_template_arg.cc should add these lines:
+#include "tests/cxx/indirect.h"
+
+tests/cxx/sizeof_in_template_arg.cc should remove these lines:
+- #include "tests/cxx/direct.h"  // lines XX-XX
+
+The full include-list for tests/cxx/sizeof_in_template_arg.cc:
+#include "tests/cxx/indirect.h"  // for IndirectClass
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/typedef_in_template.cc
+++ b/tests/cxx/typedef_in_template.cc
@@ -25,20 +25,27 @@ class Container {
 
 
 void Declarations() {
-  // These do not need the full type for Class because they're template params.
+  // Just using Container does not need the full type for Class because there
+  // are only aliases made, which do not require full-uses.
 
-  // TODO: This is almost certainly wrong, see bug #431
-  // We should not require the full definition of Class for passing it as a
-  // template argument, but we must require it when the typedef it's aliasing
-  // is full-used.
-  // The bug has instructions for how to provoke the error more obviously.
+  // TODO: But currently this is counted as a full-use because Class is used
+  // inside a template specialization (of Pair) within the definition of
+  // Container.
+  // IWYU: Class is...*typedef_in_template-i1.h
+  // IWYU: Class needs a declaration
+  Container<Class> c;
 
+  // Full-using any of those aliases *should* require a full use of Class.
+
+  // IWYU: Class is...*typedef_in_template-i1.h
   // IWYU: Class needs a declaration
   Container<Class>::value_type vt;
 
+  // IWYU: Class is...*typedef_in_template-i1.h
   // IWYU: Class needs a declaration
   Container<Class>::pair_type pt;
 
+  // IWYU: Class is...*typedef_in_template-i1.h
   // IWYU: Class needs a declaration
   Container<Class>::alias_type at;
 }
@@ -77,6 +84,16 @@ struct IndirectlyUsesAliasedParameter {
 // IWYU: IndirectClass needs a declaration
 IndirectlyUsesAliasedParameter<IndirectClass> b;
 
+template <typename T>
+struct NestedUseOfAliasedParameter {
+  using UserAlias = UsesAliasedParameter<T>;
+  UserAlias a;
+};
+
+// IWYU: IndirectClass is...*indirect.h
+// IWYU: IndirectClass needs a declaration
+NestedUseOfAliasedParameter<IndirectClass> c;
+
 /**** IWYU_SUMMARY
 
 tests/cxx/typedef_in_template.cc should add these lines:
@@ -89,6 +106,6 @@ tests/cxx/typedef_in_template.cc should remove these lines:
 
 The full include-list for tests/cxx/typedef_in_template.cc:
 #include "tests/cxx/indirect.h"  // for IndirectClass
-#include "tests/cxx/typedef_in_template-i1.h"  // for Class (ptr only), Pair
+#include "tests/cxx/typedef_in_template-i1.h"  // for Class, Pair
 
 ***** IWYU_SUMMARY */

--- a/tests/cxx/typedef_in_template.cc
+++ b/tests/cxx/typedef_in_template.cc
@@ -7,6 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "tests/cxx/direct.h"
 #include "tests/cxx/typedef_in_template-d1.h"
 
 template<class T>
@@ -42,16 +43,35 @@ void Declarations() {
   Container<Class>::alias_type at;
 }
 
+// STL containers are often implemented via a complex web of type aliases and
+// helper classes.  Tracking uses through all these layers can be non-trivial.
+// The following are some reduced examples in roughly increasing order of
+// complexity which can serve as helpful test cases while debugging such
+// issues.  They were inspired by libstdc++'s implementation of
+// std::unordered_map, but don't directly correspond to it.
+
+template <typename T>
+struct UsesAliasedParameter {
+  using TAlias = T;
+  TAlias t;
+};
+
+// IWYU: IndirectClass is...*indirect.h
+// IWYU: IndirectClass needs a declaration
+UsesAliasedParameter<IndirectClass> a;
 
 /**** IWYU_SUMMARY
 
 tests/cxx/typedef_in_template.cc should add these lines:
+#include "tests/cxx/indirect.h"
 #include "tests/cxx/typedef_in_template-i1.h"
 
 tests/cxx/typedef_in_template.cc should remove these lines:
+- #include "tests/cxx/direct.h"  // lines XX-XX
 - #include "tests/cxx/typedef_in_template-d1.h"  // lines XX-XX
 
 The full include-list for tests/cxx/typedef_in_template.cc:
+#include "tests/cxx/indirect.h"  // for IndirectClass
 #include "tests/cxx/typedef_in_template-i1.h"  // for Class (ptr only), Pair
 
 ***** IWYU_SUMMARY */

--- a/tests/cxx/typedef_in_template.cc
+++ b/tests/cxx/typedef_in_template.cc
@@ -50,6 +50,8 @@ void Declarations() {
 // issues.  They were inspired by libstdc++'s implementation of
 // std::unordered_map, but don't directly correspond to it.
 
+// Verify that a full-use of an alias of a template parameter is treated as a
+// full-use of that parameter.
 template <typename T>
 struct UsesAliasedParameter {
   using TAlias = T;
@@ -59,6 +61,21 @@ struct UsesAliasedParameter {
 // IWYU: IndirectClass is...*indirect.h
 // IWYU: IndirectClass needs a declaration
 UsesAliasedParameter<IndirectClass> a;
+
+// IWYU: IndirectClass is...*indirect.h
+// IWYU: IndirectClass needs a declaration
+UsesAliasedParameter<IndirectClass>::TAlias a2;
+
+// Try a more complex example, through an additional layer of indirection.
+template <typename T>
+struct IndirectlyUsesAliasedParameter {
+  using TAlias = typename UsesAliasedParameter<T>::TAlias;
+  TAlias t;
+};
+
+// IWYU: IndirectClass is...*indirect.h
+// IWYU: IndirectClass needs a declaration
+IndirectlyUsesAliasedParameter<IndirectClass> b;
 
 /**** IWYU_SUMMARY
 


### PR DESCRIPTION
I've been working to fix the issues around uses of typedefs / aliases in templates.  This PR replaces #707, fixes #431 and fixes #780.

However, it's not a complete solution yet.  In particular, it's still not correctly handling `libstdc++`'s `std::unordered_map`, which was the issue that originally inspired me to work on this.

So, I hope to continue to improve the solution until it does handle that case correctly.

For now, I'm posting the PR to get feedback on the general approach taken, which is as follows:

The existing code detected uses of template arguments via `VisitSubstTemplateTypeParmType` which appears in the AST whenever a template argument is used in a template instantiation.

However, when an alias of a template argument is used, no such node appears.  Instead, we get `VisitTypedefType`.

The approach of this PR is to track all aliases of template arguments in a `map`, and when `VisitTypedefType` is called on an expression using such an alias, treat it similarly to how `VisitSubstTemplateTypeParmType` used to work (the two now use a common helper function for the bulk of their functionality).

The test I've rewritten demonstrates a few cases where IWYU used to (incorrectly) suggest forward declarations were sufficient, and now treats as full-uses.

There are more cases which still fail, so (as mentioned above) I hope to understand them and improve this further.  (However, this is nevertheless an improvement on the status quo, so if you're reading this a few months after I wrote it and I haven't made further progress then it might be worth merging anyway.)