### PR TITLE
Remove trailing whitespace

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -1655,7 +1655,7 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
     // Sometimes a shadow decl comes between us and the 'real' decl.
     if (const UsingShadowDecl* shadow_decl = DynCastFrom(used_decl))
       target_decl = shadow_decl->getTargetDecl();
-    
+
     // Map private decls like __normal_iterator to their public counterpart.
     target_decl = MapPrivateDeclToPublicDecl(target_decl);
     if (CanIgnoreDecl(target_decl))
@@ -1683,7 +1683,7 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
     // instead?  We can call it "Use what you use". :-)
     // TODO(csilvers): check for using statements and namespace aliases too.
     if (const UsingDecl* using_decl
-        = GetUsingDeclarationOf(used_decl, 
+        = GetUsingDeclarationOf(used_decl,
               GetDeclContext(current_ast_node()))) {
       preprocessor_info().FileInfoFor(used_in)->ReportUsingDeclUse(
           used_loc, using_decl, use_flags, "(for using decl)");
@@ -1742,7 +1742,7 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
     // If we're a use that depends on a using declaration, make sure
     // we #include the file with the using declaration.
     if (const UsingDecl* using_decl
-        = GetUsingDeclarationOf(used_decl, 
+        = GetUsingDeclarationOf(used_decl,
               GetDeclContext(current_ast_node()))) {
       preprocessor_info().FileInfoFor(used_in)->ReportUsingDeclUse(
           used_loc, using_decl, ComputeUseFlags(current_ast_node()),

--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -596,14 +596,14 @@ bool HasImplicitConversionCtor(const CXXRecordDecl* cxx_class) {
 }
 
 // C++ [class.virtual]p8:
-//   If the return type of D::f differs from the return type of B::f, the 
+//   If the return type of D::f differs from the return type of B::f, the
 //   class type in the return type of D::f shall be complete at the point of
 //   declaration of D::f or shall be the class type D.
 bool HasCovariantReturnType(const CXXMethodDecl* method_decl) {
   QualType derived_return_type = method_decl->getReturnType();
 
   for (CXXMethodDecl::method_iterator
-       it = method_decl->begin_overridden_methods(); 
+       it = method_decl->begin_overridden_methods();
        it != method_decl->end_overridden_methods(); ++it) {
     // There are further constraints on covariant return types as such
     // (e.g. parents must be related, derived override must have return type

--- a/iwyu_globals.h
+++ b/iwyu_globals.h
@@ -99,7 +99,7 @@ struct CommandlineFlags {
   bool pch_in_code;   // Treat the first seen include as a PCH. No short option.
   bool no_comments;   // Disable 'why' comments. No short option.
   bool no_fwd_decls;  // Disable forward declarations.
-  bool quoted_includes_first; // Place quoted includes first in sort order.  
+  bool quoted_includes_first; // Place quoted includes first in sort order.
   bool cxx17ns; // -C: C++17 nested namespace syntax
 };
 

--- a/iwyu_include_picker.cc
+++ b/iwyu_include_picker.cc
@@ -1595,7 +1595,7 @@ void IncludePicker::AddMappingsFromFile(const string& filename,
 
         // Add the path of the file we're currently processing
         // to the search path. Allows refs to be relative to referrer.
-        vector<string> extended_search_path = 
+        vector<string> extended_search_path =
             ExtendMappingFileSearchPath(search_path,
                                         GetParentPath(absolute_path));
 

--- a/iwyu_include_picker.h
+++ b/iwyu_include_picker.h
@@ -194,10 +194,10 @@ class IncludePicker {
   // Adds a mapping from a one header to another, typically
   // from a private to a public quoted include.
   void AddIncludeMapping(
-      const string& map_from, IncludeVisibility from_visibility, 
+      const string& map_from, IncludeVisibility from_visibility,
       const MappedInclude& map_to, IncludeVisibility to_visibility);
 
-  // Adds a mapping from a a symbol to a quoted include. We use this to 
+  // Adds a mapping from a a symbol to a quoted include. We use this to
   // maintain mappings of documented types, e.g.
   //  For std::map<>, include <map>.
   void AddSymbolMapping(

--- a/iwyu_output.cc
+++ b/iwyu_output.cc
@@ -584,8 +584,8 @@ void IwyuFileInfo::AddUsingDecl(const UsingDecl* using_decl) {
   int start_linenum = GetLineNumber(GetInstantiationLoc(decl_lines.getBegin()));
   int end_linenum = GetLineNumber(GetInstantiationLoc(decl_lines.getEnd()));
   VERRS(6) << "Found using-decl: "
-           << GetFilePath(file_) << ":" 
-           << to_string(start_linenum) << "-" << to_string(end_linenum) << ": " 
+           << GetFilePath(file_) << ":"
+           << to_string(start_linenum) << "-" << to_string(end_linenum) << ": "
            << internal::PrintablePtr(using_decl)
            << internal::GetQualifiedNameAsString(using_decl) << "\n";
 }
@@ -678,7 +678,7 @@ void IwyuFileInfo::ReportForwardDeclareUse(SourceLocation use_loc,
 void IwyuFileInfo::ReportUsingDeclUse(SourceLocation use_loc,
                                       const UsingDecl* using_decl,
                                       UseFlags flags,
-                                      const char* comment) {  
+                                      const char* comment) {
   // If accessing a symbol through a using decl in the same file that contains
   // the using decl, we must mark the using decl as referenced. At the end of
   // traversing the AST, we check to see if a using decl is unreferenced and

--- a/iwyu_output.h
+++ b/iwyu_output.h
@@ -255,7 +255,7 @@ class IwyuFileInfo {
                                UseFlags flags, const char* comment);
 
   // Called whenever a NamedDecl is accessed through a UsingDecl.
-  // ie: using std::swap; swap(a, b); 
+  // ie: using std::swap; swap(a, b);
   void ReportUsingDeclUse(clang::SourceLocation use_loc,
                           const clang::UsingDecl* using_decl,
                           UseFlags flags, const char* comment);


### PR DESCRIPTION
Remove trailing whitespace.

One of these changes was mixed up amongst the changes of #775.  Extracting into a separate PR for clarity, and fixing all the similar trailing whitespace issues in the main code (didn't check the test code).