### PR TITLE
Make 0.14 release work with llvm9

### DIFF
--- a/iwyu_driver.cc
+++ b/iwyu_driver.cc
@@ -205,8 +205,11 @@ CompilerInstance* CreateCompilerInstance(int argc, const char **argv) {
 
   // Initialize a compiler invocation object from the clang (-cc1) arguments.
   const ArgStringList &cc_arguments = command.getArguments();
+  const char** args_start = const_cast<const char**>(cc_arguments.data());
+  const char** args_end = args_start + cc_arguments.size();
   std::shared_ptr<CompilerInvocation> invocation(new CompilerInvocation);
-  CompilerInvocation::CreateFromArgs(*invocation, cc_arguments, diagnostics);
+  CompilerInvocation::CreateFromArgs(*invocation,
+                                     args_start, args_end, diagnostics);
   invocation->getFrontendOpts().DisableFree = false;
 
   // Use libc++ headers bundled with Xcode.app on macOS.

--- a/iwyu_preprocessor.cc
+++ b/iwyu_preprocessor.cc
@@ -34,7 +34,6 @@
 #include "clang/Lex/MacroInfo.h"
 
 using clang::FileEntry;
-using clang::FileEntryRef;
 using clang::FileID;
 using clang::MacroDefinition;
 using clang::MacroDirective;
@@ -705,7 +704,7 @@ void IwyuPreprocessorInfo::FileChanged(SourceLocation loc,
 // Called when we see an #include, but decide we don't need to
 // actually read it because it's already been #included (and is
 // protected by a header guard).
-void IwyuPreprocessorInfo::FileSkipped(const FileEntryRef& file,
+void IwyuPreprocessorInfo::FileSkipped(const FileEntry& file,
                                        const Token &filename,
                                        SrcMgr::CharacteristicKind file_type) {
   CHECK_(include_filename_loc_.isValid() &&
@@ -716,11 +715,11 @@ void IwyuPreprocessorInfo::FileSkipped(const FileEntryRef& file,
       GetInstantiationLoc(filename.getLocation());
   ERRSYM(GetFileEntry(include_loc))
       << "[ (#include)  ] " << include_name_as_written
-      << " (" << GetFilePath(&file.getFileEntry()) << ")\n";
+      << " (" << GetFilePath(&file) << ")\n";
 
-  AddDirectInclude(include_loc, &file.getFileEntry(), include_name_as_written);
-  if (ShouldReportIWYUViolationsFor(&file.getFileEntry())) {
-    files_to_report_iwyu_violations_for_.insert(&file.getFileEntry());
+  AddDirectInclude(include_loc, &file, include_name_as_written);
+  if (ShouldReportIWYUViolationsFor(&file)) {
+    files_to_report_iwyu_violations_for_.insert(&file);
   }
 }
 

--- a/iwyu_preprocessor.h
+++ b/iwyu_preprocessor.h
@@ -204,7 +204,7 @@ class IwyuPreprocessorInfo : public clang::PPCallbacks,
   void FileChanged(clang::SourceLocation loc, FileChangeReason reason,
                    clang::SrcMgr::CharacteristicKind file_type,
                    clang::FileID exiting_from_id) override;
-  void FileSkipped(const clang::FileEntryRef& file, const clang::Token &filename,
+  void FileSkipped(const clang::FileEntry& file, const clang::Token &filename,
                    clang::SrcMgr::CharacteristicKind file_type) override;
   // FileChanged is actually a multi-plexer for 4 different callbacks.
   void FileChanged_EnterFile(clang::SourceLocation file_beginning);


### PR DESCRIPTION
Reverted the previous two commits to make the latest release work with llvm9

Revert "Clang r369998: FileSkipped now takes FileEntryRef"

This reverts commit c2d74ac67a81734d99b294a182b7de3392b83872.

Revert "Clang r370122: ArrayRef in CompilerInvocation::CreateFromArgs"

This reverts commit b8edb821f252799b5584ed048caec5480de0244e.

---

relates to https://github.com/Homebrew/homebrew-core/pull/57421