### PR TITLE
Revert "See through C++20 consteval for conversion functions"

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -1926,7 +1926,7 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
     // If this cast requires a user-defined conversion of the from-type, look up
     // its return type so we can see through up/down-casts via such conversions.
     const Type* converted_from_type = nullptr;
-    if (const NamedDecl* conv_decl = GetConversionFunction(expr)) {
+    if (const NamedDecl* conv_decl = expr->getConversionFunction()) {
       converted_from_type =
           cast<FunctionDecl>(conv_decl)->getReturnType().getTypePtr();
     }

--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -32,7 +32,6 @@
 #include "clang/AST/DeclCXX.h"
 #include "clang/AST/DeclTemplate.h"
 #include "clang/AST/ExprCXX.h"
-#include "clang/AST/IgnoreExpr.h"
 #include "clang/AST/NestedNameSpecifier.h"
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/AST/Stmt.h"
@@ -50,14 +49,11 @@ class FileEntry;
 
 using clang::ASTDumper;
 using clang::BlockPointerType;
-using clang::CastExpr;
-using clang::CXXBindTemporaryExpr;
 using clang::CXXConstructExpr;
 using clang::CXXConstructorDecl;
 using clang::CXXDeleteExpr;
 using clang::CXXDependentScopeMemberExpr;
 using clang::CXXDestructorDecl;
-using clang::CXXMemberCallExpr;
 using clang::CXXMethodDecl;
 using clang::CXXNewExpr;
 using clang::CXXRecordDecl;
@@ -78,15 +74,12 @@ using clang::EnumDecl;
 using clang::Expr;
 using clang::ExprWithCleanups;
 using clang::FileEntry;
-using clang::FullExpr;
 using clang::FullSourceLoc;
 using clang::FunctionDecl;
 using clang::FunctionType;
 using clang::ImplicitCastExpr;
-using clang::IgnoreExprNodes;
 using clang::InjectedClassNameType;
 using clang::LValueReferenceType;
-using clang::MaterializeTemporaryExpr;
 using clang::MemberExpr;
 using clang::MemberPointerType;
 using clang::NamedDecl;
@@ -1478,38 +1471,6 @@ TemplateArgumentListInfo GetExplicitTplArgs(const Expr* expr) {
   else if (const DependentScopeDeclRefExpr* dependent_decl_ref = DynCastFrom(expr))
     dependent_decl_ref->copyTemplateArgumentsInto(explicit_tpl_args);
   return explicit_tpl_args;
-}
-
-// This is lifted from CastExpr::getConversionFunction, and naively simplified
-// to work around bugs with consteval conversion functions.
-const NamedDecl* GetConversionFunction(const CastExpr* expr) {
-  const Expr *subexpr = nullptr;
-  for (const CastExpr *e = expr; e; e = dyn_cast<ImplicitCastExpr>(subexpr)) {
-    // Skip through implicit sema nodes.
-    subexpr = IgnoreExprNodes(e->getSubExpr(), [](Expr* expr) {
-      // FullExpr is ConstantExpr + ExprWithCleanups.
-      if (auto* fe = dyn_cast<FullExpr>(expr))
-        return fe->getSubExpr();
-
-      if (auto* mte = dyn_cast<MaterializeTemporaryExpr>(expr))
-        return mte->getSubExpr();
-
-      if (auto* bte = dyn_cast<CXXBindTemporaryExpr>(expr))
-        return bte->getSubExpr();
-
-      return expr;
-    });
-
-    // Now resolve the conversion function depending on cast kind.
-    if (e->getCastKind() == clang::CK_ConstructorConversion)
-      return cast<CXXConstructExpr>(subexpr)->getConstructor();
-
-    if (e->getCastKind() == clang::CK_UserDefinedConversion) {
-      if (auto *MCE = dyn_cast<CXXMemberCallExpr>(subexpr))
-        return MCE->getMethodDecl();
-    }
-  }
-  return nullptr;
 }
 
 }  // namespace include_what_you_use

--- a/iwyu_ast_util.h
+++ b/iwyu_ast_util.h
@@ -811,10 +811,6 @@ const clang::FunctionType* GetCalleeFunctionType(clang::CallExpr* expr);
 // such a concept (declrefexpr, memberexpr), and empty list if none is present.
 clang::TemplateArgumentListInfo GetExplicitTplArgs(const clang::Expr* expr);
 
-// Workaround for https://github.com/llvm/llvm-project/issues/53044. Remove this
-// wrapper in favor of Expr::getConversionFunction  when that is fixed upstream.
-const clang::NamedDecl* GetConversionFunction(const clang::CastExpr* expr);
-
 }  // namespace include_what_you_use
 
 #endif  // INCLUDE_WHAT_YOU_USE_IWYU_AST_UTIL_H_


### PR DESCRIPTION
A proper fix is now available in LLVM as of
https://github.com/llvm/llvm-project/commit/403d7d8d7093d6637a006f8b3f7538

This reverts commit 7d7fd80da7edcf20f731975641ec86f4e3f80462.

Closes #1018 