### PR TITLE
Fix build on non-X86 targets where the LLVM x86 backend is not built.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,11 @@ message(STATUS "IWYU: configuring for LLVM ${LLVM_VERSION}...")
 # case both static and shared libraries are available, allow to override that default.
 option(IWYU_LINK_CLANG_DYLIB "Link against the clang dynamic library" ${CLANG_LINK_CLANG_DYLIB})
 
+# Try to guess the architecture as much as possible from the underlying toolchain.
+set(IWYU_ARCH ${LLVM_NATIVE_ARCH} CACHE STRING "The architecture IWYU will run on.")
+
+add_compile_definitions(IWYU_ARCH=${IWYU_ARCH})
+
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 add_definitions(${LLVM_DEFINITIONS})
@@ -41,9 +46,9 @@ include_directories(
 set(LLVM_LINK_COMPONENTS
   Option
   Support
-  X86AsmParser
-  X86Desc
-  X86Info
+  ${IWYU_ARCH}AsmParser
+  ${IWYU_ARCH}Desc
+  ${IWYU_ARCH}Info
   )
 
 add_llvm_executable(include-what-you-use

--- a/iwyu.cc
+++ b/iwyu.cc
@@ -4136,12 +4136,15 @@ using include_what_you_use::IwyuAction;
 using include_what_you_use::CreateCompilerInstance;
 
 int main(int argc, char **argv) {
-  // Must initialize X86 target to be able to parse Microsoft inline
-  // assembly. We do this unconditionally, because it allows an IWYU
-  // built for non-X86 targets to parse MS inline asm without choking.
-  LLVMInitializeX86TargetInfo();
-  LLVMInitializeX86TargetMC();
-  LLVMInitializeX86AsmParser();
+  // Must initialize the arch target to be able to parse Microsoft inline
+  // assembly.
+#define IWYU_INTERNAL_LLVM_INITIALIZE_ARCH_TARGET_HELPER2(arch, target) LLVMInitialize##arch##target()
+  // This second macro will expand IWYU_ARCH correctly.
+#define IWYU_INTERNAL_LLVM_INITIALIZE_ARCH_TARGET_HELPER1(arch, target) IWYU_INTERNAL_LLVM_INITIALIZE_ARCH_TARGET_HELPER2(arch, target)
+#define IWYU_INTERNAL_LLVM_INITIALIZE_ARCH_TARGET(target) IWYU_INTERNAL_LLVM_INITIALIZE_ARCH_TARGET_HELPER1(IWYU_ARCH, target)
+  IWYU_INTERNAL_LLVM_INITIALIZE_ARCH_TARGET(TargetInfo);
+  IWYU_INTERNAL_LLVM_INITIALIZE_ARCH_TARGET(TargetMC);
+  IWYU_INTERNAL_LLVM_INITIALIZE_ARCH_TARGET(AsmParser);
 
   // The command line should look like
   //   path/to/iwyu -Xiwyu --verbose=4 [-Xiwyu --other_iwyu_flag]... CLANG_FLAGS... foo.cc


### PR DESCRIPTION
Hi,

Today I started a built of a full gcc+clang toolchain with PGO + LTO (so taking quite a very long time), and it happens that at the very end the job failed when trying to build include-what-you-use. It happens that I was doing all that on a aarch64 target using native compilers and where the X86 backend was deactivated on purpose. I didn't expect include-what-you-use is X86 only, but it seems I was wrong ;)

I got:

```
FAILED: CMakeFiles/include-what-you-use.dir/iwyu.cc.o
/opt/1A/toolchain/aarch64-v19.0.53/bin/c++  -DGTEST_HAS_RTTI=0 -DIWYU_GIT_REV=\"\" -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -I/opt/1A/toolchain/aarch64-
v19.0.53/include -O2 -I/opt/1A/toolchain/aarch64-v19.0.53/build-pack/19.0.53.0/include -I/workdir/build/build-pack/build-pack-temporary-static-dependencies/install/include -I/workdi
r/build/build-pack/build-pack-temporary-static-dependencies/install/include/ncursesw -I/workdir/build/build-pack/build-pack-temporary-static-dependencies/install/lib/libffi-3.3/include -I/opt/1A/toolchain/aarch64-v19.0.53/build-pack/19.0.53.0/internal-python-only-for-build-pack/include -Wno-error -fPIC -fvisibility-inlines-hidden -Werror=date-time -w -fdiagnostics-color -ffunction-sections -fdata-sections -O3 -DNDEBUG   -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS  -fno-exceptions -fno-rtti -MD -MT CMakeFiles/include-what-you-use.dir/iwyu.cc.o -MF CMakeFiles/include-what-you-use.dir/iwyu.cc.o.d -o CMakeFiles/include-what-you-use.dir/iwyu.cc.o -c /workdir/src/include-what-you-use-0.16/iwyu.cc
/workdir/src/include-what-you-use-0.16/iwyu.cc: In function 'int main(int, char**)':
/workdir/src/include-what-you-use-0.16/iwyu.cc:4142:3: error: 'LLVMInitializeX86TargetInfo' was not declared in this scope; did you mean 'LLVMInitializeAArch64TargetInfo'?
 4142 |   LLVMInitializeX86TargetInfo();
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~
      |   LLVMInitializeAArch64TargetInfo
/workdir/src/include-what-you-use-0.16/iwyu.cc:4143:3: error: 'LLVMInitializeX86TargetMC' was not declared in this scope; did you mean 'LLVMInitializeAArch64TargetMC'?
 4143 |   LLVMInitializeX86TargetMC(); 
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~
      |   LLVMInitializeAArch64TargetMC
/workdir/src/include-what-you-use-0.16/iwyu.cc:4144:3: error: 'LLVMInitializeX86AsmParser' was not declared in this scope; did you mean 'LLVMInitializeAArch64AsmParser'?
 4144 |   LLVMInitializeX86AsmParser();
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~   
      |   LLVMInitializeAArch64AsmParser
[166/167] Building CXX object CMakeFiles/include-what-you-use.dir/iwyu_ast_util.cc.o
ninja: build stopped: subcommand failed.
```

Unfortunately, I have lost the rest of the toolchain with the job, so right now I can't test this on aarch64. I will re-start a build with this patch and let you know if it worked. I did however test this on a x86_64 machine where I already had saved a working toolchain. On x86_64, this seems to compile (I have not tried to run, but normally it shall work).

Cheers,
Romain