### PR TITLE
C++11 type aliases should be treated similar to typedefs

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -3943,9 +3943,6 @@ class IwyuAstConsumer
   // (that way we'll correctly identify need for hash<> in hash_set).
   // This is a Traverse*() because Visit*() can't call HandleFunctionCall().
   bool TraverseTypedefDecl(clang::TypedefDecl* decl) {
-    // Before we go up the tree, make sure the parents know we don't
-    // forward-declare the underlying type of a typedef decl.
-    current_ast_node()->set_in_forward_declare_context(false);
     if (!Base::TraverseTypedefDecl(decl))
       return false;
     if (CanIgnoreCurrentASTNode())  return true;

--- a/tests/cxx/iwyu_stricter_than_cpp-type_alias.h
+++ b/tests/cxx/iwyu_stricter_than_cpp-type_alias.h
@@ -1,0 +1,76 @@
+//===--- iwyu_stricter_than_cpp-type_alias.h - test input file for iwyu ---===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// The two rules the author has to follow to disable iwyu's
+// stricter-than-C++ rule and force it to fall back on the c++
+// requirement (forward-declare ok):
+// (1) forward-declare the relevant type
+// (2) do not directly #include the definition of the relevant type.
+
+#include "tests/cxx/iwyu_stricter_than_cpp-d1.h"
+
+// --- Type aliases.
+
+// Requires the full type because it does not obey rule (1)
+// IWYU: IndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h
+using DoesNotForwardDeclareAl = IndirectStruct1;
+
+// This also does not obey rule (1): it's -d1 that does the fwd-declaring.
+// IWYU: IndirectStructForwardDeclaredInD1 is...*iwyu_stricter_than_cpp-i1.h
+using DoesNotForwardDeclareProperlyAl = IndirectStructForwardDeclaredInD1;
+
+// Requires the full type because it does not obey rule (2)
+struct DirectStruct1;
+using IncludesAl = DirectStruct1;
+
+// Requires the full type because it does not obey rules (1) *or* (2)
+using DoesNotForwardDeclareAndIncludesAl = DirectStruct2;
+
+// Does not require full type because it obeys all the rules.
+struct IndirectStruct2;
+using DoesEverythingRightAl = IndirectStruct2;
+
+// --- Now do it all again, with templates!
+
+// IWYU: TplIndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h
+using TplDoesNotForwardDeclareAl = TplIndirectStruct1<int>;
+
+using TplDoesNotForwardDeclareProperlyAl
+// IWYU: TplIndirectStructForwardDeclaredInD1 is...*iwyu_stricter_than_cpp-i1.h
+    = TplIndirectStructForwardDeclaredInD1<int>;
+
+template <typename T> struct TplDirectStruct1;
+using TplIncludesAl = TplDirectStruct1<int>;
+
+using TplDoesNotForwardDeclareAndIncludesAl = TplDirectStruct2<int>;
+
+template <typename T> struct TplIndirectStruct2;
+using TplDoesEverythingRightAl = TplIndirectStruct2<int>;
+
+// Another way to forward-declare a class template.
+template <> struct TplIndirectStruct2<float>;
+using TplDoesEverythingRightAgainAl = TplIndirectStruct2<float>;
+
+
+/**** IWYU_SUMMARY
+
+tests/cxx/iwyu_stricter_than_cpp-type_alias.h should add these lines:
+#include "tests/cxx/iwyu_stricter_than_cpp-i1.h"
+
+tests/cxx/iwyu_stricter_than_cpp-type_alias.h should remove these lines:
+- struct DirectStruct1;  // lines XX-XX
+- template <typename T> struct TplDirectStruct1;  // lines XX-XX
+
+The full include-list for tests/cxx/iwyu_stricter_than_cpp-type_alias.h:
+#include "tests/cxx/iwyu_stricter_than_cpp-d1.h"  // for DirectStruct1, DirectStruct2, TplDirectStruct1, TplDirectStruct2
+#include "tests/cxx/iwyu_stricter_than_cpp-i1.h"  // for IndirectStruct1, IndirectStructForwardDeclaredInD1, TplIndirectStruct1, TplIndirectStructForwardDeclaredInD1
+struct IndirectStruct2;  // lines XX-XX
+template <typename T> struct TplIndirectStruct2;  // lines XX-XX
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/iwyu_stricter_than_cpp.cc
+++ b/tests/cxx/iwyu_stricter_than_cpp.cc
@@ -10,6 +10,7 @@
 // IWYU_ARGS: -Xiwyu --check_also="tests/cxx/*-autocast.h" \
 //            -Xiwyu --check_also="tests/cxx/*-fnreturn.h" \
 //            -Xiwyu --check_also="tests/cxx/*-typedefs.h" \
+//            -Xiwyu --check_also="tests/cxx/*-type_alias.h" \
 //            -Xiwyu --check_also="tests/cxx/*-d2.h" \
 //            -I .
 
@@ -36,6 +37,7 @@
 // when these two conditions are met, and not otherwise.
 
 #include "tests/cxx/iwyu_stricter_than_cpp-typedefs.h"
+#include "tests/cxx/iwyu_stricter_than_cpp-type_alias.h"
 #include "tests/cxx/iwyu_stricter_than_cpp-autocast.h"
 #include "tests/cxx/iwyu_stricter_than_cpp-fnreturn.h"
 // We include this so the second declaration of TwiceDeclaredFunction
@@ -79,6 +81,39 @@ void TestTypedefs() {
 
   // TODO(csilvers): test template types where we need some (but not
   // all) of the template args as well.
+}
+
+using DoubleTypedefAl = DoesEverythingRightAl;
+
+void TestTypeAliases() {
+  DoesNotForwardDeclareAl dnfd(1);
+  DoesNotForwardDeclareProperlyAl dnfdp(2);
+  IncludesAl i(3);
+  DoesNotForwardDeclareAndIncludesAl dnfdai(4);
+  // IWYU: IndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
+  DoesEverythingRightAl dor(5);
+  // Because DoubleTypedefAl resolves to DoesEverythingRightAl, we need the
+  // same things DoesEverythingRightAl does.
+  // IWYU: IndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
+  DoubleTypedefAl dt(6);
+
+  // ...and with templates.
+  TplDoesNotForwardDeclareAl tdnfd(7);
+  TplDoesNotForwardDeclareProperlyAl tdnfdp(8);
+  TplIncludesAl ti(9);
+  TplDoesNotForwardDeclareAndIncludesAl tdnfdai(10);
+  // IWYU: TplIndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
+  TplDoesEverythingRightAl tdor(11);
+  // IWYU: TplIndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
+  TplDoesEverythingRightAgainAl tdora(12);
+
+  // But if we're in a forward-declare context, we don't require the
+  // underlying type!
+  DoesEverythingRightAl* dor_ptr = 0;
+  TplDoesEverythingRightAgainAl* tdora_ptr = 0;
+  // ...at least until we dereference the pointer
+  // IWYU: IndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
+  (void) dor_ptr->a;
 }
 
 void TestAutocast() {
@@ -159,6 +194,7 @@ The full include-list for tests/cxx/iwyu_stricter_than_cpp.cc:
 #include "tests/cxx/iwyu_stricter_than_cpp-autocast.h"  // for Fn, TplFn
 #include "tests/cxx/iwyu_stricter_than_cpp-fnreturn.h"  // for DoesEverythingRightFn, DoesNotForwardDeclareAndIncludesFn, DoesNotForwardDeclareFn, DoesNotForwardDeclareProperlyFn, IncludesFn, TplDoesEverythingRightAgainFn, TplDoesEverythingRightFn, TplDoesNotForwardDeclareAndIncludesFn, TplDoesNotForwardDeclareFn, TplDoesNotForwardDeclareProperlyFn, TplIncludesFn
 #include "tests/cxx/iwyu_stricter_than_cpp-i2.h"  // for IndirectStruct2, TplIndirectStruct2
+#include "tests/cxx/iwyu_stricter_than_cpp-type_alias.h"  // for DoesEverythingRightAl, DoesNotForwardDeclareAl, DoesNotForwardDeclareAndIncludesAl, DoesNotForwardDeclareProperlyAl, IncludesAl, TplDoesEverythingRightAgainAl, TplDoesEverythingRightAl, TplDoesNotForwardDeclareAl, TplDoesNotForwardDeclareAndIncludesAl, TplDoesNotForwardDeclareProperlyAl, TplIncludesAl
 #include "tests/cxx/iwyu_stricter_than_cpp-typedefs.h"  // for DoesEverythingRight, DoesNotForwardDeclare, DoesNotForwardDeclareAndIncludes, DoesNotForwardDeclareProperly, Includes, TplDoesEverythingRight, TplDoesEverythingRightAgain, TplDoesNotForwardDeclare, TplDoesNotForwardDeclareAndIncludes, TplDoesNotForwardDeclareProperly, TplIncludes
 struct DirectStruct1;
 struct DirectStruct2;


### PR DESCRIPTION
Seemingly useless line of code removed by the way.