### PR TITLE
Don't crash on consteval conversion functions

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -1910,7 +1910,7 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
     // If this cast requires a user-defined conversion of the from-type, look up
     // its return type so we can see through up/down-casts via such conversions.
     const Type* converted_from_type = nullptr;
-    if (const NamedDecl* conv_decl = expr->getConversionFunction()) {
+    if (const NamedDecl* conv_decl = GetConversionFunction(expr)) {
       converted_from_type =
           cast<FunctionDecl>(conv_decl)->getReturnType().getTypePtr();
     }

--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -32,6 +32,7 @@
 #include "clang/AST/DeclCXX.h"
 #include "clang/AST/DeclTemplate.h"
 #include "clang/AST/ExprCXX.h"
+#include "clang/AST/IgnoreExpr.h"
 #include "clang/AST/NestedNameSpecifier.h"
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/AST/Stmt.h"
@@ -49,11 +50,14 @@ class FileEntry;
 
 using clang::ASTDumper;
 using clang::BlockPointerType;
+using clang::CastExpr;
+using clang::CXXBindTemporaryExpr;
 using clang::CXXConstructExpr;
 using clang::CXXConstructorDecl;
 using clang::CXXDeleteExpr;
 using clang::CXXDependentScopeMemberExpr;
 using clang::CXXDestructorDecl;
+using clang::CXXMemberCallExpr;
 using clang::CXXMethodDecl;
 using clang::CXXNewExpr;
 using clang::CXXRecordDecl;
@@ -74,12 +78,15 @@ using clang::EnumDecl;
 using clang::Expr;
 using clang::ExprWithCleanups;
 using clang::FileEntry;
+using clang::FullExpr;
 using clang::FullSourceLoc;
 using clang::FunctionDecl;
 using clang::FunctionType;
 using clang::ImplicitCastExpr;
+using clang::IgnoreExprNodes;
 using clang::InjectedClassNameType;
 using clang::LValueReferenceType;
+using clang::MaterializeTemporaryExpr;
 using clang::MemberExpr;
 using clang::MemberPointerType;
 using clang::NamedDecl;
@@ -1473,6 +1480,38 @@ TemplateArgumentListInfo GetExplicitTplArgs(const Expr* expr) {
   else if (const DependentScopeDeclRefExpr* dependent_decl_ref = DynCastFrom(expr))
     dependent_decl_ref->copyTemplateArgumentsInto(explicit_tpl_args);
   return explicit_tpl_args;
+}
+
+// This is lifted from CastExpr::getConversionFunction, and naively simplified
+// to work around bugs with consteval conversion functions.
+const NamedDecl* GetConversionFunction(const CastExpr* expr) {
+  const Expr *subexpr = nullptr;
+  for (const CastExpr *e = expr; e; e = dyn_cast<ImplicitCastExpr>(subexpr)) {
+    // Skip through implicit sema nodes.
+    subexpr = IgnoreExprNodes(e->getSubExpr(), [](Expr* expr) {
+      // FullExpr is ConstantExpr + ExprWithCleanups.
+      if (auto* fe = dyn_cast<FullExpr>(expr))
+        return fe->getSubExpr();
+
+      if (auto* mte = dyn_cast<MaterializeTemporaryExpr>(expr))
+        return mte->getSubExpr();
+
+      if (auto* bte = dyn_cast<CXXBindTemporaryExpr>(expr))
+        return bte->getSubExpr();
+
+      return expr;
+    });
+
+    // Now resolve the conversion function depending on cast kind.
+    if (e->getCastKind() == clang::CK_ConstructorConversion)
+      return cast<CXXConstructExpr>(subexpr)->getConstructor();
+
+    if (e->getCastKind() == clang::CK_UserDefinedConversion) {
+      if (auto *MCE = dyn_cast<CXXMemberCallExpr>(subexpr))
+        return MCE->getMethodDecl();
+    }
+  }
+  return nullptr;
 }
 
 }  // namespace include_what_you_use

--- a/iwyu_ast_util.h
+++ b/iwyu_ast_util.h
@@ -816,6 +816,10 @@ const clang::FunctionType* GetCalleeFunctionType(clang::CallExpr* expr);
 // such a concept (declrefexpr, memberexpr), and empty list if none is present.
 clang::TemplateArgumentListInfo GetExplicitTplArgs(const clang::Expr* expr);
 
+// Workaround for https://github.com/llvm/llvm-project/issues/53044. Remove this
+// wrapper in favor of Expr::getConversionFunction  when that is fixed upstream.
+const clang::NamedDecl* GetConversionFunction(const clang::CastExpr* expr);
+
 }  // namespace include_what_you_use
 
 #endif  // INCLUDE_WHAT_YOU_USE_IWYU_AST_UTIL_H_

--- a/tests/cxx/consteval.cc
+++ b/tests/cxx/consteval.cc
@@ -1,0 +1,51 @@
+//===--- consteval.cc - test input file for iwyu --------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_ARGS: -I . -std=c++20
+
+// These tests are not particularly interesting in themselves, but they cover an
+// upstream bug in Clang (https://github.com/llvm/llvm-project/issues/53044) for
+// which we have a workaround.
+
+#include "tests/cxx/direct.h"
+
+struct X {
+  // IWYU: IndirectClass needs a declaration
+  consteval X(const IndirectClass& v) {
+  }
+
+  // IWYU: IndirectClass needs a declaration
+  consteval operator IndirectClass*() const {
+    return nullptr;
+  }
+};
+
+void t() {
+  // Pass value through Consteval conversion constructor.
+  // IWYU: IndirectClass is...*indirect.h
+  IndirectClass a;
+  X x = a;
+
+  // Try an implicit consteval user-defined conversion too.
+  // IWYU: IndirectClass needs a declaration
+  IndirectClass* b = x;
+}
+
+/**** IWYU_SUMMARY
+
+tests/cxx/consteval.cc should add these lines:
+#include "tests/cxx/indirect.h"
+
+tests/cxx/consteval.cc should remove these lines:
+- #include "tests/cxx/direct.h"  // lines XX-XX
+
+The full include-list for tests/cxx/consteval.cc:
+#include "tests/cxx/indirect.h"  // for IndirectClass
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
This fixes #951 by working around the upstream bug.

I would normally prefer to fix this at the source, but IWYU 0.18 will need to be released soon and I don't want to ship with this crasher. Hopefully we can revert soon.