### PR TITLE
Use version sort to determine the highest llvm version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ addons:
 
 before_install:
  # Extract the version number from the most-recently installed LLVM
- - VERSION=`ls -t /usr/lib/ | grep '^llvm-' | head -n 1 | sed -E 's/llvm-(.+)/\1/'`
+ - VERSION=`find /usr/lib -maxdepth 1 -name llvm-* -printf '%f\n' | sort -V -r | head -n1 | cut -c 6-`
 
  # Absolute paths to LLVM's root and bin directory
  - PREFIX_PATH=`llvm-config-$VERSION --prefix`


### PR DESCRIPTION
```
# install earlier version later
$ apt install llvm-11
$ apt install llvm-10

# current version
$ ls -t /usr/lib/ | grep '^llvm-' | head -n 1 | sed -E 's/llvm-(.+)/\1/'
10

# updated version
$ find /usr/lib -maxdepth 1 -name llvm-* -printf '%f\n' | sort -V -r | head -n1 | cut -c 6-
11
```