### PR TITLE
Avoid author-intent analysis on implicit decls

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -1345,6 +1345,15 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
     if (decl == nullptr)   // only class-types are candidates for returning true
       return false;
 
+    // Sometimes a type points back to an implicit decl (e.g. a bultin type),
+    // and we can't do author-intent analysis without location information.
+    // Assume that it's not forward-declarable.
+    if (decl->isImplicit()) {
+      VERRS(5) << "Skipping forward-declare analysis for implicit decl: '"
+               << PrintableDecl(decl) << "'\n";
+      return false;
+    }
+
     // If we're a template specialization, we also accept
     // forward-declarations of the underlying template (vector<T>, not
     // vector<int>).


### PR DESCRIPTION
CodeAuthorWantsJustAForwardDeclare uses location information to see whether the
there's a forward-declare hint earlier in the same file.

Implicit decls do not have locations, so assume the author (actually the
compiler itself) does not intend to provide hints to IWYU.

I've found no way to test this in a self-contained example. It was originally
reported in issue #1005 as an assertion triggered by the AArch64 target's
implementation of va_list:

  $ cat /tmp/test.c
  #include <stdarg.h>

  void test(void) {
      va_list args;
  }

  $ include-what-you-use --target=aarch64-linux-gnu -c /tmp/test.c
  include-what-you-use: ...SourceLocation.h:433: ...
     Assertion `Loc.isValid()' failed.
  Aborted (core dumped)

Since I don't want the test suite to depend on environment (in this case,
particular targets being available), I'll leave it untested.