### PR TITLE
Update implicitly defined operator new/delete check for newer C++ standards

### DIFF
--- a/run_iwyu_tests.py
+++ b/run_iwyu_tests.py
@@ -100,6 +100,8 @@ class OneIwyuTest(unittest.TestCase):
     clang_flags_map = {
       'alias_template.cc': ['-std=c++11'],
       'auto_type_within_template.cc': ['-std=c++11'],
+      'builtins_new_included_cxx14.cc': ['-std=c++14', '-fsized-deallocation'],
+      'builtins_new_included_cxx17.cc': ['-std=c++17'],
       # MSVC targets need to explicitly enable exceptions, so we do it for all.
       'catch.cc': ['-fcxx-exceptions', '-fexceptions'],
       'clmode.cc': ['--driver-mode=cl', '/GF', '/Os', '/W2'],

--- a/tests/cxx/builtins_new_included_cxx14.cc
+++ b/tests/cxx/builtins_new_included_cxx14.cc
@@ -1,0 +1,31 @@
+//===--- builtins_new_included_cxx14.cc - test input file for iwyu --------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// Test that iwyu suggests the include for <new> be removed if only
+// built-in functions are used, C++14 edition (i.e. with -fsized-deallocation).
+
+#include <new>
+
+void foo() {
+  char* ch = new char;
+  delete ch;
+  int* int_array = new int[10];
+  delete[] int_array;
+}
+
+/**** IWYU_SUMMARY
+
+tests/cxx/builtins_new_included_cxx14.cc should add these lines:
+
+tests/cxx/builtins_new_included_cxx14.cc should remove these lines:
+- #include <new>  // lines XX-XX
+
+The full include-list for tests/cxx/builtins_new_included_cxx14.cc:
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/builtins_new_included_cxx17.cc
+++ b/tests/cxx/builtins_new_included_cxx17.cc
@@ -1,0 +1,35 @@
+//===--- builtins_new_included_cxx17.cc - test input file for iwyu --------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// Test that iwyu suggests the include for <new> be removed if only
+// built-in functions are used, C++17 edition (i.e. with aligned allocations).
+
+#include <new>
+
+void foo() {
+  class alignas(32) test_struct {
+    float value[8];
+  };
+
+  test_struct* t = new test_struct;
+  delete t;
+  test_struct* t_array = new test_struct[10];
+  delete[] t_array;
+}
+
+/**** IWYU_SUMMARY
+
+tests/cxx/builtins_new_included_cxx17.cc should add these lines:
+
+tests/cxx/builtins_new_included_cxx17.cc should remove these lines:
+- #include <new>  // lines XX-XX
+
+The full include-list for tests/cxx/builtins_new_included_cxx17.cc:
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
IsDefaultNewOrDelete attempts to identify when a particular usage of
operator new or operator delete is one of a small set of functions that are
implicitly defined in every translation unit by the compiler. Unfortunately,
it doesn't appear to honor newer implicitly defined variants added in C++14
and C++17.

This patch updates it accordingly, and adds a test that fails without the
patch but passes with it.

Fixes tracking issue #777.