### PR TITLE
Support class template argument deduction

### DIFF
--- a/tests/cxx/ctad-d1.h
+++ b/tests/cxx/ctad-d1.h
@@ -1,0 +1,10 @@
+//===--- ctad-d1.h - test input file for iwyu -----------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/ctad-i1.h"

--- a/tests/cxx/ctad-i1.h
+++ b/tests/cxx/ctad-i1.h
@@ -1,0 +1,20 @@
+//===--- ctad-i1.h - test input file for iwyu -----------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+template <class Func>
+struct Deduced {
+  Deduced(Func&& deferred) : deferred(deferred) {
+  }
+
+  ~Deduced() {
+    deferred();
+  }
+
+  Func deferred;
+};

--- a/tests/cxx/ctad.cc
+++ b/tests/cxx/ctad.cc
@@ -1,0 +1,33 @@
+//===--- ctad.cc - test input file for iwyu -------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_ARGS: -I . -std=c++17
+
+// Test that C++17 CTAD (Class Template Argument Deduction) is recognized as
+// pointing back to a template, even if it's not explicitly specialized.
+
+#include "tests/cxx/ctad-d1.h"
+
+void f() {
+  // IWYU: Deduced is...*ctad-i1.h
+  Deduced d([] {});
+}
+
+/**** IWYU_SUMMARY
+
+tests/cxx/ctad.cc should add these lines:
+#include "tests/cxx/ctad-i1.h"
+
+tests/cxx/ctad.cc should remove these lines:
+- #include "tests/cxx/ctad-d1.h"  // lines XX-XX
+
+The full include-list for tests/cxx/ctad.cc:
+#include "tests/cxx/ctad-i1.h"  // for Deduced
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
CTAD is a C++17 feature that allows template arguments to be deduced from
constructor expressions. For example:

    A a(10, 20);

is shorthand for:

    A<int, int> a(10, 20);

This should fix issue #826.