### PR TITLE
Improve detection of builtin functions

### DIFF
--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -1095,11 +1095,14 @@ bool DeclsAreInSameClass(const Decl* decl1, const Decl* decl2) {
   return decl1->getDeclContext()->isRecord();
 }
 
-bool IsBuiltinFunction(const clang::NamedDecl* decl,
-                       const std::string& symbol_name) {
+bool IsBuiltinFunction(const clang::NamedDecl* decl) {
   if (const clang::IdentifierInfo* iden = decl->getIdentifier()) {
-    return iden->getBuiltinID() != 0 &&
-           !clang::Builtin::Context::isBuiltinFunc(symbol_name.c_str());
+    unsigned builtin_id = iden->getBuiltinID();
+    if (builtin_id != 0) {
+      const clang::Builtin::Context& ctx = decl->getASTContext().BuiltinInfo;
+      return !ctx.isPredefinedLibFunction(builtin_id) &&
+             !ctx.isHeaderDependentFunction(builtin_id);
+    }
   }
   return false;
 }

--- a/iwyu_ast_util.h
+++ b/iwyu_ast_util.h
@@ -652,8 +652,7 @@ const clang::NamedDecl* GetNonfriendClassRedecl(const clang::NamedDecl* decl);
 bool DeclsAreInSameClass(const clang::Decl* decl1, const clang::Decl* decl2);
 
 // Returns true if the given decl/name is a builtin function
-bool IsBuiltinFunction(const clang::NamedDecl* decl,
-                       const std::string& symbol_name);
+bool IsBuiltinFunction(const clang::NamedDecl* decl);
 
 // --- Utilities for Type.
 

--- a/iwyu_output.cc
+++ b/iwyu_output.cc
@@ -1161,7 +1161,7 @@ void ProcessFullUse(OneUse* use,
   // We normally ignore uses for builtins, but when there is a mapping defined
   // for the symbol, we should respect that.  So, we need to determine whether
   // the symbol has any mappings.
-  bool is_builtin_function = IsBuiltinFunction(use->decl(), use->symbol_name());
+  bool is_builtin_function = IsBuiltinFunction(use->decl());
 
   bool is_builtin_function_with_mappings =
       is_builtin_function && HasMapping(use->symbol_name());

--- a/tests/c/libbuiltins-direct.h
+++ b/tests/c/libbuiltins-direct.h
@@ -1,0 +1,10 @@
+//===--- libbuiltins-direct.h - test input file for iwyu ------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include <math.h>

--- a/tests/c/libbuiltins.c
+++ b/tests/c/libbuiltins.c
@@ -1,0 +1,34 @@
+//===--- libbuiltins.c - test input file for iwyu -------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// Library builtins are, like normal builtins, compiled down to an intrinsic,
+// but a header still needs to be included for the program to be valid. The math
+// library (pow, round, etc) is a typical example.
+
+// IWYU_ARGS: -I .
+
+#include "tests/c/libbuiltins-direct.h"
+
+float kapow(float x) {
+  // IWYU: pow is...*math.h
+  return pow(x, 2.0F);
+}
+
+/**** IWYU_SUMMARY
+
+tests/c/libbuiltins.c should add these lines:
+#include <math.h>
+
+tests/c/libbuiltins.c should remove these lines:
+- #include "tests/c/libbuiltins-direct.h"  // lines XX-XX
+
+The full include-list for tests/c/libbuiltins.c:
+#include <math.h>  // for pow
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/libbuiltins-direct.h
+++ b/tests/cxx/libbuiltins-direct.h
@@ -1,0 +1,10 @@
+//===--- libbuiltins-direct.h - test input file for iwyu ------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cmath>

--- a/tests/cxx/libbuiltins.cc
+++ b/tests/cxx/libbuiltins.cc
@@ -1,0 +1,34 @@
+//===--- libbuiltins.cc - test input file for iwyu ------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// Library builtins are, like normal builtins, compiled down to an intrinsic,
+// but a header still needs to be included for the program to be valid. The math
+// library (std::pow, std::round, etc) is a typical example.
+
+// IWYU_ARGS: -I .
+
+#include "tests/cxx/libbuiltins-direct.h"
+
+float kapow(float x) {
+  // IWYU: std::pow is...*cmath
+  return std::pow(x, 2.0F);
+}
+
+/**** IWYU_SUMMARY
+
+tests/cxx/libbuiltins.cc should add these lines:
+#include <cmath>
+
+tests/cxx/libbuiltins.cc should remove these lines:
+- #include "tests/cxx/libbuiltins-direct.h"  // lines XX-XX
+
+The full include-list for tests/cxx/libbuiltins.cc:
+#include <cmath>  // for pow
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
The technique used before relied on linear search of all builtins by
name. This did not work with qualified C++ names of C library names such
as std::pow and std::round.

Use ASTContext to get to BuiltinInfo, and in turn use that to check more
specific traits of the builtin by ID instead of name.

Fixes issue #918.