### PR TITLE
Add flag to exit with exit code 0 on success

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -3695,8 +3695,10 @@ class IwyuAstConsumer
     // unless --exit_code is specified
     if (GlobalFlags().exit_code && num_edits == 0)
       exit(EXIT_SUCCESSFULLY);
-    else
+    else if (EXIT_SUCCESS_OFFSET + num_edits <= EXIT_MAX)
       exit(EXIT_SUCCESS_OFFSET + num_edits);
+    else
+      exit(EXIT_MAX);
   }
 
   void ParseFunctionTemplates(TranslationUnitDecl* decl) {

--- a/iwyu.cc
+++ b/iwyu.cc
@@ -3691,8 +3691,12 @@ class IwyuAstConsumer
     num_edits += preprocessor_info().FileInfoFor(main_file)
         ->CalculateAndReportIwyuViolations();
 
-    // We need to force the compile to fail so we can re-run.
-    exit(EXIT_SUCCESS_OFFSET + num_edits);
+    // We need to force the compile to fail so we can re-run,
+    // unless --exit_code is specified
+    if (GlobalFlags().exit_code && num_edits == 0)
+      exit(EXIT_SUCCESSFULLY);
+    else
+      exit(EXIT_SUCCESS_OFFSET + num_edits);
   }
 
   void ParseFunctionTemplates(TranslationUnitDecl* decl) {
@@ -4162,5 +4166,7 @@ int main(int argc, char **argv) {
   // We always return a failure exit code, to indicate we didn't
   // successfully compile (produce a .o for) the source files we were
   // given.
+  // Note: If --exit_code was passed, we want to exit with code 0
+  // if there are no edits. That's handled in HandleTranslationUnit.
   return 1;
 }

--- a/iwyu_globals.cc
+++ b/iwyu_globals.cc
@@ -96,6 +96,7 @@ static void PrintHelp(const char* extra_msg) {
          "   --quoted_includes_first: when sorting includes, place quoted\n"
          "        ones first.\n"
          "   --cxx17ns: suggests the more concise syntax introduced in C++17\n"
+         "   --exit_code: Return 0 if no issues were found\n"
          "\n"
          "In addition to IWYU-specific options you can specify the following\n"
          "options without -Xiwyu prefix:\n"
@@ -165,7 +166,8 @@ CommandlineFlags::CommandlineFlags()
       no_comments(false),
       no_fwd_decls(false),
       quoted_includes_first(false),
-      cxx17ns(false) {
+      cxx17ns(false),
+      exit_code(false) {
   // Always keep Qt .moc includes; its moc compiler does its own IWYU analysis.
   keep.emplace("*.moc");
 }
@@ -185,6 +187,7 @@ int CommandlineFlags::ParseArgv(int argc, char** argv) {
     {"no_fwd_decls", no_argument, nullptr, 'f'},
     {"quoted_includes_first", no_argument, nullptr, 'q' },
     {"cxx17ns", no_argument, nullptr, 'C'},
+    {"exit_code", no_argument, nullptr, 'e'},
     {nullptr, 0, nullptr, 0}
   };
   static const char shortopts[] = "v:c:m:n";
@@ -217,6 +220,7 @@ int CommandlineFlags::ParseArgv(int argc, char** argv) {
         break;
       case 'q': quoted_includes_first = true; break;
       case 'C': cxx17ns = true; break;
+      case 'e': exit_code = true; break;
       case -1: return optind;   // means 'no more input'
       default:
         PrintHelp("FATAL ERROR: unknown flag.");

--- a/iwyu_globals.h
+++ b/iwyu_globals.h
@@ -30,6 +30,8 @@ namespace include_what_you_use {
 // Of course, this means that IWYU always fails (i.e. never returns 0.)
 // This is intentional, so it can be used with make -k without ever being
 // considered up-to-date.
+// However, if --exit_code is passed, we return 0 if there are no edits.
+static const int EXIT_SUCCESSFULLY = 0;
 static const int EXIT_INVALIDARGS = 1;
 static const int EXIT_SUCCESS_OFFSET = 2;
 
@@ -101,6 +103,7 @@ struct CommandlineFlags {
   bool no_fwd_decls;  // Disable forward declarations.
   bool quoted_includes_first; // Place quoted includes first in sort order.
   bool cxx17ns; // -C: C++17 nested namespace syntax
+  bool exit_code;
 };
 
 const CommandlineFlags& GlobalFlags();

--- a/iwyu_globals.h
+++ b/iwyu_globals.h
@@ -30,10 +30,14 @@ namespace include_what_you_use {
 // Of course, this means that IWYU always fails (i.e. never returns 0.)
 // This is intentional, so it can be used with make -k without ever being
 // considered up-to-date.
-// However, if --exit_code is passed, we return 0 if there are no edits.
+// Additionally, we never want to exit with an exit code that's too big.
+// Exit codes over 255 wrap around on common systems, and high exit codes are
+// used by shells to signal that a process exited abnormally and other errors.
+// if --exit_code is passed, we return 0 if there are no edits.
 static const int EXIT_SUCCESSFULLY = 0;
 static const int EXIT_INVALIDARGS = 1;
 static const int EXIT_SUCCESS_OFFSET = 2;
+static const int EXIT_MAX = 100;
 
 using std::set;
 using std::string;


### PR DESCRIPTION
As discussed in https://github.com/include-what-you-use/include-what-you-use/issues/440 and https://github.com/include-what-you-use/include-what-you-use/issues/790, there's a need for IWYU to exit with code 0 if there are no suggested edits, and a non-zero exit code if there are suggested edits. This PR adds the `--exit_code` flag to do just that.

Here are some considerations:

* I don't know if the name `--exit_code` is ideal. I used it because that's what other tools, such as `git diff`, uses to make the exit code useful. Maybe it should be called `--fail_only_on_error` or something, I don't know. I'm open to suggestions.
* I don't like having both `EXIT_SUCCESSFULLY` and `EXIT_SUCCESS_OFFSET`, but I'm having trouble coming up with better names.
* It might be better to switch the default state of the option, so that the default behavior is to exit with code 0 if there are no suggested edits, and passing `--always_fail` makes it exit with code `2 + num_edits`. That would certainly be more in line with what people expect, since people expect a tool to exit with code 0 when there were no errors. I can imagine people spending a long time trying to figure out what's wrong with their makefile, without realizing that it's actually IWYW that behaves weirdly, not their makefile that's wrong. On the other hand, it would break backwards compatibility.

Also, I think I noticed a bug in the existing exit handling code: `exit(EXIT_SUCCESS_OFFSET + num_edits);` will exit with exit code 0 if `num_edits + 2` is a multiple of 256. I don't know if that's realistically ever going to happen.