### PR TITLE
[ci] Fix YAML syntax

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,9 @@
 name: IWYU CI
 
 on:
-  - push
-  - pull_request
-  - schedule:
+  push:
+  pull_request:
+  schedule:
     # Run build of master at 03:38 every day
     - cron: '38 3 * * *'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,7 @@ jobs:
 
       - name: Work around broken packaging
         run: |
-          sudo touch /usr/lib/llvm-14/lib/libclang-14.so.14.0.0
-          sudo touch /usr/lib/llvm-14/bin/llvm-omp-device-info
+          sudo touch /usr/lib/llvm-14/lib/libMLIRSupportIndentedOstream.a
 
       - name: Check out default branch
         uses: actions/checkout@v2


### PR DESCRIPTION
In the previous commit, I merged overlooking the fact that it didn't work.

Apparently push and pull_request can be combined with schedule if they're all
dict forms; the former two can have empty values.