### PR TITLE
Implement Stmt printing with ASTDumper

### DIFF
--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -25,6 +25,7 @@
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/raw_ostream.h"
 #include "clang/AST/ASTContext.h"
+#include "clang/AST/ASTDumper.h"
 #include "clang/AST/CanonicalType.h"
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclBase.h"
@@ -46,6 +47,7 @@ namespace clang {
 class FileEntry;
 }  // namespace clang
 
+using clang::ASTDumper;
 using clang::BlockPointerType;
 using clang::CXXConstructExpr;
 using clang::CXXConstructorDecl;
@@ -450,12 +452,14 @@ string PrintableDecl(const Decl* decl, bool terse/*=true*/) {
 string PrintableStmt(const Stmt* stmt) {
   std::string buffer;
   raw_string_ostream ostream(buffer);
-  stmt->dump(ostream, *GlobalSourceManager());
+  ASTDumper dumper(ostream, /*ShowColors=*/false);
+  dumper.Visit(stmt);
   return ostream.str();
 }
 
 void PrintStmt(const Stmt* stmt) {
-  stmt->dump(*GlobalSourceManager());  // This prints to errs().
+  ASTDumper dumper(llvm::errs(), /*ShowColors=*/false);
+  dumper.Visit(stmt);
 }
 
 string PrintableType(const Type* type) {


### PR DESCRIPTION
The Clang API changed in commit 473fbc90d1fbf17e so that Stmt::dump
takes an ASTContext instead of a SourceManager.

Rather than wire a global ASTContext, reimplement PrintableStmt and
PrintStmt to duplicate the most trivial implementations not requiring
ASTContext.

No functional change.