### PR TITLE
Do not assume CMAKE_PREFIX_PATH is LLVM_ROOT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,7 @@ if (NOT IWYU_IN_TREE)
   # Use only major.minor.patch for the resource directory structure; some
   # platforms include suffix in LLVM_VERSION.
   set(llvm_ver ${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR}.${LLVM_VERSION_PATCH})
-  set(clang_headers_src ${CMAKE_PREFIX_PATH}/lib/clang/${llvm_ver}/include)
+  set(clang_headers_src ${LLVM_INSTALL_PREFIX}/lib/clang/${llvm_ver}/include)
   set(clang_headers_dst ${CMAKE_BINARY_DIR}/lib/clang/${llvm_ver}/include)
 
   file(GLOB_RECURSE in_files RELATIVE ${clang_headers_src} ${clang_headers_src}/*)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,21 +64,22 @@ if (NOT IWYU_IN_TREE)
   # Use only major.minor.patch for the resource directory structure; some
   # platforms include suffix in LLVM_VERSION.
   set(llvm_ver ${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR}.${LLVM_VERSION_PATCH})
-  set(clang_headers_src ${LLVM_INSTALL_PREFIX}/lib/clang/${llvm_ver}/include)
-  set(clang_headers_dst ${CMAKE_BINARY_DIR}/lib/clang/${llvm_ver}/include)
+  set(clang_headers_src "${LLVM_INSTALL_PREFIX}/lib/clang/${llvm_ver}/include")
+  set(clang_headers_dst "${CMAKE_BINARY_DIR}/lib/clang/${llvm_ver}/include")
 
-  file(GLOB_RECURSE in_files RELATIVE ${clang_headers_src} ${clang_headers_src}/*)
+  file(GLOB_RECURSE in_files RELATIVE "${clang_headers_src}"
+    "${clang_headers_src}/*")
 
   set(out_files)
   foreach (file ${in_files})
-    set(src ${clang_headers_src}/${file})
-    set(dst ${clang_headers_dst}/${file})
+    set(src "${clang_headers_src}/${file}")
+    set(dst "${clang_headers_dst}/${file}")
 
-    add_custom_command(OUTPUT ${dst}
-      DEPENDS ${src}
-      COMMAND ${CMAKE_COMMAND} -E copy_if_different ${src} ${dst}
+    add_custom_command(OUTPUT "${dst}"
+      DEPENDS "${src}"
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different "${src}" "${dst}"
       COMMENT "Copying clang's ${file}...")
-    list(APPEND out_files ${dst})
+    list(APPEND out_files "${dst}")
   endforeach()
 
   add_custom_target(clang-resource-headers ALL DEPENDS ${out_files})


### PR DESCRIPTION
It is not atypical for a user's CMake prefix path to include multiple paths. (This is the case when installing a package with Spack, for example.) Instead of assuming that `CMAKE_PREFIX_PATH` is identically `LLVM_ROOT`, use the LLVM prefix path defined by `find_package(LLVM)`.

See https://github.com/include-what-you-use/include-what-you-use/pull/730