### PR TITLE
Add mapping from <bits/time.h> to <time.h>

### DIFF
--- a/gcc.libc.imp
+++ b/gcc.libc.imp
@@ -97,6 +97,7 @@
   { include: [ "<bits/syslog-path.h>", private, "<sys/syslog.h>", private ] },
   { include: [ "<bits/syslog.h>", private, "<sys/syslog.h>", private ] },
   { include: [ "<bits/termios.h>", private, "<termios.h>", public ] },
+  { include: [ "<bits/time.h>", private, "<time.h>", public ] },
   { include: [ "<bits/time.h>", private, "<sys/time.h>", public ] },
   { include: [ "<bits/timerfd.h>", private, "<sys/timerfd.h>", public ] },
   { include: [ "<bits/timex.h>", private, "<sys/timex.h>", public ] },

--- a/iwyu_include_picker.cc
+++ b/iwyu_include_picker.cc
@@ -353,6 +353,7 @@ const IncludeMapEntry libc_include_map[] = {
   { "<bits/syslog-path.h>", kPrivate, "<sys/syslog.h>", kPrivate },
   { "<bits/syslog.h>", kPrivate, "<sys/syslog.h>", kPrivate },
   { "<bits/termios.h>", kPrivate, "<termios.h>", kPublic },
+  { "<bits/time.h>", kPrivate, "<time.h>", kPublic },
   { "<bits/time.h>", kPrivate, "<sys/time.h>", kPublic },
   { "<bits/timerfd.h>", kPrivate, "<sys/timerfd.h>", kPublic },
   { "<bits/timex.h>", kPrivate, "<sys/timex.h>", kPublic },


### PR DESCRIPTION
This makes <time.h> a valid provider of CLOCKS_PER_SEC and other symbols
declared in <bits/time.h>.

Not entirely sure how this fares with older glibc versions, but my
suspicion is <time.h> is a better candidate than <sys/time.h> in the
general case.