### PR TITLE
Revert "Add workaround for broken packaging"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,10 +33,6 @@ jobs:
           sudo apt install -y libclang$LLVM_TAG-dev
           sudo apt install -y clang$LLVM_TAG
 
-      - name: Broken packaging workaround
-        run: |
-          sudo touch /usr/lib/llvm-14/lib/libclang-14.so.14.0.0
-
       - name: Check out default branch
         uses: actions/checkout@v2
 


### PR DESCRIPTION
This reverts commit 2d9c0c733d38c531d6c5426bbe35ed40a468d9ca.

libclang-14.so.14.0.0 seems to be available as of late September.