### PR TITLE
Undefine CALLBACK after including Shlwapi.h

### DIFF
--- a/iwyu_port.h
+++ b/iwyu_port.h
@@ -66,10 +66,12 @@ class OstreamVoidifier {
 #define NOMINMAX 1 // Prevent Windows headers from redefining min/max.
 #include "Shlwapi.h"  // for PathMatchSpecA
 
-// This undef is necessary to prevent conflicts between llvm
+// These undefs are necessary to prevent conflicts between llvm
 // and Windows headers.
 // objbase.h has #define interface struct.
 #undef interface
+// minwindef.h has #define CALLBACK __stdcall
+#undef CALLBACK  
 
 inline bool GlobMatchesPath(const char *glob, const char *path) {
   return PathMatchSpecA(path, glob);


### PR DESCRIPTION
clang/Analysis/CFG.h uses CALLBACK as a template parameter to the
function VisitBlockStmts. Since this is defined as a calling convention
in minwindef.h, we end up with an error similar to the following:

CFG.h(1380): error C2988: unrecognizable template declaration/definition

The fix is a continuation of the existing workaround to just undefine
the offending macro since it's not needed in our code anyway.