### PR TITLE
Add libstdc++-10 related mappings

### DIFF
--- a/gcc.stl.headers.imp
+++ b/gcc.stl.headers.imp
@@ -1,7 +1,9 @@
 # GCC STL headers
 [
+  # Note: make sure to sync this setting with iwyu_include_picker.cc
+
   # Headers explicitly annotated with `@headername`
-  # ( cd /usr/include/c++/8 && grep -r headername | perl -nle 'm/^([^:]+).*@headername\{([^,]*)\}/ && print qq@  { include: ["<$1>", private, "<$2>", public ] },@' | sort -u )
+  # ( cd /usr/include/c++/10 && grep -r headername | perl -nle 'm/^([^:]+).*@headername\{([^,]*)\}/ && print qq@  { include: ["<$1>", private, "<$2>", public ] },@' | sort -u )
   { include: ["<backward/auto_ptr.h>", private, "<memory>", public ] },
   { include: ["<backward/backward_warning.h>", private, "<iosfwd>", public ] },
   { include: ["<backward/binders.h>", private, "<functional>", public ] },
@@ -17,6 +19,7 @@
   { include: ["<bits/basic_string.tcc>", private, "<string>", public ] },
   { include: ["<bits/boost_concept_check.h>", private, "<iterator>", public ] },
   { include: ["<bits/c++0x_warning.h>", private, "<iosfwd>", public ] },
+  { include: ["<bits/charconv.h>", private, "<charconv>", public ] },
   { include: ["<bits/char_traits.h>", private, "<string>", public ] },
   { include: ["<bits/codecvt.h>", private, "<locale>", public ] },
   { include: ["<bits/concept_check.h>", private, "<iterator>", public ] },
@@ -38,9 +41,11 @@
   { include: ["<bits/gslice.h>", private, "<valarray>", public ] },
   { include: ["<bits/hash_bytes.h>", private, "<functional>", public ] },
   { include: ["<bits/indirect_array.h>", private, "<valarray>", public ] },
+  { include: ["<bits/int_limits.h>", private, "<limits>", public ] },
   { include: ["<bits/invoke.h>", private, "<functional>", public ] },
   { include: ["<bits/ios_base.h>", private, "<ios>", public ] },
   { include: ["<bits/istream.tcc>", private, "<istream>", public ] },
+  { include: ["<bits/iterator_concepts.h>", private, "<iterator>", public ] },
   { include: ["<bits/list.tcc>", private, "<list>", public ] },
   { include: ["<bits/locale_classes.h>", private, "<locale>", public ] },
   { include: ["<bits/locale_classes.tcc>", private, "<locale>", public ] },
@@ -64,6 +69,10 @@
   { include: ["<bits/random.h>", private, "<random>", public ] },
   { include: ["<bits/random.tcc>", private, "<random>", public ] },
   { include: ["<bits/range_access.h>", private, "<iterator>", public ] },
+  { include: ["<bits/range_cmp.h>", private, "<functional>", public ] },
+  { include: ["<bits/ranges_algobase.h>", private, "<algorithm>", public ] },
+  { include: ["<bits/ranges_algo.h>", private, "<algorithm>", public ] },
+  { include: ["<bits/ranges_uninitialized.h>", private, "<memory>", public ] },
   { include: ["<bits/refwrap.h>", private, "<functional>", public ] },
   { include: ["<bits/regex_automaton.h>", private, "<regex>", public ] },
   { include: ["<bits/regex_automaton.tcc>", private, "<regex>", public ] },
@@ -115,6 +124,7 @@
   { include: ["<bits/stringfwd.h>", private, "<string>", public ] },
   { include: ["<bits/string_view.tcc>", private, "<string_view>", public ] },
   { include: ["<bits/uniform_int_dist.h>", private, "<random>", public ] },
+  { include: ["<bits/unique_lock.h>", private, "<mutex>", public ] },
   { include: ["<bits/unique_ptr.h>", private, "<memory>", public ] },
   { include: ["<bits/unordered_map.h>", private, "<unordered_map>", public ] },
   { include: ["<bits/unordered_set.h>", private, "<unordered_set>", public ] },
@@ -128,6 +138,7 @@
   { include: ["<experimental/bits/fs_fwd.h>", private, "<experimental/filesystem>", public ] },
   { include: ["<experimental/bits/fs_ops.h>", private, "<experimental/filesystem>", public ] },
   { include: ["<experimental/bits/fs_path.h>", private, "<experimental/filesystem>", public ] },
+  { include: ["<experimental/bits/net.h>", private, "<experimental/net>", public ] },
   { include: ["<experimental/bits/shared_ptr.h>", private, "<experimental/memory>", public ] },
   { include: ["<experimental/bits/string_view.tcc>", private, "<experimental/string_view>", public ] },
   { include: ["<ext/cast.h>", private, "<ext/pointer.h>", public ] },
@@ -157,15 +168,17 @@
   { include: ["<tr1/unordered_map.h>", private, "<tr1/unordered_map>", public ] },
   { include: ["<tr1/unordered_set.h>", private, "<tr1/unordered_set>", public ] },
   { include: ["<tr2/dynamic_bitset.tcc>", private, "<tr2/dynamic_bitset>", public ] },
-  # ( cd /usr/include/x86_64-linux-gnu/c++/8 && grep -r headername | perl -nle 'm/^([^:]+).*@headername\{([^,]*)\}/ && print qq@  { include: ["<$1>", private, "<$2>", public ] },@' | sort -u )
+  # ( cd /usr/include/x86_64-linux-gnu/c++/10 && grep -r headername | perl -nle 'm/^([^:]+).*@headername\{([^,]*)\}/ && print qq@  { include: ["<$1>", private, "<$2>", public ] },@' | sort -u )
   { include: ["<bits/basic_file.h>", private, "<ios>", public ] },
   { include: ["<bits/c++allocator.h>", private, "<memory>", public ] },
   { include: ["<bits/c++config.h>", private, "<iosfwd>", public ] },
+  { include: ["<bits/c++config.h>", private, "<version>", public ] },
   { include: ["<bits/c++io.h>", private, "<ios>", public ] },
   { include: ["<bits/c++locale.h>", private, "<locale>", public ] },
   { include: ["<bits/cpu_defines.h>", private, "<iosfwd>", public ] },
   { include: ["<bits/ctype_base.h>", private, "<locale>", public ] },
   { include: ["<bits/ctype_inline.h>", private, "<locale>", public ] },
+  { include: ["<bits/cxxabi_tweaks.h>", private, "<cxxabi.h>", public ] },
   { include: ["<bits/error_constants.h>", private, "<system_error>", public ] },
   { include: ["<bits/messages_members.h>", private, "<locale>", public ] },
   { include: ["<bits/opt_random.h>", private, "<random>", public ] },
@@ -300,4 +313,12 @@
   # The location of exception_defines.h varies by GCC version.  It should
   # never be included directly.
   { include: ["<exception_defines.h>", private, "<exception>", public ] },
+
+  # post libstdc++-10 stuff which is not automatically caught by commands above
+  { include: ["<bits/exception.h>", private, "<exception>", public ] },
+  { include: ["<pstl/execution_defs.h>", private, "<execution>", public ] },
+  { include: ["<pstl/glue_algorithm_impl.h>", private, "<execution>", public ] },
+  { include: ["<pstl/glue_execution_defs.h>", private, "<execution>", public ] },
+  { include: ["<pstl/parallel_backend_tbb.h>", private, "<execution>", public ] },
+  { include: ["<tbb/tbb_stddef.h>", private, "<execution>", public ] },
 ]

--- a/iwyu_include_picker.cc
+++ b/iwyu_include_picker.cc
@@ -473,9 +473,10 @@ const IncludeMapEntry stdlib_c_include_map[] = {
   // mapping.)  Here is how I identified the files to map:
   // $ for i in /usr/include/c++/4.4/c* ; do ls /usr/include/`basename $i | cut -b2-`.h /usr/lib/gcc/*/4.4/include/`basename $i | cut -b2-`.h 2>/dev/null ; done
   //
-  // These headers are defined in C++14 [headers]p3.  You can get them with
-  // $ sed -n '/begin{floattable}.*{tab:cpp.c.headers}/,/end{floattable}/p' lib-intro.tex | grep tcode | perl -nle 'm/tcode{<c(.*)>}/ && print qq@  { "<$1.h>", kPublic, "<c$1>", kPublic },@' | sort
-  // on https://github.com/cplusplus/draft/blob/master/source/lib-intro.tex
+  // These headers are defined in [headers.cpp.c].
+  // https://github.com/cplusplus/draft/blob/c+%2B20/source/lib-intro.tex
+  //
+  // $ curl -s -N https://raw.githubusercontent.com/cplusplus/draft/c%2B%2B20/source/lib-intro.tex | sed -n '/begin{multicolfloattable}.*{headers.cpp.c}/,/end{multicolfloattable}/p' lib-intro.tex | grep tcode | perl -nle 'm/tcode{<c(.*)>}/ && print qq@  { "<$1.h>", kPublic, "<c$1>", kPublic },@' | sort
   { "<assert.h>", kPublic, "<cassert>", kPublic },
   { "<complex.h>", kPublic, "<ccomplex>", kPublic },
   { "<ctype.h>", kPublic, "<cctype>", kPublic },
@@ -505,19 +506,30 @@ const IncludeMapEntry stdlib_c_include_map[] = {
 };
 
 const char* stdlib_cpp_public_headers[] = {
-  // These headers are defined in C++14 [headers]p2.  You can get them with
-  // $ sed -n '/begin{floattable}.*{tab:cpp.library.headers}/,/end{floattable}/p' lib-intro.tex | grep tcode | perl -nle 'm/tcode{(.*)}/ && print qq@  "$1",@' | sort
-  // on https://github.com/cplusplus/draft/blob/master/source/lib-intro.tex
+  // These headers are defined in [headers.cpp].
+  // https://github.com/cplusplus/draft/blob/c+%2B20/source/lib-intro.tex
+  //
+  // $ curl -s -N https://raw.githubusercontent.com/cplusplus/draft/c%2B%2B20/source/lib-intro.tex | sed -n '/begin{multicolfloattable}.*{headers.cpp}/,/end{multicolfloattable}/p' lib-intro.tex | grep tcode | perl -nle 'm/tcode{(.*)}/ && print qq@  "$1",@' | sort
   "<algorithm>",
+  "<any>",
   "<array>",
   "<atomic>",
+  "<barrier>",
+  "<bit>",
   "<bitset>",
+  "<charconv>",
   "<chrono>",
   "<codecvt>",
+  "<compare>",
   "<complex>",
+  "<concepts>",
   "<condition_variable>",
+  "<coroutine>",
   "<deque>",
   "<exception>",
+  "<execution>",
+  "<filesystem>",
+  "<format>",
   "<forward_list>",
   "<fstream>",
   "<functional>",
@@ -529,43 +541,60 @@ const char* stdlib_cpp_public_headers[] = {
   "<iostream>",
   "<istream>",
   "<iterator>",
+  "<latch>",
   "<limits>",
   "<list>",
   "<locale>",
   "<map>",
   "<memory>",
+  "<memory_resource>",
   "<mutex>",
   "<new>",
+  "<numbers>",
   "<numeric>",
+  "<optional>",
   "<ostream>",
   "<queue>",
   "<random>",
+  "<ranges>",
   "<ratio>",
   "<regex>",
   "<scoped_allocator>",
+  "<semaphore>",
   "<set>",
+  "<shared_mutex>",
+  "<source_location>",
+  "<span>",
   "<sstream>",
   "<stack>",
   "<stdexcept>",
+  "<stop_token>",
   "<streambuf>",
   "<string>",
+  "<string_view>",
   "<strstream>",
+  "<syncstream>",
   "<system_error>",
   "<thread>",
   "<tuple>",
-  "<type_traits>",
   "<typeindex>",
   "<typeinfo>",
+  "<type_traits>",
   "<unordered_map>",
   "<unordered_set>",
   "<utility>",
   "<valarray>",
+  "<variant>",
   "<vector>",
+  "<version>",
 };
 
 // Private -> public include mappings for GNU libstdc++
+//
+// Note: make sure to sync this setting with gcc.stl.headers.imp
+//
 const IncludeMapEntry libstdcpp_include_map[] = {
-  // cd /usr/include/c++/8 && grep -r headername | perl -nle 'm/^([^:]+).*@headername\{([^,]*)\}/ && print qq@  { "<$1>", kPrivate, "<$2>", kPublic },@' | sort -u
+  // cd /usr/include/c++/10 && grep -r headername | perl -nle 'm/^([^:]+).*@headername\{([^,]*)\}/ && print qq@  { "<$1>", kPrivate, "<$2>", kPublic },@' | sort -u
   { "<backward/auto_ptr.h>", kPrivate, "<memory>", kPublic },
   { "<backward/backward_warning.h>", kPrivate, "<iosfwd>", kPublic },
   { "<backward/binders.h>", kPrivate, "<functional>", kPublic },
@@ -581,6 +610,7 @@ const IncludeMapEntry libstdcpp_include_map[] = {
   { "<bits/basic_string.tcc>", kPrivate, "<string>", kPublic },
   { "<bits/boost_concept_check.h>", kPrivate, "<iterator>", kPublic },
   { "<bits/c++0x_warning.h>", kPrivate, "<iosfwd>", kPublic },
+  { "<bits/charconv.h>", kPrivate, "<charconv>", kPublic },
   { "<bits/char_traits.h>", kPrivate, "<string>", kPublic },
   { "<bits/codecvt.h>", kPrivate, "<locale>", kPublic },
   { "<bits/concept_check.h>", kPrivate, "<iterator>", kPublic },
@@ -602,9 +632,11 @@ const IncludeMapEntry libstdcpp_include_map[] = {
   { "<bits/gslice.h>", kPrivate, "<valarray>", kPublic },
   { "<bits/hash_bytes.h>", kPrivate, "<functional>", kPublic },
   { "<bits/indirect_array.h>", kPrivate, "<valarray>", kPublic },
+  { "<bits/int_limits.h>", kPrivate, "<limits>", kPublic },
   { "<bits/invoke.h>", kPrivate, "<functional>", kPublic },
   { "<bits/ios_base.h>", kPrivate, "<ios>", kPublic },
   { "<bits/istream.tcc>", kPrivate, "<istream>", kPublic },
+  { "<bits/iterator_concepts.h>", kPrivate, "<iterator>", kPublic },
   { "<bits/list.tcc>", kPrivate, "<list>", kPublic },
   { "<bits/locale_classes.h>", kPrivate, "<locale>", kPublic },
   { "<bits/locale_classes.tcc>", kPrivate, "<locale>", kPublic },
@@ -628,6 +660,10 @@ const IncludeMapEntry libstdcpp_include_map[] = {
   { "<bits/random.h>", kPrivate, "<random>", kPublic },
   { "<bits/random.tcc>", kPrivate, "<random>", kPublic },
   { "<bits/range_access.h>", kPrivate, "<iterator>", kPublic },
+  { "<bits/range_cmp.h>", kPrivate, "<functional>", kPublic },
+  { "<bits/ranges_algobase.h>", kPrivate, "<algorithm>", kPublic },
+  { "<bits/ranges_algo.h>", kPrivate, "<algorithm>", kPublic },
+  { "<bits/ranges_uninitialized.h>", kPrivate, "<memory>", kPublic },
   { "<bits/refwrap.h>", kPrivate, "<functional>", kPublic },
   { "<bits/regex_automaton.h>", kPrivate, "<regex>", kPublic },
   { "<bits/regex_automaton.tcc>", kPrivate, "<regex>", kPublic },
@@ -679,6 +715,7 @@ const IncludeMapEntry libstdcpp_include_map[] = {
   { "<bits/stringfwd.h>", kPrivate, "<string>", kPublic },
   { "<bits/string_view.tcc>", kPrivate, "<string_view>", kPublic },
   { "<bits/uniform_int_dist.h>", kPrivate, "<random>", kPublic },
+  { "<bits/unique_lock.h>", kPrivate, "<mutex>", kPublic },
   { "<bits/unique_ptr.h>", kPrivate, "<memory>", kPublic },
   { "<bits/unordered_map.h>", kPrivate, "<unordered_map>", kPublic },
   { "<bits/unordered_set.h>", kPrivate, "<unordered_set>", kPublic },
@@ -692,6 +729,7 @@ const IncludeMapEntry libstdcpp_include_map[] = {
   { "<experimental/bits/fs_fwd.h>", kPrivate, "<experimental/filesystem>", kPublic },
   { "<experimental/bits/fs_ops.h>", kPrivate, "<experimental/filesystem>", kPublic },
   { "<experimental/bits/fs_path.h>", kPrivate, "<experimental/filesystem>", kPublic },
+  { "<experimental/bits/net.h>", kPrivate, "<experimental/net>", kPublic },
   { "<experimental/bits/shared_ptr.h>", kPrivate, "<experimental/memory>", kPublic },
   { "<experimental/bits/string_view.tcc>", kPrivate, "<experimental/string_view>", kPublic },
   { "<ext/cast.h>", kPrivate, "<ext/pointer.h>", kPublic },
@@ -721,10 +759,11 @@ const IncludeMapEntry libstdcpp_include_map[] = {
   { "<tr1/unordered_map.h>", kPrivate, "<tr1/unordered_map>", kPublic },
   { "<tr1/unordered_set.h>", kPrivate, "<tr1/unordered_set>", kPublic },
   { "<tr2/dynamic_bitset.tcc>", kPrivate, "<tr2/dynamic_bitset>", kPublic },
-  // cd /usr/include/x86_64-linux-gnu/c++/8 && grep -r headername | perl -nle 'm/^([^:]+).*@headername\{([^,]*)\}/ && print qq@  { "<$1>", kPrivate, "<$2>", kPublic },@' | sort -u
+  // cd /usr/include/x86_64-linux-gnu/c++/10 && grep -r headername | perl -nle 'm/^([^:]+).*@headername\{([^,]*)\}/ && print qq@  { "<$1>", kPrivate, "<$2>", kPublic },@' | sort -u
   { "<bits/basic_file.h>", kPrivate, "<ios>", kPublic },
   { "<bits/c++allocator.h>", kPrivate, "<memory>", kPublic },
   { "<bits/c++config.h>", kPrivate, "<iosfwd>", kPublic },
+  { "<bits/c++config.h>", kPrivate, "<version>", kPublic },
   { "<bits/c++io.h>", kPrivate, "<ios>", kPublic },
   { "<bits/c++locale.h>", kPrivate, "<locale>", kPublic },
   { "<bits/cpu_defines.h>", kPrivate, "<iosfwd>", kPublic },
@@ -865,6 +904,14 @@ const IncludeMapEntry libstdcpp_include_map[] = {
   // The location of exception_defines.h varies by GCC version.  It should
   // never be included directly.
   { "<exception_defines.h>", kPrivate, "<exception>", kPublic },
+
+  // post libstdc++-10 stuff which is not automatically caught by commands above
+  { "<bits/exception.h>", kPrivate, "<exception>", kPublic },
+  { "<pstl/execution_defs.h>", kPrivate, "<execution>", kPublic },
+  { "<pstl/glue_algorithm_impl.h>", kPrivate, "<execution>", kPublic },
+  { "<pstl/glue_execution_defs.h>", kPrivate, "<execution>", kPublic },
+  { "<pstl/parallel_backend_tbb.h>", kPrivate, "<execution>", kPublic },
+  { "<tbb/tbb_stddef.h>", kPrivate, "<execution>", kPublic },
 };
 
 // Returns true if str is a valid quoted filepath pattern (i.e. either


### PR DESCRIPTION
Checked for my application using C++20 flags, with Clang 13.

---

__Issue described below has been moved to: #884__

~~Although most of the diff is trivial, I still get some error in my code:~~

> ~~#include <filesystem>~~
>
> ~~void clean_file(const std::filesystem::path& path)~~
> ~~{~~
>      ~~remove(path); // ADL~~
> ~~}~~

~~`std::filesystem::path` and `std::filesystem::remove` both sit in the same namespace, `std::filesystem`. So calling the `remove` function without namespace qualification should trigger ADL. My code correctly compiles without any compiler warning on my actual build.~~

~~However IWYU suggests including `<stdio.h>` for the function `remove`. It is obvious that [`remove(const char*)`](https://en.cppreference.com/w/c/io/remove) (in global namespace) should not be found even with ADL; the more matching signature is [`remove(const std::filesystem::path&)`](https://en.cppreference.com/w/cpp/filesystem/remove) (in namespace std::filesystem). In IWYU, where does this strange suggestion come from?~~

~~The ADL issue seem unrelated to this specific PR, so I omitted the workaround inside mapping update. I guess there exists some nasty pitfalls for ADL detection in IWYU. Maybe we could discuss that in another issue?~~