### PR TITLE
Remove source manager from ASTNode constructor

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -322,7 +322,7 @@ class BaseAstVisitor : public RecursiveASTVisitor<Derived> {
   bool TraverseDecl(Decl* decl) {
     if (current_ast_node_ && current_ast_node_->StackContainsContent(decl))
       return true;               // avoid recursion
-    ASTNode node(decl, *GlobalSourceManager());
+    ASTNode node(decl);
     CurrentASTNodeUpdater canu(&current_ast_node_, &node);
     return Base::TraverseDecl(decl);
   }
@@ -330,7 +330,7 @@ class BaseAstVisitor : public RecursiveASTVisitor<Derived> {
   bool TraverseStmt(Stmt* stmt) {
     if (current_ast_node_ && current_ast_node_->StackContainsContent(stmt))
       return true;               // avoid recursion
-    ASTNode node(stmt, *GlobalSourceManager());
+    ASTNode node(stmt);
     CurrentASTNodeUpdater canu(&current_ast_node_, &node);
     return Base::TraverseStmt(stmt);
   }
@@ -341,7 +341,7 @@ class BaseAstVisitor : public RecursiveASTVisitor<Derived> {
     const Type* type = qualtype.getTypePtr();
     if (current_ast_node_ && current_ast_node_->StackContainsContent(type))
       return true;               // avoid recursion
-    ASTNode node(type, *GlobalSourceManager());
+    ASTNode node(type);
     CurrentASTNodeUpdater canu(&current_ast_node_, &node);
     return Base::TraverseType(qualtype);
   }
@@ -365,7 +365,7 @@ class BaseAstVisitor : public RecursiveASTVisitor<Derived> {
     }
     if (current_ast_node_ && current_ast_node_->StackContainsContent(&typeloc))
       return true;               // avoid recursion
-    ASTNode node(&typeloc, *GlobalSourceManager());
+    ASTNode node(&typeloc);
     CurrentASTNodeUpdater canu(&current_ast_node_, &node);
     return Base::TraverseTypeLoc(typeloc);
   }
@@ -373,7 +373,7 @@ class BaseAstVisitor : public RecursiveASTVisitor<Derived> {
   bool TraverseNestedNameSpecifier(NestedNameSpecifier* nns) {
     if (nns == nullptr)
       return true;
-    ASTNode node(nns, *GlobalSourceManager());
+    ASTNode node(nns);
     CurrentASTNodeUpdater canu(&current_ast_node_, &node);
     if (!this->getDerived().VisitNestedNameSpecifier(nns))
       return false;
@@ -383,7 +383,7 @@ class BaseAstVisitor : public RecursiveASTVisitor<Derived> {
   bool TraverseNestedNameSpecifierLoc(NestedNameSpecifierLoc nns_loc) {
     if (!nns_loc)   // using NNSLoc::operator bool()
       return true;
-    ASTNode node(&nns_loc, *GlobalSourceManager());
+    ASTNode node(&nns_loc);
     CurrentASTNodeUpdater canu(&current_ast_node_, &node);
     // TODO(csilvers): have VisitNestedNameSpecifierLoc instead.
     if (!this->getDerived().VisitNestedNameSpecifier(
@@ -393,7 +393,7 @@ class BaseAstVisitor : public RecursiveASTVisitor<Derived> {
   }
 
   bool TraverseTemplateName(TemplateName template_name) {
-    ASTNode node(&template_name, *GlobalSourceManager());
+    ASTNode node(&template_name);
     CurrentASTNodeUpdater canu(&current_ast_node_, &node);
     if (!this->getDerived().VisitTemplateName(template_name))
       return false;
@@ -401,7 +401,7 @@ class BaseAstVisitor : public RecursiveASTVisitor<Derived> {
   }
 
   bool TraverseTemplateArgument(const TemplateArgument& arg) {
-    ASTNode node(&arg, *GlobalSourceManager());
+    ASTNode node(&arg);
     CurrentASTNodeUpdater canu(&current_ast_node_, &node);
     if (!this->getDerived().VisitTemplateArgument(arg))
       return false;
@@ -409,7 +409,7 @@ class BaseAstVisitor : public RecursiveASTVisitor<Derived> {
   }
 
   bool TraverseTemplateArgumentLoc(const TemplateArgumentLoc& argloc) {
-    ASTNode node(&argloc, *GlobalSourceManager());
+    ASTNode node(&argloc);
     CurrentASTNodeUpdater canu(&current_ast_node_, &node);
     if (!this->getDerived().VisitTemplateArgumentLoc(argloc))
       return false;
@@ -3967,7 +3967,7 @@ class IwyuAstConsumer
     if (const TemplateSpecializationType* arg_tmpl = DynCastFrom(arg_type)) {
       // Special case: We are instantiating the type in the context of an
       // expression. Need to push the type to the AST stack explicitly.
-      ASTNode node(arg_tmpl, *GlobalSourceManager());
+      ASTNode node(arg_tmpl);
       node.SetParent(current_ast_node());
 
       instantiated_template_visitor_.ScanInstantiatedType(

--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -186,13 +186,12 @@ SourceLocation ASTNode::GetLocation() const {
   // locations are in a different file, then we're uncertain of our
   // own location.  Return an invalid location.
   if (retval.isValid()) {
-    FullSourceLoc full_loc(retval, source_manager_);
+    clang::SourceManager& sm = *GlobalSourceManager();
+    FullSourceLoc full_loc(retval, sm);
     const FileEntry* spelling_file =
-        source_manager_.getFileEntryForID(
-            source_manager_.getFileID(full_loc.getSpellingLoc()));
+        sm.getFileEntryForID(sm.getFileID(full_loc.getSpellingLoc()));
     const FileEntry* instantiation_file =
-        source_manager_.getFileEntryForID(
-            source_manager_.getFileID(full_loc.getExpansionLoc()));
+        sm.getFileEntryForID(sm.getFileID(full_loc.getExpansionLoc()));
     if (spelling_file != instantiation_file)
       return SourceLocation();
   }

--- a/iwyu_ast_util.h
+++ b/iwyu_ast_util.h
@@ -40,7 +40,6 @@ class ClassTemplateDecl;
 class Expr;
 class FunctionDecl;
 class NamedDecl;
-class SourceManager;
 class TagDecl;
 class TemplateDecl;
 class TemplateName;
@@ -72,37 +71,33 @@ class ASTNode {
  public:
   // In each case, the caller owns the object, and must guarantee it
   // lives for at least as long as the ASTNode object does.
-  ASTNode(const clang::Decl* decl, const clang::SourceManager& sm)
+  ASTNode(const clang::Decl* decl)
       : kind_(kDeclKind), as_decl_(decl),
-        parent_(nullptr), in_fwd_decl_context_(false), source_manager_(sm) { }
-  ASTNode(const clang::Stmt* stmt, const clang::SourceManager& sm)
+        parent_(nullptr), in_fwd_decl_context_(false) { }
+  ASTNode(const clang::Stmt* stmt)
       : kind_(kStmtKind), as_stmt_(stmt),
-        parent_(nullptr), in_fwd_decl_context_(false), source_manager_(sm) { }
-  ASTNode(const clang::Type* type, const clang::SourceManager& sm)
+        parent_(nullptr), in_fwd_decl_context_(false) { }
+  ASTNode(const clang::Type* type)
       : kind_(kTypeKind), as_type_(type),
-        parent_(nullptr), in_fwd_decl_context_(false), source_manager_(sm) { }
-  ASTNode(const clang::TypeLoc* typeloc, const clang::SourceManager& sm)
+        parent_(nullptr), in_fwd_decl_context_(false) { }
+  ASTNode(const clang::TypeLoc* typeloc)
       : kind_(kTypelocKind), as_typeloc_(typeloc),
-        parent_(nullptr), in_fwd_decl_context_(false), source_manager_(sm) { }
-  ASTNode(const clang::NestedNameSpecifier* nns, const clang::SourceManager& sm)
+        parent_(nullptr), in_fwd_decl_context_(false) { }
+  ASTNode(const clang::NestedNameSpecifier* nns)
       : kind_(kNNSKind), as_nns_(nns),
-        parent_(nullptr), in_fwd_decl_context_(false), source_manager_(sm) { }
-  ASTNode(const clang::NestedNameSpecifierLoc* nnsloc,
-          const clang::SourceManager& sm)
+        parent_(nullptr), in_fwd_decl_context_(false) { }
+  ASTNode(const clang::NestedNameSpecifierLoc* nnsloc)
       : kind_(kNNSLocKind), as_nnsloc_(nnsloc),
-        parent_(nullptr), in_fwd_decl_context_(false), source_manager_(sm) { }
-  ASTNode(const clang::TemplateName* template_name,
-          const clang::SourceManager& sm)
+        parent_(nullptr), in_fwd_decl_context_(false) { }
+  ASTNode(const clang::TemplateName* template_name)
       : kind_(kTemplateNameKind), as_template_name_(template_name),
-        parent_(nullptr), in_fwd_decl_context_(false), source_manager_(sm) { }
-  ASTNode(const clang::TemplateArgument* template_arg,
-          const clang::SourceManager& sm)
+        parent_(nullptr), in_fwd_decl_context_(false) { }
+  ASTNode(const clang::TemplateArgument* template_arg)
       : kind_(kTemplateArgumentKind), as_template_arg_(template_arg),
-        parent_(nullptr), in_fwd_decl_context_(false), source_manager_(sm) { }
-  ASTNode(const clang::TemplateArgumentLoc* template_argloc,
-          const clang::SourceManager& sm)
+        parent_(nullptr), in_fwd_decl_context_(false) { }
+  ASTNode(const clang::TemplateArgumentLoc* template_argloc)
       : kind_(kTemplateArgumentLocKind), as_template_argloc_(template_argloc),
-        parent_(nullptr), in_fwd_decl_context_(false), source_manager_(sm) { }
+        parent_(nullptr), in_fwd_decl_context_(false) { }
 
   // A 'forward-declare' context means some parent of us can be
   // forward-declared, which means we can be too.  e.g. in
@@ -327,7 +322,6 @@ class ASTNode {
   };
   const ASTNode* parent_;
   bool in_fwd_decl_context_;
-  const clang::SourceManager& source_manager_;
 };
 
 // --- Helper classes for ASTNode.


### PR DESCRIPTION
ASTNode was consistently instantiated using GlobalSourceManager(). The
passed-in source manager was only used in ASTNode::GetLocation().

Use GlobalSourceManager() there directly instead to keep the constructor
interface simpler.

No functional change.