### PR TITLE
Handle new UsingType

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -4043,6 +4043,20 @@ class IwyuAstConsumer
     return Base::VisitTypedefType(type);
   }
 
+  bool VisitUsingType(clang::UsingType* type) {
+    if (CanIgnoreCurrentASTNode())
+      return true;
+
+    // UsingType is similar to TypedefType, so treat it the same.
+    if (CanForwardDeclareType(current_ast_node())) {
+      ReportDeclForwardDeclareUse(CurrentLoc(), type->getFoundDecl());
+    } else {
+      ReportDeclUse(CurrentLoc(), type->getFoundDecl());
+    }
+
+    return Base::VisitUsingType(type);
+  }
+
   // This is a superclass of RecordType and CXXRecordType.
   bool VisitTagType(clang::TagType* type) {
     if (CanIgnoreCurrentASTNode())  return true;


### PR DESCRIPTION
Clang added a new AST node in
https://github.com/llvm/llvm-project/commit/e1600db19d6303f84b995acb93, which
shows up in the AST instead of a desugared type.

The presence of a using declaration would be omitted in the AST in favor of the
target type.

Outside of the test suite, we noticed this for <cstdint>, where the integer
types would show up as TypedefTypes in the AST, despite being pulled in via
using-declarations. They now show as UsingTypes. UsingType represents a new
so-called sugar type introduced by way of a using declaration, and links to its
UsingShadowDecl, which in turn makes it possible to chase through the
using-chain.

Report a use of the UsingShadowDecl, which is resolved centrally to the
underlying target decl (desugared typedef) as well as reporting the using-decl
itself. This is consistent with the prior behavior, but should provide better
results for tracking using declarations.

Fixes issue #990