### PR TITLE
Correctly detect link with LLVM/CLANG shared libraries.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,10 @@ endif()
 
 message(STATUS "IWYU: configuring for LLVM ${LLVM_VERSION}...")
 
+# The good default is given by the llvm toolchain installation itself, but still in
+# case both static and shared libraries are available, allow to override that default.
+option(IWYU_LINK_CLANG_DYLIB "Link against the clang dynamic library" ${CLANG_LINK_CLANG_DYLIB})
+
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 add_definitions(${LLVM_DEFINITIONS})
@@ -106,7 +110,7 @@ if (MSVC)
 endif()
 
 # If only clang-cpp is available, we take that.
-if (TARGET clang-cpp AND NOT TARGET clangBasic)
+if (IWYU_LINK_CLANG_DYLIB)
   target_link_libraries(include-what-you-use PRIVATE clang-cpp)
 else()
   target_link_libraries(include-what-you-use


### PR DESCRIPTION
Hi,

I do try to build include-what-you-use outside of the LLVM build tree, and my LLVM/Clang installation was configured with LLVM_LINK_LLVM_DYLIB=On. It looks like include-what-you-use CMakeLists.txt fails to detect that correctly.

I am fixing it thusly (this is how @Maskray who is a big LLVM contributor does it in his own out of tree clang-based tool CCLS: https://github.com/MaskRay/ccls/blob/master/CMakeLists.txt#L73)

Cheers,
Romain