### PR TITLE
Ensure TU has a scope in implicit method instantiation

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -191,6 +191,7 @@ using clang::QualifiedTypeLoc;
 using clang::RecordDecl;
 using clang::RecursiveASTVisitor;
 using clang::ReferenceType;
+using clang::Sema;
 using clang::SourceLocation;
 using clang::Stmt;
 using clang::SubstTemplateTypeParmType;
@@ -588,7 +589,7 @@ class BaseAstVisitor : public RecursiveASTVisitor<Derived> {
     if (decl->isDependentType())   // only instantiate if class is instantiated
       return;
 
-    clang::Sema& sema = compiler()->getSema();
+    Sema& sema = compiler()->getSema();
     DeclContext::lookup_result ctors = sema.LookupConstructors(decl);
     for (NamedDecl* ctor_lookup : ctors) {
       // Ignore templated or inheriting constructors.
@@ -598,7 +599,7 @@ class BaseAstVisitor : public RecursiveASTVisitor<Derived> {
         continue;
       CXXConstructorDecl* ctor = cast<CXXConstructorDecl>(ctor_lookup);
       if (!ctor->hasBody() && !ctor->isDeleted() && ctor->isImplicit()) {
-        if (sema.getSpecialMember(ctor) == clang::Sema::CXXDefaultConstructor) {
+        if (sema.getSpecialMember(ctor) == Sema::CXXDefaultConstructor) {
           sema.DefineImplicitDefaultConstructor(CurrentLoc(), ctor);
         } else {
           // TODO(nlewycky): enable this!
@@ -3711,7 +3712,7 @@ class IwyuAstConsumer
 
   void ParseFunctionTemplates(TranslationUnitDecl* tu_decl) {
     set<FunctionDecl*> late_parsed_decls = GetLateParsedFunctionDecls(tu_decl);
-    clang::Sema& sema = compiler()->getSema();
+    Sema& sema = compiler()->getSema();
 
     // If we have any late-parsed functions, make sure the
     // -fdelayed-template-parsing flag is on. Otherwise we don't know where

--- a/iwyu.cc
+++ b/iwyu.cc
@@ -3657,11 +3657,14 @@ class IwyuAstConsumer
     const_cast<IwyuPreprocessorInfo*>(&preprocessor_info())->
         HandlePreprocessingDone();
 
+    TranslationUnitDecl* tu_decl = context.getTranslationUnitDecl();
+
     // We run a separate pass to force parsing of late-parsed function
     // templates.
-    ParseFunctionTemplates(context.getTranslationUnitDecl());
+    ParseFunctionTemplates(tu_decl);
 
-    TraverseDecl(context.getTranslationUnitDecl());
+    // Run IWYU analysis.
+    TraverseDecl(tu_decl);
 
     // Check if any unrecoverable errors have occurred.
     // There is no point in continuing when the AST is in a bad state.
@@ -3706,8 +3709,8 @@ class IwyuAstConsumer
     exit(EXIT_SUCCESS_OFFSET + num_edits);
   }
 
-  void ParseFunctionTemplates(TranslationUnitDecl* decl) {
-    set<FunctionDecl*> late_parsed_decls = GetLateParsedFunctionDecls(decl);
+  void ParseFunctionTemplates(TranslationUnitDecl* tu_decl) {
+    set<FunctionDecl*> late_parsed_decls = GetLateParsedFunctionDecls(tu_decl);
     clang::Sema& sema = compiler()->getSema();
 
     // If we have any late-parsed functions, make sure the

--- a/tests/cxx/scope_crash.cc
+++ b/tests/cxx/scope_crash.cc
@@ -1,0 +1,45 @@
+//===--- scope_crash.cc - test input file for iwyu ------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// This is a weak testcase, but it's the smallest example we've found to
+// reproduce an IWYU crash where Sema::TUScope was unexpectedly null.
+//
+// For some reason libstdc++9's std::map with a value with explicit default
+// constructor triggers some path in Sema's constructor lookup that needs a
+// non-null TUScope.
+//
+// Clang or libstdc++ might change so that this can no longer trigger the
+// original bug, or so that the bug manifests some other way. But testers can't
+// be choosers.
+
+#include <string>
+#include <map>
+
+struct A {};
+
+bool operator<(const A& lhs, const A& rhs) {
+  return false;
+}
+
+struct B {
+  // Used to crash with libstdc++ 9, worked without 'explicit'
+  explicit B() = default;
+  std::string data;
+};
+
+void foo(const A& a) {
+  std::map<A, B> m;
+  m.erase(a);
+}
+
+/**** IWYU_SUMMARY
+
+(tests/cxx/scope_crash.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
This attempts to fix the crash observed in #151, #419, #601, #673 and #820.

It also moves `InstantiateImplicitMethods` out of the main IWYU AST visitor and into a separate pass, based on the approach in PR #818. After debugging this for a significant time, I believe this is the right move.

One thing I've noticed in testing is that the example repro case from #601 now generates a clang diagnostic rather than crashing:
```
$ include-what-you-use -Xiwyu -v3 llvm_tablegen_jsonbackend.cc
llvm_tablegen_jsonbackend.cc:24:24: error: no member named 'c' in 'r<G>'
struct e<f, g> : aa<f::c, g>::h {};
                    ~~~^
llvm_tablegen_jsonbackend.cc:56:24: note: in instantiation of template class 'e<r<G>, int>' requested here
            typename s<e<r<t>, u>::c>::h = true>
                       ^
llvm_tablegen_jsonbackend.cc:57:3: note: while substituting prior template arguments into non-type template parameter [with t = G, u = int]
  H();
  ^~~
llvm_tablegen_jsonbackend.cc:54:8: note: while substituting deduced template arguments into function template 'H' [with t = (no value), u = (no value), $2 = (no value)]
struct H {
       ^
```

I believe this is reasonable, because we're now instantiating templates that were otherwise uninstantiated in the TU, and it appears the templates are actually incorrectly defined. This can be verified by adding:
```
void food() {
  H haxx;
} 
```
at the end of `llvm_tablegen_jsonbackend.cc` and running it through clang: `clang++-13 -fsyntax-only llvm_tablegen_jsonbackend.cc`, which produces the same error.

Testing and feedback very welcome!