### PR TITLE
Replace dynamically created test cases with test functions

### DIFF
--- a/run_iwyu_tests.py
+++ b/run_iwyu_tests.py
@@ -39,63 +39,71 @@ def Partition(l, delimiter):
   return l[:delim_index], l[delim_index+1:]
 
 
-class OneIwyuTest(unittest.TestCase):
-  """Superclass for tests.  A subclass per test-file is created at runtime."""
+def GenerateTests(rootdir, pattern):
+  def _GetTestBody(filename):
+    def _test(self):
+      logging.info('Testing iwyu on %s', filename)
 
-  def RunOneTest(self, filename):
-    logging.info('Testing iwyu on %s', filename)
-    # Split full/path/to/foo.cc into full/path/to/foo and .cc.
-    (all_but_extension, _) = os.path.splitext(filename)
-    (dirname, basename) = os.path.split(all_but_extension)
-    # Generate diagnostics on all foo-* files (well, not other
-    # foo-*.cc files, which is not kosher but is legal), in addition
-    # to foo.h (if present) and foo.cc.
-    all_files = (glob.glob('%s-*' % all_but_extension) +
-                 glob.glob('%s/*/%s-*' % (dirname, basename)) +
-                 glob.glob('%s.h' % all_but_extension) +
-                 glob.glob('%s/*/%s.h' % (dirname, basename)))
-    files_to_check = [f for f in all_files if not fnmatch(f, self.pattern)]
-    files_to_check.append(filename)
+      # Split full/path/to/foo.cc into full/path/to/foo and .cc.
+      (all_but_extension, _) = os.path.splitext(filename)
+      (dirname, basename) = os.path.split(all_but_extension)
+      # Generate diagnostics on all foo-* files (well, not other
+      # foo-*.cc files, which is not kosher but is legal), in addition
+      # to foo.h (if present) and foo.cc.
+      all_files = (glob.glob('%s-*' % all_but_extension) +
+                   glob.glob('%s/*/%s-*' % (dirname, basename)) +
+                   glob.glob('%s.h' % all_but_extension) +
+                   glob.glob('%s/*/%s.h' % (dirname, basename)))
+      files_to_check = [f for f in all_files if not fnmatch(f, pattern)]
+      files_to_check.append(filename)
 
-    # IWYU emits summaries with canonicalized filepaths, where all the
-    # directory separators are set to '/'. In order for the testsuite to
-    # correctly match up file summaries, we must canonicalize the filepaths
-    # in the same way here.
-    files_to_check = [PosixPath(f) for f in files_to_check]
+      # IWYU emits summaries with canonicalized filepaths, where all the
+      # directory separators are set to '/'. In order for the testsuite to
+      # correctly match up file summaries, we must canonicalize the filepaths
+      # in the same way here.
+      files_to_check = [PosixPath(f) for f in files_to_check]
 
-    iwyu_test_util.TestIwyuOnRelativeFile(self, filename, files_to_check,
-                                          verbose=True)
+      iwyu_test_util.TestIwyuOnRelativeFile(self, filename, files_to_check,
+                                            verbose=True)
+    return _test
 
 
-def RegisterFilesForTesting(rootdir, pattern):
-  """Create a test-class for every file in rootdir matching pattern."""
-  filenames = []
-  for (dirpath, dirs, files) in os.walk(rootdir):
-    dirpath = PosixPath(dirpath)  # Normalize path separators.
-    filenames.extend(posixpath.join(dirpath, f) for f in files
-                     if fnmatch(f, pattern))
-  if not filenames:
-    print('No tests found in %s!' % os.path.abspath(rootdir))
-    return
+  def _AddTestFunctions(cls):
+    filenames = []
+    for (dirpath, _, files) in os.walk(rootdir):
+      dirpath = PosixPath(dirpath)  # Normalize path separators.
+      filenames.extend(posixpath.join(dirpath, f) for f in files
+                       if fnmatch(f, pattern))
+    if not filenames:
+      print('No tests found in %s!' % os.path.abspath(rootdir))
+      return
 
-  module = sys.modules[__name__]
+    for filename in filenames:
+      all_but_extension = os.path.splitext(filename)[0]
+      basename = os.path.basename(all_but_extension)
+      test_name = re.sub('[^0-9a-zA-Z_]', '_', basename)  # python-clean
+      test_name = 'test_%s' % test_name
 
-  for filename in filenames:
-    all_but_extension = os.path.splitext(filename)[0]
-    basename = os.path.basename(all_but_extension)
-    class_name = re.sub('[^0-9a-zA-Z_]', '_', basename)  # python-clean
-    if class_name[0].isdigit():            # classes can't start with a number
-      class_name = '_' + class_name
-    while class_name in module.__dict__:   # already have a class with that name
-      class_name += '2'                    # just append a suffix :-)
+      while hasattr(cls, test_name):   # already have a class with that name
+        test_name += '2'               # just append a suffix :-)
 
-    logging.info('Registering %s to test %s', class_name, filename)
-    test_class = type(class_name,          # class name
-                      (OneIwyuTest,),      # superclass
-                      # and attrs. f=filename is required for proper scoping
-                      {'runTest': lambda self, f=filename: self.RunOneTest(f),
-                       'pattern': pattern})
-    setattr(module, test_class.__name__, test_class)
+      logging.info('Registering %s.%s to test %s', cls.__name__, test_name,
+                   filename)
+      setattr(cls, test_name, _GetTestBody(filename))
+
+    return cls
+
+  return _AddTestFunctions
+
+
+@GenerateTests(rootdir='tests/c', pattern='*.c')
+class c(unittest.TestCase):
+  pass
+
+
+@GenerateTests(rootdir='tests/cxx', pattern='*.cc')
+class cxx(unittest.TestCase):
+  pass
 
 
 if __name__ == '__main__':
@@ -103,6 +111,4 @@ if __name__ == '__main__':
   if additional_args:
     iwyu_test_util.SetIwyuPath(additional_args[0])
 
-  RegisterFilesForTesting('tests/cxx', '*.cc')
-  RegisterFilesForTesting('tests/c', '*.c')
   unittest.main(argv=unittest_args)


### PR DESCRIPTION
Depends on #855.

Currently each test source file `{dir}/{name}.{ext}` creates a test case with `{name}` name. Files in different root `{dir}`s but with same {name}s can end up with a name collision, so test runner just adds suffix '2' to the name of test suite to avoid collisions. If a developer wants to only run a specific test using `run_iwyu_tests.py {name}` it might be difficult to figure out which exactly test failed.

This change adds extra layer of hierarchy (scoping) for tests.

Having 'C' and 'Cxx' tests this change introduces 'c' and 'cxx' TestCase classes. As before, test runner walks down the `tests/` subtree, and populates test case classes with `test_{filename}` methods automatically.

Test name examples before and after this change:
File Name  | Test Before   | Test After
-|-|-
c/keep_includes.c   | keep_includes | c.test_keep_includes
cxx/using_unused.cc | using_unused  | cxx.test_using_unused

It also becomes possible to run C or Cxx tests only:
```
run_iwyu_tests.py c
run_iwyu_tests.py cxx
```