### PR TITLE
Get a FileEntry for <new> imports

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -1155,6 +1155,7 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
   using Base::CurrentFileEntry;
   using Base::PrintableCurrentLoc;
   using Base::current_ast_node;
+  using Base::compiler;
 
   enum class IgnoreKind {
     ForUse,
@@ -2426,9 +2427,18 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
         // parse it to '<new>' before using, so any path that does
         // that, and is clearly a c++ path, is fine; its exact
         // contents don't matter that much.
+        using clang::Optional;
+        using clang::DirectoryLookup;
+        using clang::FileEntryRef;
         const FileEntry* use_file = CurrentFileEntry();
-        preprocessor_info().FileInfoFor(use_file)->ReportFullSymbolUse(
-            CurrentLoc(), "<new>", "operator new");
+        const DirectoryLookup* curdir = nullptr;
+        Optional<FileEntryRef> file = compiler()->getPreprocessor().LookupFile(
+            CurrentLoc(), "new", true, nullptr, use_file, curdir, nullptr,
+            nullptr, nullptr, nullptr, nullptr, false);
+        if (file) {
+          preprocessor_info().FileInfoFor(use_file)->ReportFullSymbolUse(
+              CurrentLoc(), *file, "operator new");
+        }
       }
     }
 

--- a/iwyu_output.cc
+++ b/iwyu_output.cc
@@ -631,9 +631,10 @@ void IwyuFileInfo::ReportFullSymbolUse(SourceLocation use_loc,
 }
 
 void IwyuFileInfo::ReportFullSymbolUse(SourceLocation use_loc,
-                                       const string& dfn_filepath,
+                                       const FileEntry* dfn_file,
                                        const string& symbol) {
-  symbol_uses_.push_back(OneUse(symbol, nullptr, dfn_filepath, use_loc));
+  symbol_uses_.push_back(OneUse(symbol, dfn_file, 
+                                GetFilePath(dfn_file), use_loc));
   LogSymbolUse("Marked full-info use of symbol", symbol_uses_.back());
 }
 

--- a/iwyu_output.h
+++ b/iwyu_output.h
@@ -236,7 +236,7 @@ class IwyuFileInfo {
   // only for placement operator new in templates (see
   // IwyuBaseAstVisitor::VisitCXXNewExpr).
   void ReportFullSymbolUse(clang::SourceLocation use_loc,
-                           const string& dfn_filepath,
+                           const clang::FileEntry* dfn_file,
                            const string& symbol);
   // TODO(dsturtevant): Can we determine in_cxx_method_body? Do we care?
 


### PR DESCRIPTION
Use preprocessor to lookup the `FileEntry` for `<new>` in the corner case that reports the "placement new" symbol usage.

This is an experimental change and I am looking for your feedback @kimgr.

I find the current implementation of the final steps of IWYU a bit overcomplicated. I mean the steps that actually find the intersection and the difference of two sets: existing imports and "desired" imports.

As far as I can see now IWYU works with "lines" (`OneIncludeOrForwardDeclareLine`), and IMO we can treat these as "strings".

I find it a bit inefficient and inaccurate, and my proposal is to use `FileEntries` for that. For every `IwyuFileInfo` we could collect the set of `FileEntries` being `#included`, as well as all the `SourceLocations` of these includes.

For example `IwyuFileInfo` could contain a map like:
```
std::map<const FileEntry*, std::set<SourceLocation>>
```
where the key is an import, and the value is all the locations of that import in the file relevant to that `IwuiFileInfo`. Then when we report a Full Use or a Forward Declaration we could also get the `FileEntry` for the corresponding symbol. In the end of AST traversal there will be two sets of `FileEntry` values and it should be much easier to calculate the deletions and the insertions.

Header mapping might be a good question, but as far as I can understand, mappings should only be applied to insertions (because IMO the existing imports that were used should not be modified - ?), and that operation could probably be made in the very end of the imports diffing algorithm.

I find the idea of migrating the logic to FileEntries very promising, and that pull request makes a first small step towards it. I am looking forward to get rid of as many of string-based operations as possible. One of the blockers was the `<new>` special case, and that change finds the FileEntry for `<new>` header.

What do you think about moving to FileEntry-based solution?