### PR TITLE
Add <bits/struct_stat.h> include mapping for glibc 2.33

### DIFF
--- a/gcc.libc.imp
+++ b/gcc.libc.imp
@@ -75,6 +75,7 @@
   { include: [ "<bits/socket_type.h>", private, "<sys/socket.h>", public ] },
   { include: [ "<bits/stab.def>", private, "<stab.h>", public ] },
   { include: [ "<bits/stat.h>", private, "<sys/stat.h>", public ] },
+  { include: [ "<bits/struct_stat.h>", private, "<sys/stat.h>", public ] },
   { include: [ "<bits/statfs.h>", private, "<sys/statfs.h>", public ] },
   { include: [ "<bits/statvfs.h>", private, "<sys/statvfs.h>", public ] },
   { include: [ "<bits/stdio-ldbl.h>", private, "<stdio.h>", public ] },

--- a/iwyu_include_picker.cc
+++ b/iwyu_include_picker.cc
@@ -437,6 +437,7 @@ const IncludeMapEntry libc_include_map[] = {
   { "<bits/socket_type.h>", kPrivate, "<sys/socket.h>", kPublic },
   { "<bits/stab.def>", kPrivate, "<stab.h>", kPublic },
   { "<bits/stat.h>", kPrivate, "<sys/stat.h>", kPublic },
+  { "<bits/struct_stat.h>", kPrivate, "<sys/stat.h>", kPublic },
   { "<bits/statfs.h>", kPrivate, "<sys/statfs.h>", kPublic },
   { "<bits/statvfs.h>", kPrivate, "<sys/statvfs.h>", kPublic },
   { "<bits/stdio-ldbl.h>", kPrivate, "<stdio.h>", kPublic },


### PR DESCRIPTION
glibc commit [d8927238307b](https://sourceware.org/git/?p=glibc.git;a=commit;h=d8927238307b9df32319a34755ac36f6e92a0b7d) ("linux: Move the struct stat{64} to
struct_stat.h") moved the definition of struct stat from <bits/stat.h>
to <bits/struct_stat.h>. This results in the following IWYU warning:

```
  $ cat test.c
  #include <sys/stat.h>

  struct stat x;
  $ include-what-you-use test.c

  test.c should add these lines:
  #include <bits/struct_stat.h>  // for stat

  test.c should remove these lines:
  - #include <sys/stat.h>  // lines 1-1

  The full include-list for test.c:
  #include <bits/struct_stat.h>  // for stat
  ---
```

Fix it by adding an include mapping.