### PR TITLE
Encourage use of std::size_t in C++

### DIFF
--- a/gcc.symbols.imp
+++ b/gcc.symbols.imp
@@ -169,5 +169,13 @@
   # string/ostream/istream type.
   { symbol: [ "std::char_traits", private, "<string>", public ] },
   { symbol: [ "std::char_traits", private, "<ostream>", public ] },
-  { symbol: [ "std::char_traits", private, "<istream>", public ] }
+  { symbol: [ "std::char_traits", private, "<istream>", public ] },
+
+  { symbol: [ "std::size_t", private, "<cstddef>", public ] },
+  { symbol: [ "std::size_t", private, "<cstdio>", public ] },
+  { symbol: [ "std::size_t", private, "<cstdlib>", public ] },
+  { symbol: [ "std::size_t", private, "<cstring>", public ] },
+  { symbol: [ "std::size_t", private, "<ctime>", public ] },
+  { symbol: [ "std::size_t", private, "<cuchar>", public ] },
+  { symbol: [ "std::size_t", private, "<cwchar>", public ] }
 ]

--- a/iwyu_include_picker.cc
+++ b/iwyu_include_picker.cc
@@ -252,6 +252,14 @@ const IncludeMapEntry libstdcpp_symbol_map[] = {
   { "std::char_traits", kPrivate, "<string>", kPublic },
   { "std::char_traits", kPrivate, "<ostream>", kPublic },
   { "std::char_traits", kPrivate, "<istream>", kPublic },
+
+  { "std::size_t", kPrivate, "<cstddef>", kPublic },  // 'canonical' location for std::size_t
+  { "std::size_t", kPrivate, "<cstdio>", kPublic },
+  { "std::size_t", kPrivate, "<cstdlib>", kPublic },
+  { "std::size_t", kPrivate, "<cstring>", kPublic },
+  { "std::size_t", kPrivate, "<ctime>", kPublic },
+  { "std::size_t", kPrivate, "<cuchar>", kPublic },
+  { "std::size_t", kPrivate, "<cwchar>", kPublic },
 };
 
 // Private -> public include mappings for GNU libc

--- a/tests/cxx/std_size_t.cc
+++ b/tests/cxx/std_size_t.cc
@@ -1,0 +1,39 @@
+//===--- std_size_t.cc - test input file for iwyu -------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// This tests a little quirk with the mappings for the new <cstd...> headers.
+// size_t is such a commonly-used type that it deserves a dedicated test to
+// demonstrate how this behaves in general. Note how the use of 'printf' is
+// attributed to <cstdio> and <stdio.h> is removed. This happens because
+// std::size_t is mapped to <cstdio> before 'printf' is seen and already-needed
+// includes take precedence if a symbol is available from multiple sources.
+//
+// (Note that if 'printf' was seen before std::size_t, <stdio.h> would still be
+// required.)
+
+#include <cstdio>
+#include <stdio.h>
+
+std::size_t f() {
+  const size_t x = 100;
+  printf("%zu\n", x);
+  return sizeof(int);
+}
+
+/**** IWYU_SUMMARY
+
+tests/cxx/std_size_t.cc should add these lines:
+
+tests/cxx/std_size_t.cc should remove these lines:
+- #include <stdio.h>  // lines XX-XX
+
+The full include-list for tests/cxx/std_size_t.cc:
+#include <cstdio>  // for printf, size_t
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
iwyu was previously suggesting `<iosfwd>` for `std::size_t` (which works because of transitive includes on standard headers, but due to the spec it's not guaranteed to work always). 

- <https://timsong-cpp.github.io/cppwp/n4861/support>
- <https://timsong-cpp.github.io/cppwp/n4861/iosfwd.syn#:%3ciosfwd%3e>

iwyu now suggests either `<iosfwd>` or `<version>` depending on the code's context, see #883

This pr resolves `std::size_t` to appropriate C++ headers. Same kind of workaround had already been implemented for C, but C++ support was lacking. Also iwyu's internal implementation is modified to use `std::size_t` instead of `size_t`. 