### PR TITLE
Simplify _StripCommentFromLine

### DIFF
--- a/iwyu_test_util.py
+++ b/iwyu_test_util.py
@@ -190,12 +190,7 @@ def _GetActualDiagnostics(actual_output):
 
 def _StripCommentFromLine(line):
   """Removes the "// ..." comment at the end of the given line."""
-
-  m = re.match(r'(.*)//', line)
-  if m:
-    return m.group(1).strip() + '\n'
-  else:
-    return line
+  return re.sub(r'\s*//.*$', '', line)
 
 
 def _NormalizeSummaryLineNumbers(line):


### PR DESCRIPTION
Replace with a one-liner.

By the way it might either introduce or fix a possible bug.
`strip` is being called only if a line has a comment, and `strip` cuts whitespaces from both ends of a string. That might cause inconsistent behavior:
```
# original version:
_StripCommentFromLine("\sline\s//comment\n") # "line\n"
_StripCommentFromLine("\sline\n") # "\sline\n"

# updated version:
_StripCommentFromLine("\sline\s//comment\n") # "\sline\n"
_StripCommentFromLine("\sline\n") # "\sline\n"
```

This change keeps leading whitespaces untouched.