### PR TITLE
Use `[[noreturn]]` instead of `LLVM_ATTRIBUTE_NORETURN`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,10 @@ jobs:
           sudo apt install -y libclang$LLVM_TAG-dev
           sudo apt install -y clang$LLVM_TAG
 
+      - name: Broken packaging workaround
+        run: |
+          sudo touch /usr/lib/llvm-14/lib/libclang-14.so.14.0.0
+
       - name: Check out default branch
         uses: actions/checkout@v2
 

--- a/iwyu_port.h
+++ b/iwyu_port.h
@@ -26,7 +26,7 @@ class FatalMessageEmitter {
   FatalMessageEmitter(const char* file, int line, const char* message) {
     stream() << file << ":" << line << ": Assertion failed: " << message;
   }
-  LLVM_ATTRIBUTE_NORETURN ~FatalMessageEmitter() {
+  [[noreturn]] ~FatalMessageEmitter() {
     stream() << "\n";
     ::abort();
 #ifdef LLVM_BUILTIN_UNREACHABLE


### PR DESCRIPTION
A recent change to LLVM removed `LLVM_ATTRIBUTE_NORETURN` in favor of plain C++11
`[[noreturn]]`. Since we require C++14 to build these days, just assume that
the `[[noreturn]]` attribute is available.