### PR TITLE
Add --regex=dialect option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,7 @@ add_llvm_executable(include-what-you-use
   iwyu_output.cc
   iwyu_path_util.cc
   iwyu_preprocessor.cc
+  iwyu_regex.cc
   iwyu_verrs.cc
 )
 

--- a/include-what-you-use.1
+++ b/include-what-you-use.1
@@ -134,6 +134,20 @@ No new includes are added, existing ones are removed.
 .B \-\-quoted_includes_first
 When sorting includes, place quoted includes first.
 .TP
+.BI \-\-regex= dialect
+Use the specified regex
+.IR dialect
+for matching in IWYU:
+.RS
+.TP
+.B llvm
+Fast and simple extended regular expressions. This is the default.
+.TP
+.B ecmascript
+Slower but more full-featured regular expressions with support for lookaround
+assertions, etc.
+.RE
+.TP
 .B \-\-transitive_includes_only
 Do not suggest that a file should add
 .IR foo.h " unless " foo.h

--- a/iwyu_globals.h
+++ b/iwyu_globals.h
@@ -28,6 +28,7 @@ using std::set;
 using std::string;
 using std::vector;
 
+enum class RegexDialect;
 class FullUseCache;
 class IncludePicker;
 class SourceManagerCharacterDataGetter;
@@ -98,6 +99,7 @@ struct CommandlineFlags {
   int exit_code_error;   // Exit with this code for iwyu violations.
   int exit_code_always;  // Always exit with this exit code.
   set<string> dbg_flags; // Debug flags.
+  RegexDialect regex_dialect;  // Dialect for regular expression processing.
 };
 
 const CommandlineFlags& GlobalFlags();

--- a/iwyu_include_picker.cc
+++ b/iwyu_include_picker.cc
@@ -1425,8 +1425,8 @@ void IncludePicker::ExpandRegexes() {
     const string& hdr = incmap.first;
     for (const string& regex_key : filepath_include_map_regex_keys) {
       const vector<MappedInclude>& map_to = filepath_include_map_[regex_key];
-      // Enclose the regex in ^(...)$ for full match.
-      std::string regex("^(" + regex_key.substr(1) + ")$");
+      // Enclose the regex in ^...$ for full match.
+      std::string regex("^" + regex_key.substr(1) + "$");
       if (RegexMatch(regex_dialect, hdr, regex) &&
           !ContainsQuotedInclude(map_to, hdr)) {
         Extend(&filepath_include_map_[hdr], filepath_include_map_[regex_key]);
@@ -1435,7 +1435,7 @@ void IncludePicker::ExpandRegexes() {
       }
     }
     for (const string& regex_key : friend_to_headers_map_regex_keys) {
-      std::string regex("^(" + regex_key.substr(1) + ")$");
+      std::string regex("^" + regex_key.substr(1) + "$");
       if (RegexMatch(regex_dialect, hdr, regex)) {
         InsertAllInto(friend_to_headers_map_[regex_key],
                       &friend_to_headers_map_[hdr]);

--- a/iwyu_include_picker.cc
+++ b/iwyu_include_picker.cc
@@ -16,7 +16,6 @@
 // not hash_map: it's not as portable and needs hash<string>.
 #include <map>                          // for map, map<>::mapped_type, etc
 #include <memory>
-#include <regex>
 #include <string>                       // for string, basic_string, etc
 #include <system_error>                 // for error_code
 #include <utility>                      // for pair, make_pair
@@ -25,6 +24,7 @@
 #include "iwyu_location_util.h"
 #include "iwyu_path_util.h"
 #include "iwyu_port.h"
+#include "iwyu_regex.h"
 #include "iwyu_stl_util.h"
 #include "iwyu_string_util.h"
 #include "iwyu_verrs.h"
@@ -1424,17 +1424,16 @@ void IncludePicker::ExpandRegexes() {
     for (const string& regex_key : filepath_include_map_regex_keys) {
       const vector<MappedInclude>& map_to = filepath_include_map_[regex_key];
       // Enclose the regex in ^(...)$ for full match.
-      std::regex regex(std::string("^(" + regex_key.substr(1) + ")$"));
-      if (std::regex_match(hdr, regex) &&
-          !ContainsQuotedInclude(map_to, hdr)) {
+      std::string regex("^(" + regex_key.substr(1) + ")$");
+      if (RegexMatch(hdr, regex) && !ContainsQuotedInclude(map_to, hdr)) {
         Extend(&filepath_include_map_[hdr], filepath_include_map_[regex_key]);
         MarkVisibility(&include_visibility_map_, hdr,
                        include_visibility_map_[regex_key]);
       }
     }
     for (const string& regex_key : friend_to_headers_map_regex_keys) {
-      std::regex regex(std::string("^(" + regex_key.substr(1) + ")$"));
-      if (std::regex_match(hdr, regex)) {
+      std::string regex("^(" + regex_key.substr(1) + ")$");
+      if (RegexMatch(hdr, regex)) {
         InsertAllInto(friend_to_headers_map_[regex_key],
                       &friend_to_headers_map_[hdr]);
       }

--- a/iwyu_include_picker.cc
+++ b/iwyu_include_picker.cc
@@ -1425,9 +1425,7 @@ void IncludePicker::ExpandRegexes() {
     const string& hdr = incmap.first;
     for (const string& regex_key : filepath_include_map_regex_keys) {
       const vector<MappedInclude>& map_to = filepath_include_map_[regex_key];
-      // Enclose the regex in ^...$ for full match.
-      std::string regex("^" + regex_key.substr(1) + "$");
-      if (RegexMatch(regex_dialect, hdr, regex) &&
+      if (RegexMatch(regex_dialect, hdr, regex_key.substr(1)) &&
           !ContainsQuotedInclude(map_to, hdr)) {
         Extend(&filepath_include_map_[hdr], filepath_include_map_[regex_key]);
         MarkVisibility(&include_visibility_map_, hdr,
@@ -1435,8 +1433,7 @@ void IncludePicker::ExpandRegexes() {
       }
     }
     for (const string& regex_key : friend_to_headers_map_regex_keys) {
-      std::string regex("^" + regex_key.substr(1) + "$");
-      if (RegexMatch(regex_dialect, hdr, regex)) {
+      if (RegexMatch(regex_dialect, hdr, regex_key.substr(1))) {
         InsertAllInto(friend_to_headers_map_[regex_key],
                       &friend_to_headers_map_[hdr]);
       }

--- a/iwyu_include_picker.h
+++ b/iwyu_include_picker.h
@@ -65,6 +65,7 @@ using std::vector;
 
 struct IncludeMapEntry;
 
+enum class RegexDialect;
 enum IncludeVisibility { kUnusedVisibility, kPublic, kPrivate };
 
 // When a symbol or file is mapped to an include, that include is represented
@@ -91,7 +92,7 @@ class IncludePicker {
   // visibility of the respective files.
   typedef map<string, IncludeVisibility> VisibilityMap;
 
-  explicit IncludePicker(bool no_default_mappings);
+  IncludePicker(bool no_default_mappings, RegexDialect regex_dialect);
 
   // ----- Routines to dynamically modify the include-picker
 
@@ -291,6 +292,9 @@ class IncludePicker {
 
   // Make sure we don't do any non-const operations after finalizing.
   bool has_called_finalize_added_include_lines_;
+
+  // Controls regex dialect to use for mappings.
+  RegexDialect regex_dialect;
 };  // class IncludePicker
 
 }  // namespace include_what_you_use

--- a/iwyu_regex.cc
+++ b/iwyu_regex.cc
@@ -10,12 +10,38 @@
 #include "iwyu_regex.h"
 
 #include <regex>
+#include "llvm/Support/Regex.h"
+
+#include "iwyu_port.h"
 
 namespace include_what_you_use {
 
-bool RegexMatch(const std::string& str, const std::string& pattern) {
-  std::regex r(pattern);
-  return std::regex_match(str, r);
+bool ParseRegexDialect(const char* str, RegexDialect* dialect) {
+  if (strcmp(str, "llvm") == 0) {
+    *dialect = RegexDialect::LLVM;
+    return true;
+  } else if (strcmp(str, "ecmascript") == 0) {
+    *dialect = RegexDialect::ECMAScript;
+    return true;
+  }
+  return false;
+}
+
+// Returns true if str matches regular expression pattern for the given dialect.
+bool RegexMatch(RegexDialect dialect, const std::string& str,
+                const std::string& pattern) {
+  switch (dialect) {
+    case RegexDialect::LLVM: {
+      llvm::Regex r(pattern);
+      return r.match(str);
+    }
+
+    case RegexDialect::ECMAScript: {
+      std::regex r(pattern, std::regex_constants::ECMAScript);
+      return std::regex_match(str, r);
+    }
+  }
+  CHECK_UNREACHABLE_("Unexpected regex dialect");
 }
 
 }  // namespace include_what_you_use

--- a/iwyu_regex.cc
+++ b/iwyu_regex.cc
@@ -1,0 +1,21 @@
+//===--- iwyu_regex.cc - iwyu regex implementation ------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "iwyu_regex.h"
+
+#include <regex>
+
+namespace include_what_you_use {
+
+bool RegexMatch(const std::string& str, const std::string& pattern) {
+  std::regex r(pattern);
+  return std::regex_match(str, r);
+}
+
+}  // namespace include_what_you_use

--- a/iwyu_regex.cc
+++ b/iwyu_regex.cc
@@ -32,7 +32,9 @@ bool RegexMatch(RegexDialect dialect, const std::string& str,
                 const std::string& pattern) {
   switch (dialect) {
     case RegexDialect::LLVM: {
-      llvm::Regex r(pattern);
+      // llvm::Regex::match has search semantics. Enclose the pattern in ^...$
+      // for start/end anchoring.
+      llvm::Regex r("^" + pattern + "$");
       return r.match(str);
     }
 

--- a/iwyu_regex.h
+++ b/iwyu_regex.h
@@ -1,0 +1,22 @@
+//===--- iwyu_regex.h - iwyu regex implementation -------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_WHAT_YOU_USE_IWYU_REGEX_H_
+#define INCLUDE_WHAT_YOU_USE_IWYU_REGEX_H_
+
+#include <string>
+
+namespace include_what_you_use {
+
+// Returns true if str matches regular expression pattern.
+bool RegexMatch(const std::string& str, const std::string& pattern);
+
+}  // namespace include_what_you_use
+
+#endif  // INCLUDE_WHAT_YOU_USE_IWYU_REGEX_H_

--- a/iwyu_regex.h
+++ b/iwyu_regex.h
@@ -14,8 +14,14 @@
 
 namespace include_what_you_use {
 
-// Returns true if str matches regular expression pattern.
-bool RegexMatch(const std::string& str, const std::string& pattern);
+enum class RegexDialect { LLVM = 0, ECMAScript = 1 };
+
+// Parse dialect string to enum.
+bool ParseRegexDialect(const char* str, RegexDialect* dialect);
+
+// Returns true if str matches regular expression pattern for the given dialect.
+bool RegexMatch(RegexDialect dialect, const std::string& str,
+                const std::string& pattern);
 
 }  // namespace include_what_you_use
 

--- a/tests/cxx/mapping_regex.cc
+++ b/tests/cxx/mapping_regex.cc
@@ -1,0 +1,42 @@
+//===--- mapping_regex.cc - test input file for iwyu ----------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_ARGS: -I . \
+//            -Xiwyu --regex=ecmascript \
+//            -Xiwyu --mapping_file=tests/cxx/mapping_regex.imp
+
+// This test is a little forced, but here's the idea:
+// * The include of tests/cxx/direct.h should nominally be replaced by
+//   tests/cxx/indirect.h, where IndirectClass is defined
+// * But we provide a mapping file with a negative lookahead assertion mapping
+//   any indirect.h **except in not-tests/not-cxx** to foobar.h
+// * Since tests/cxx/indirect.h does not match not-tests/not-cxx/indirect.h,
+//   the mapping will apply...
+// * ... but only since the --regex=ecmascript, which is the only dialect
+//   supporting negative lookahead.
+
+#include "tests/cxx/direct.h"
+
+void f() {
+  // IWYU: IndirectClass is defined in...*foobar.h
+  IndirectClass i;
+}
+
+/**** IWYU_SUMMARY
+
+tests/cxx/mapping_regex.cc should add these lines:
+#include "foobar.h"
+
+tests/cxx/mapping_regex.cc should remove these lines:
+- #include "tests/cxx/direct.h"  // lines XX-XX
+
+The full include-list for tests/cxx/mapping_regex.cc:
+#include "foobar.h"  // for IndirectClass
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/mapping_regex.imp
+++ b/tests/cxx/mapping_regex.imp
@@ -1,0 +1,5 @@
+# Bogus header mapping using a negative lookahead regex.
+# The foobar.h header does not exist; we just want IWYU to suggest using it.
+[
+  { include: ["@\"(?!.*not-tests/not-cxx/).*indirect.h\"", private, "\"foobar.h\"", public ] },
+]


### PR DESCRIPTION
@firewave I decided to give this a try to work around #981.

@zimin2000 This PR switches the default back to llvm::Regex for reasons discussed in the commit message, but adds an override command-line switch. I trust that works for you as well?