### PR TITLE
Workaround missing libomptarget.so.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,6 @@ before_install:
  - PREFIX_PATH=`llvm-config-$VERSION --prefix`
  - BIN_PATH=`llvm-config-$VERSION --bindir`
 
- # Workaround for broken packaging.
- - sudo touch /usr/lib/llvm-12/lib/libomptarget.so.12
-
 script:
 # Build IWYU
  - mkdir build

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@ before_install:
  # Extract the version number from the most-recently installed LLVM
  - VERSION=`ls -t /usr/lib/ | grep '^llvm-' | head -n 1 | sed -E 's/llvm-(.+)/\1/'`
 
+ # Workaround missing libomptarget.so.13
+ - sudo apt-get -y install libomp-$VERSION-dev
+
  # Absolute paths to LLVM's root and bin directory
  - PREFIX_PATH=`llvm-config-$VERSION --prefix`
  - BIN_PATH=`llvm-config-$VERSION --bindir`


### PR DESCRIPTION
`llvm-13` is now the latest version, and the previous workaround does not work anymore.

It turned out that `libomptarget.so.12` is provided by `libomp-dev` package. That package is one of the recommended packages, however Travis uses `--no-install-recommends` option, and that package does not get installed.

Adding `libomp-dev` to the list of packages does not help because it seems that some version of `libomp-dev` (v5 probably) is pre-installed, so the recommended upgrade to v13 does not get installed.

This workaround explicitly installs `libomp-$VERSION-dev`.