### PR TITLE
Use primary function template declaration for macro author intent

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -1259,7 +1259,26 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
     for (const NamedDecl* redecl : GetClassRedecls(decl)) {
       if (GetFileEntry(redecl) == macro_def_file && IsForwardDecl(redecl)) {
         fwd_decl = redecl;
+        break;
+      }
+    }
 
+    if (!fwd_decl) {
+      if (const auto* func_decl = dyn_cast<FunctionDecl>(decl)) {
+        if (const FunctionTemplateDecl* ft_decl =
+            func_decl->getPrimaryTemplate()) {
+          VERRS(5) << "No fwd-decl found, looking for function template decl\n";
+          for (const NamedDecl* redecl : ft_decl->redecls()) {
+            if (GetFileEntry(redecl) == macro_def_file) {
+              fwd_decl = redecl;
+              break;
+            }
+          }
+        }
+      }
+    }
+
+    if (fwd_decl) {
         // Make sure we keep that forward-declaration, even if it's probably
         // unused in this file.
         IwyuFileInfo* file_info =
@@ -1267,8 +1286,6 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
         file_info->ReportForwardDeclareUse(
             spelling_loc, fwd_decl,
             ComputeUseFlags(current_ast_node()), nullptr);
-        break;
-      }
     }
 
     // Resolve the best use location based on our current knowledge.

--- a/tests/cxx/macro_location_tpl-d1.h
+++ b/tests/cxx/macro_location_tpl-d1.h
@@ -1,0 +1,10 @@
+//===--- macro_location_tpl-d1.h - test input file for iwyu ---------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/macro_location_tpl-i1.h"

--- a/tests/cxx/macro_location_tpl-d2.h
+++ b/tests/cxx/macro_location_tpl-d2.h
@@ -1,0 +1,33 @@
+//===--- macro_location_tpl-d2.h - test input file for iwyu ---------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// Declare a couple of function templates whose specializations are used in a
+// macro, to check that author intent hints attribute uses to the right place.
+template <typename>
+void expansion_template() = delete;
+template <>
+void expansion_template<int>();
+
+template <typename>
+void spelling_template() = delete;
+template <>
+void spelling_template<int>();
+
+// As above, but for class templates.
+template <typename>
+struct ExpansionTemplate {
+  void method() {
+  }
+};
+
+template <typename>
+struct SpellingTemplate {
+  void method() {
+  }
+};

--- a/tests/cxx/macro_location_tpl-i1.h
+++ b/tests/cxx/macro_location_tpl-i1.h
@@ -1,0 +1,30 @@
+//===--- macro_location_tpl-i1.h - test input file for iwyu ---------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// Forward-declare the primary templates as a signal that specialization uses
+// belong in the expansion location.
+template <typename>
+void expansion_template();
+
+template <typename>
+class ExpansionTemplate;
+
+// expansion_template should be attributed to expansion loc.
+#define FUNC_TEMPLATE_SPEC_EXPANSION expansion_template<int>()
+
+// spelling_template should be attributed to this file, because there's no
+// forward-declare hint.
+#define FUNC_TEMPLATE_SPEC_SPELLING spelling_template<int>();
+
+// ExpansionTemplate should be attributed to expansion loc.
+#define CLASS_TEMPLATE_SPEC_EXPANSION ExpansionTemplate<int>().method();
+
+// SpellingTemplate should be attributed to this file, because there's no
+// forward-declare hint.
+#define CLASS_TEMPLATE_SPEC_SPELLING SpellingTemplate<int>().method();

--- a/tests/cxx/macro_location_tpl.cc
+++ b/tests/cxx/macro_location_tpl.cc
@@ -1,0 +1,46 @@
+//===--- macro_location_tpl.cc - test input file for iwyu -----------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// Expands on macro_location test case to also cover template scenarios.  Macro
+// uses are attributed to spelling location, but forward-declarations of primary
+// templates also work as author intent hints for template specializations used
+// inside the macro.
+
+// IWYU_ARGS: -I .
+
+#include "tests/cxx/macro_location_tpl-d2.h"
+#include "tests/cxx/macro_location_tpl-d1.h"
+
+void use_macro_with_template_spec() {
+  // IWYU: FUNC_TEMPLATE_SPEC_EXPANSION is defined...*macro_location_tpl-i1.h
+  FUNC_TEMPLATE_SPEC_EXPANSION;
+
+  // IWYU: FUNC_TEMPLATE_SPEC_SPELLING is defined...*macro_location_tpl-i1.h
+  FUNC_TEMPLATE_SPEC_SPELLING;
+
+  // IWYU: CLASS_TEMPLATE_SPEC_EXPANSION is defined...*macro_location_tpl-i1.h
+  CLASS_TEMPLATE_SPEC_EXPANSION;
+
+  // IWYU: CLASS_TEMPLATE_SPEC_SPELLING is defined...*macro_location_tpl-i1.h
+  CLASS_TEMPLATE_SPEC_SPELLING;
+}
+
+/**** IWYU_SUMMARY
+
+tests/cxx/macro_location_tpl.cc should add these lines:
+#include "tests/cxx/macro_location_tpl-i1.h"
+
+tests/cxx/macro_location_tpl.cc should remove these lines:
+- #include "tests/cxx/macro_location_tpl-d1.h"  // lines XX-XX
+
+The full include-list for tests/cxx/macro_location_tpl.cc:
+#include "tests/cxx/macro_location_tpl-d2.h"  // for ExpansionTemplate, expansion_template
+#include "tests/cxx/macro_location_tpl-i1.h"  // for CLASS_TEMPLATE_SPEC_EXPANSION, CLASS_TEMPLATE_SPEC_SPELLING, FUNC_TEMPLATE_SPEC_EXPANSION, FUNC_TEMPLATE_SPEC_SPELLING
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
We already have a rule that if a decl is used entirely inside a macro, and it's
forward-declared in the macro file, the use is attributed to the expansion
location. This, however, did not cover template specializations, as described in
issue 847.

So now we treat a primary function template declaration in the macro file as a
regular forward-declaration, which means that function template specializations
used in macros will be attributed to the expansion location iff the primary
template has a declaration in the macro file.