### PR TITLE
Don't force aliased type method callability

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -3944,7 +3944,10 @@ class IwyuAstConsumer
   // This is called from Traverse*() because Visit*()
   // can't call HandleFunctionCall().
   bool HandleAliasedClassMethods(TypedefNameDecl* decl) {
-    if (CanIgnoreCurrentASTNode())  return true;
+    if (CanIgnoreCurrentASTNode())
+      return true;
+    if (current_ast_node()->in_forward_declare_context())
+      return true;
 
     const Type* underlying_type = decl->getUnderlyingType().getTypePtr();
     const Decl* underlying_decl = TypeToDeclAsWritten(underlying_type);

--- a/tests/cxx/no_forced_alias_callability-d1.h
+++ b/tests/cxx/no_forced_alias_callability-d1.h
@@ -1,0 +1,14 @@
+//===--- no_forced_alias_callability-d1.h - test input file for iwyu ------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+struct ReturnType;
+
+struct Aliased {
+  ReturnType doSomething();
+};

--- a/tests/cxx/no_forced_alias_callability-d2.h
+++ b/tests/cxx/no_forced_alias_callability-d2.h
@@ -1,0 +1,18 @@
+//===--- no_forced_alias_callability-d2.h - test input file for iwyu ------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+struct Aliased;
+
+typedef Aliased Alias;
+
+/**** IWYU_SUMMARY
+
+(tests/cxx/no_forced_alias_callability-d2.h has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/no_forced_alias_callability.cc
+++ b/tests/cxx/no_forced_alias_callability.cc
@@ -1,0 +1,29 @@
+//===--- no_forced_alias_callability.cc - test input file for iwyu --------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_ARGS: -Xiwyu --check_also="tests/cxx/no_forced_alias_callability-d2.h" \
+//            -I .
+
+// Tests that IWYU doesn't require inclusion of an aliased class header
+// (...-d1.h) into a header with the alias to provide callability of methods
+// of the aliased class if the aliased class is explicitly made forward declared
+// in accordance with the IWYU policy
+
+#include "tests/cxx/no_forced_alias_callability-d1.h"
+#include "tests/cxx/no_forced_alias_callability-d2.h"
+
+int main() {
+  Alias a;
+}
+
+/**** IWYU_SUMMARY
+
+(tests/cxx/no_forced_alias_callability.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
Don't require aliased type method callability if explicitly forward declared
according to the IWYU forward declaration policy.