### PR TITLE
Do not provide arguments when calling Decl.isReplaceableGlobalAllocationFunction()

### DIFF
--- a/iwyu_output.cc
+++ b/iwyu_output.cc
@@ -1249,7 +1249,7 @@ void ProcessFullUse(OneUse* use,
   // <new> will be required for them without us doing any magic for operator new
   // itself.
   if (const FunctionDecl* fn_decl = DynCastFrom(use->decl())) {
-    if (fn_decl->isReplaceableGlobalAllocationFunction(nullptr, nullptr)) {
+    if (fn_decl->isReplaceableGlobalAllocationFunction()) {
       VERRS(6) << "Ignoring use of " << use->symbol_name()
                << " (" << use->PrintableUseLoc() << "): built-in new/delete\n";
       use->set_ignore_use();


### PR DESCRIPTION
LLVM added a second boolean argument to
isReplaceableGlobalAllocationFunction() with 3dd5a298bfff ("[clang]
Annotating C++'s `operator new` with more attributes"). However both
parameters define a default argument. Hence there is no need to
explicitly state the argument, if it is already the default argument,
which is nullptr is isReplaceableGlobalAllocationFunction() case. This
also increases readability.