### PR TITLE
Use CMake to generate and run tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,9 +177,23 @@ endif()
 find_package(PythonInterp)
 if(PYTHONINTERP_FOUND)
   enable_testing()
-  add_test(NAME iwyu_tests
-    COMMAND ${PYTHON_EXECUTABLE} run_iwyu_tests.py -- $<TARGET_FILE:include-what-you-use>
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+  function(ADD_IWYU_TEST NAME FILE)
+    add_test(NAME ${NAME}
+      COMMAND ${PYTHON_EXECUTABLE} run_iwyu_tests.py --run-test-file=${FILE} -- $<TARGET_FILE:include-what-you-use>
+      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+  endfunction()
+
+  execute_process(
+    COMMAND ${PYTHON_EXECUTABLE} run_iwyu_tests.py --list-test-files
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    OUTPUT_VARIABLE TEST_NAMES_AND_FILES)
+  string(REPLACE "\n" ";" TEST_NAMES_LIST ${TEST_NAMES_AND_FILES})
+  foreach (TEST_NAME_AND_FILE IN ITEMS ${TEST_NAMES_LIST})
+    string(REPLACE ":" ";" TEST_NAME_AND_FILE ${TEST_NAME_AND_FILE})
+    ADD_IWYU_TEST(${TEST_NAME_AND_FILE})
+  endforeach()
+
   add_test(NAME fix_includes_test
     COMMAND ${PYTHON_EXECUTABLE} fix_includes_test.py
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})

--- a/iwyu_test_util.py
+++ b/iwyu_test_util.py
@@ -429,12 +429,10 @@ def _GetLaunchArguments(cc_file):
   return args
 
 
-def TestIwyuOnRelativeFile(test_case, cc_file, cpp_files_to_check,
-                           verbose=False):
+def TestIwyuOnRelativeFile(cc_file, cpp_files_to_check, verbose=False):
   """Checks running IWYU on the given .cc file.
 
   Args:
-    test_case: A googletest.TestCase instance.
     cc_file: The name of the file to test, relative to the current dir.
     cpp_files_to_check: A list of filenames for the files
               to check the diagnostics on, relative to the current dir.
@@ -474,4 +472,5 @@ def TestIwyuOnRelativeFile(test_case, cc_file, cpp_files_to_check,
       _GetExpectedSummaries(cpp_files_to_check),
       _GetActualSummaries(output))
 
-  test_case.assertTrue(not failures, ''.join(failures))
+  if failures:
+    raise AssertionError(''.join(failures))

--- a/run_iwyu_tests.py
+++ b/run_iwyu_tests.py
@@ -87,8 +87,6 @@ def GenerateTests(rootdir, pattern):
       while hasattr(cls, test_name):   # already have a class with that name
         test_name += '2'               # just append a suffix :-)
 
-      logging.info('Registering %s.%s to test %s', cls.__name__, test_name,
-                   filename)
       setattr(cls, test_name, _GetTestBody(filename))
 
     return cls

--- a/run_iwyu_tests.py
+++ b/run_iwyu_tests.py
@@ -67,6 +67,7 @@ def TestIwyuOnRelevantFiles(filename):
 def GenerateTests(rootdir, pattern):
   def _AddTestFunctions(cls):
     filenames = []
+    test_files = {}
     for (dirpath, _, files) in os.walk(rootdir):
       dirpath = PosixPath(dirpath)  # Normalize path separators.
       filenames.extend(posixpath.join(dirpath, f) for f in files
@@ -85,6 +86,9 @@ def GenerateTests(rootdir, pattern):
         test_name += '2'               # just append a suffix :-)
 
       setattr(cls, test_name, lambda x, f=filename: TestIwyuOnRelevantFiles(f))
+      test_files[test_name] = filename
+
+    setattr(cls, 'test_files', test_files)
 
     return cls
 
@@ -100,6 +104,11 @@ def EnumerateLoadedTests():
 def PrintLoadedTests():
   for (cls, test) in EnumerateLoadedTests():
     print('%s.%s' % (cls.__name__, test))
+
+
+def PrintLoadedTestsAndFiles():
+  for (cls, test) in EnumerateLoadedTests():
+    print('%s.%s:%s' % (cls.__name__, test, cls.test_files[test]))
 
 
 @GenerateTests(rootdir='tests/c', pattern='*.c')
@@ -120,9 +129,12 @@ if __name__ == '__main__':
   parser = argparse.ArgumentParser(add_help=False, usage=argparse.SUPPRESS)
   group = parser.add_mutually_exclusive_group()
   group.add_argument('--list', dest='list_tests', action='store_true')
+  group.add_argument('--list-test-files', action='store_true')
   (runner_args, _) = parser.parse_known_args(unittest_args)
 
   if runner_args.list_tests:
     exit(PrintLoadedTests())
+  elif runner_args.list_test_files:
+    exit(PrintLoadedTestsAndFiles())
 
   unittest.main(argv=unittest_args)

--- a/run_iwyu_tests.py
+++ b/run_iwyu_tests.py
@@ -63,8 +63,7 @@ def GenerateTests(rootdir, pattern):
       # in the same way here.
       files_to_check = [PosixPath(f) for f in files_to_check]
 
-      iwyu_test_util.TestIwyuOnRelativeFile(self, filename, files_to_check,
-                                            verbose=True)
+      iwyu_test_util.TestIwyuOnRelativeFile(filename, files_to_check, verbose=True)
     return _test
 
 

--- a/run_iwyu_tests.py
+++ b/run_iwyu_tests.py
@@ -111,16 +111,6 @@ def PrintLoadedTestsAndFiles():
     print('%s.%s:%s' % (cls.__name__, test, cls.test_files[test]))
 
 
-@GenerateTests(rootdir='tests/c', pattern='*.c')
-class c(unittest.TestCase):
-  pass
-
-
-@GenerateTests(rootdir='tests/cxx', pattern='*.cc')
-class cxx(unittest.TestCase):
-  pass
-
-
 if __name__ == '__main__':
   unittest_args, additional_args = Partition(sys.argv, '--')
   if additional_args:
@@ -130,7 +120,17 @@ if __name__ == '__main__':
   group = parser.add_mutually_exclusive_group()
   group.add_argument('--list', dest='list_tests', action='store_true')
   group.add_argument('--list-test-files', action='store_true')
+  group.add_argument('--run-test-file')
   (runner_args, _) = parser.parse_known_args(unittest_args)
+
+  if runner_args.run_test_file:
+    exit(TestIwyuOnRelevantFiles(runner_args.run_test_file))
+
+  @GenerateTests(rootdir='tests/c', pattern='*.c')
+  class c(unittest.TestCase): pass
+
+  @GenerateTests(rootdir='tests/cxx', pattern='*.cc')
+  class cxx(unittest.TestCase): pass
 
   if runner_args.list_tests:
     exit(PrintLoadedTests())


### PR DESCRIPTION
This PR is based on #855 and it introduces two commits with similar changes.

The idea of "Replace dynamically created test cases…" came to me while working on ObjC support, and I wanted to have simpler way to run ObjC tests only. So I replaced per-test-file TestCases with per-test-file test functions in scoped TestCases. It ended up with three "scopes": C, Cxx and ObjC so I could execute `./run_iwyu_tests.py ObjC` to only run ObjC tests.

Then I researched possible ways of tests parallelization in Python, but I could not find any suitable solution.

I analyzed `run_iwyu_tests.py` script and concluded that it should be easy to let CMake do the job while leaving `iwyu_test_util.py` as a test runner. It worked, and tests parallelization looks impressive to me.

The biggest benefits of cmake-based tests from my perspective:
* test parallelization (`ctest -j N`);
* rerun only failed tests (`ctest --rerun-failed`);
* potentially better integration with other tools (?);
* much faster on 12-core CPU:
** ~7.7s with `run_iwyu_tests.py`;
** ~11.2s with `ctest --progress`;
** ~1.3s with `ctest -j 12 --progress`;
** ~0.9s with `ctest -R 'Cxx::badinc' -j 12 --progress`;

Overall it gives about 8x speedup of local test runs on my machine, I think it might be a good productivity bonus.