### PR TITLE
Do not warn on unnamed struct fields

### DIFF
--- a/iwyu_output.cc
+++ b/iwyu_output.cc
@@ -727,10 +727,10 @@ bool DeclCanBeForwardDeclared(const Decl* decl, string* reason) {
   if (isa<ClassTemplateDecl>(decl)) {
     // Class templates can always be forward-declared.
   } else if (const auto* record = dyn_cast<RecordDecl>(decl)) {
-    // Record decls can be forward-declared unless they denote a lambda
-    // expression; these have no type name to forward-declare.
-    if (record->isLambda()) {
-      *reason = "is a lambda";
+    // Record decls can be forward-declared unless they don't have
+    // a type name to forward-declare (that includes lambdas).
+    if (!record->getIdentifier()) {
+      *reason = "declaration has no name";
       return false;
     }
   } else {

--- a/tests/cxx/anonymous_struct.cc
+++ b/tests/cxx/anonymous_struct.cc
@@ -72,6 +72,22 @@ typedef_struct ts;
 typedef_struct_with_label tswl;
 typedef_enum te;
 
+// Unnamed struct field should not cause a warning.
+
+#define UNNAMED_STRUCT_FIELD \
+  struct {                   \
+    int x;                   \
+  }
+
+struct UnnamedStructFieldA {
+  UNNAMED_STRUCT_FIELD;
+};
+
+struct UnnamedStructFieldB {
+  struct {
+    int x;
+  };
+};
 
 /**** IWYU_SUMMARY
 


### PR DESCRIPTION
I've been getting warnings on unnamed struct fields inside structs (<https://gcc.gnu.org/onlinedocs/gcc/Unnamed-Fields.html>). The warning wants me to forward declare the anonymous struct type. Of course, this is not possible.

Weirdly, the warnings only happen when the unnamed struct field gets expanded from a macro. I haven't dug in too deep to find out why, but I found that changing the condition that decides if a struct type is forward declarable helps. Previously, it only checked if the type is a lambda. With this PR, it just checks if `getIdentifier()` returns `NULL`. I'm not sure if this check is more correct, but at least no tests seem to get broken.