### PR TITLE
iwyu_tool: remove compiler wrappers from the command list

### DIFF
--- a/iwyu_tool.py
+++ b/iwyu_tool.py
@@ -267,6 +267,11 @@ class Process(object):
         return cls(process, outfile)
 
 
+KNOWN_COMPILER_WRAPPERS=frozenset([
+    "ccache"
+])
+
+
 class Invocation(object):
     """ Holds arguments of an IWYU invocation. """
     def __init__(self, command, cwd):
@@ -287,6 +292,10 @@ class Invocation(object):
             command = split_command(entry['command'])
         else:
             raise ValueError('Invalid compilation database entry: %s' % entry)
+
+        if command[0] in KNOWN_COMPILER_WRAPPERS:
+            # Remove the compiler wrapper from the command.
+            command = command[1:]
 
         # Rewrite the compile command for IWYU
         compile_command, compile_args = command[0], command[1:]

--- a/iwyu_tool_test.py
+++ b/iwyu_tool_test.py
@@ -310,6 +310,19 @@ class CompilationDBTests(unittest.TestCase):
         self.assertEqual('/c057f113f69311e990bf54a05050d914/foobar/Test.cpp',
                          entry['file'])
 
+    def test_unwrap_compile_command(self):
+        """ Wrapping compile commands should be unwrapped. """
+        compilation_db = {
+            'directory': '/home/user/llvm/build',
+            "command": "ccache cc -c test.c"
+        }
+
+        invocation = iwyu_tool.Invocation.from_compile_command(compilation_db, [])
+
+        self.assertEqual(
+            invocation.command,
+            [iwyu_tool.IWYU_EXECUTABLE, '-c', 'test.c'])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
If a compiler wrapper like ccache is used in the compile command
database, then iwyu_tool will only replace the wrapper with
IWYU_EXECUTABLE, while keeping the compiler executable in the
compile_args list. This leads to "error: no such file or directory
'c++'" warnings.

Fixes #789.