### PR TITLE
Run tests in parallel on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Test include-what-you-use
         run: |
           cd ./build
-          CTEST_OUTPUT_ON_FAILURE=1 ctest
+          CTEST_OUTPUT_ON_FAILURE=1 ctest -j 6
 
       - name: Test install
         run: |


### PR DESCRIPTION
It currently takes ~18s to run tests on CI. Running tests in parallel can be much faster.