### PR TITLE
Add --update_comments option

### DIFF
--- a/fix_includes.py
+++ b/fix_includes.py
@@ -2309,11 +2309,12 @@ def ProcessIWYUOutput(f, files_to_process, flags, cwd):
   # seen for them.  (We have to wait until we're all done, since a .h
   # file may have a contentful change when #included from one .cc
   # file, but not another, and we need to have merged them above.)
-  for filename in iwyu_output_records:
-    if not iwyu_output_records[filename].HasContentfulChanges():
-      print('(skipping %s: iwyu reports no contentful changes)' % filename)
-      # Mark that we're skipping this file by setting the record to None
-      iwyu_output_records[filename] = None
+  if not flags.update_comments:
+    for filename in iwyu_output_records:
+      if not iwyu_output_records[filename].HasContentfulChanges():
+        print('(skipping %s: iwyu reports no contentful changes)' % filename)
+        # Mark that we're skipping this file by setting the record to None
+        iwyu_output_records[filename] = None
 
   # Now do all the fixing, and return the number of files modified
   contentful_records = [ior for ior in iwyu_output_records.values() if ior]
@@ -2372,6 +2373,12 @@ def main(argv):
   parser.add_option('--comments', action='store_true', default=False,
                     help='Put comments after the #include lines')
   parser.add_option('--nocomments', action='store_false', dest='comments')
+
+  parser.add_option('--update_comments', action='store_true', default=False,
+                    help=('Update #include comments, even if no #include lines'
+                          ' are added or removed'))
+  parser.add_option('--noupdate_comments', action='store_false',
+                    dest='update_comments')
 
   parser.add_option('--safe_headers', action='store_true', default=True,
                     help=('Do not remove unused #includes/fwd-declares from'
@@ -2439,6 +2446,9 @@ def main(argv):
       not flags.separate_project_includes.endswith(os.path.sep) and
       not flags.separate_project_includes.endswith('/')):
     flags.separate_project_includes += os.path.sep
+
+  if flags.update_comments:
+    flags.comments = True
 
   if flags.sort_only:
     if not files_to_modify:

--- a/iwyu_globals.cc
+++ b/iwyu_globals.cc
@@ -91,6 +91,8 @@ static void PrintHelp(const char* extra_msg) {
          "        the maximum line length can still be exceeded with long\n"
          "        file names (default: 80).\n"
          "   --no_comments: do not add 'why' comments.\n"
+         "   --update_comments: always add 'why' comments, even if no\n"
+         "        #include lines need to be added or removed.\n"
          "   --no_fwd_decls: do not use forward declarations.\n"
          "   --verbose=<level>: the higher the level, the more output.\n"
          "   --quoted_includes_first: when sorting includes, place quoted\n"
@@ -163,6 +165,7 @@ CommandlineFlags::CommandlineFlags()
       prefix_header_include_policy(CommandlineFlags::kAdd),
       pch_in_code(false),
       no_comments(false),
+      update_comments(false),
       no_fwd_decls(false),
       quoted_includes_first(false),
       cxx17ns(false) {
@@ -182,6 +185,7 @@ int CommandlineFlags::ParseArgv(int argc, char** argv) {
     {"pch_in_code", no_argument, nullptr, 'h'},
     {"max_line_length", required_argument, nullptr, 'l'},
     {"no_comments", no_argument, nullptr, 'o'},
+    {"update_comments", no_argument, nullptr, 'u'},
     {"no_fwd_decls", no_argument, nullptr, 'f'},
     {"quoted_includes_first", no_argument, nullptr, 'q' },
     {"cxx17ns", no_argument, nullptr, 'C'},
@@ -197,6 +201,7 @@ int CommandlineFlags::ParseArgv(int argc, char** argv) {
       case 'm': mapping_files.push_back(optarg); break;
       case 'n': no_default_mappings = true; break;
       case 'o': no_comments = true; break;
+      case 'u': update_comments = true; break;
       case 'f': no_fwd_decls = true; break;
       case 'x':
         if (strcmp(optarg, "add") == 0) {

--- a/iwyu_globals.h
+++ b/iwyu_globals.h
@@ -98,6 +98,7 @@ struct CommandlineFlags {
   PrefixHeaderIncludePolicy prefix_header_include_policy;
   bool pch_in_code;   // Treat the first seen include as a PCH. No short option.
   bool no_comments;   // Disable 'why' comments. No short option.
+  bool update_comments; // Force 'why' comments. No short option.
   bool no_fwd_decls;  // Disable forward declarations.
   bool quoted_includes_first; // Place quoted includes first in sort order.
   bool cxx17ns; // -C: C++17 nested namespace syntax

--- a/iwyu_output.cc
+++ b/iwyu_output.cc
@@ -1987,7 +1987,7 @@ size_t PrintableDiffs(const string& filename,
       break;
     }
   }
-  if (no_adds_or_deletes) {
+  if (no_adds_or_deletes && !GlobalFlags().update_comments) {
     output = "\n(" + filename + " has correct #includes/fwd-decls)\n";
     return 0;
   }

--- a/tests/cxx/update_comments.cc
+++ b/tests/cxx/update_comments.cc
@@ -1,0 +1,28 @@
+//===--- update_comments.cc - test input file for iwyu --------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_ARGS: -Xiwyu --update_comments -I .
+
+// Test that passing the --update_comments switch to IWYU makes it always print
+// the full include-list, with up to date "// for XYZ" comments.
+
+#include "tests/cxx/indirect.h"  // for SomethingElse
+
+IndirectClass indirect;
+
+/**** IWYU_SUMMARY
+
+tests/cxx/update_comments.cc should add these lines:
+
+tests/cxx/update_comments.cc should remove these lines:
+
+The full include-list for tests/cxx/update_comments.cc:
+#include "tests/cxx/indirect.h"  // for IndirectClass
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
…clude comments, regardless of whether any include lines need to be added or removed.

Fixes #75 and fixes #494.

With this change, IWYU will update the "// for xyz" comments as the code changes, preventing the comments from becoming stale.