### PR TITLE
[cmake] Include headers correctly for in-tree builds.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,14 +33,21 @@ option(IWYU_LINK_CLANG_DYLIB "Link against the clang dynamic library" ${CLANG_LI
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 add_definitions(${LLVM_DEFINITIONS})
-include_directories(
-  ${LLVM_INCLUDE_DIRS}
-  ${CLANG_INCLUDE_DIRS}
-  )
 
-# Synthesize a clang-resource-headers target for out-of-tree builds (in-tree
-# already has it available by default)
-if (NOT IWYU_IN_TREE)
+if (IWYU_IN_TREE)
+  include_directories(
+    ${LLVM_SOURCE_DIR}/include
+    ${LLVM_EXTERNAL_CLANG_SOURCE_DIR}/include
+    ${LLVM_BINARY_DIR}/include
+    ${LLVM_BINARY_DIR}/tools/clang/include
+    )
+else()
+  include_directories(
+    ${LLVM_INCLUDE_DIRS}
+    ${CLANG_INCLUDE_DIRS}
+    )
+  # Synthesize a clang-resource-headers target for out-of-tree builds (in-tree
+  # already has it available by default)
   # Use only major.minor.patch for the resource directory structure; some
   # platforms include suffix in LLVM_VERSION.
   set(llvm_ver ${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR}.${LLVM_VERSION_PATCH})

--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ To set up an environment for building:
 
       iwyu/build$ cmake -G "Unix Makefiles" -DCMAKE_PREFIX_PATH=~/llvm-project/build ../include-what-you-use
 
+ or, If you have LLVM source code and want to compile IWYU while compiling with other LLVM and CLang components, you can integrate IWYW by defining `LLVM_EXTERNAL_PROJECTS`.
+
+      iwyu/build$ cmake -G "Unix Makefiles" -DLLVM_ENABLE_PROJECTS=clang -DLLVM_EXTERNAL_PROJECTS=iwyu -DLLVM_EXTERNAL_IWYU_SOURCE_DIR=/path/to/iwyu /path/to/llvm-project/llvm
+
 * Once CMake has generated a build system, you can invoke it directly from `build`, e.g.
 
       iwyu/build$ make


### PR DESCRIPTION
When trying to build in-tree, I found that neither
`LLVM_INCLUDE_DIRS` nor `CLANG_INCLUDE_DIRS` were not defined.
Fix it by manually including the correct headers.

Also,  add a guide for building IWYU with LLVM source code.