### PR TITLE
Robustify logging in the face of null pointers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,10 @@ jobs:
           sudo apt install -y libclang$LLVM_TAG-dev
           sudo apt install -y clang$LLVM_TAG
 
+      - name: Work around broken packaging
+        run: |
+          sudo touch /usr/lib/llvm-15/bin/tblgen-lsp-server
+
       - name: Check out default branch
         uses: actions/checkout@v2
 

--- a/iwyu.cc
+++ b/iwyu.cc
@@ -972,7 +972,7 @@ class AstFlattenerVisitor : public BaseAstVisitor<AstFlattenerVisitor> {
   bool TraverseImplicitDestructorCall(clang::CXXDestructorDecl* decl,
                                       const Type* type) {
     VERRS(7) << GetSymbolAnnotation() << "[implicit dtor] "
-             << static_cast<void*>(decl)
+             << static_cast<void*>(decl) << " "
              << PrintableDecl(decl) << "\n";
     AddAstNodeAsPointer(decl);
     return Base::TraverseImplicitDestructorCall(decl, type);
@@ -982,7 +982,7 @@ class AstFlattenerVisitor : public BaseAstVisitor<AstFlattenerVisitor> {
                           const clang::Type* parent_type,
                           const clang::Expr* calling_expr) {
     VERRS(7) << GetSymbolAnnotation() << "[function call] "
-             << static_cast<void*>(callee)
+             << static_cast<void*>(callee) << " "
              << PrintableDecl(callee) << "\n";
     AddAstNodeAsPointer(callee);
     return Base::HandleFunctionCall(callee, parent_type, calling_expr);

--- a/iwyu.cc
+++ b/iwyu.cc
@@ -973,7 +973,7 @@ class AstFlattenerVisitor : public BaseAstVisitor<AstFlattenerVisitor> {
                                       const Type* type) {
     VERRS(7) << GetSymbolAnnotation() << "[implicit dtor] "
              << static_cast<void*>(decl)
-             << (decl ? PrintableDecl(decl) : "nullptr") << "\n";
+             << PrintableDecl(decl) << "\n";
     AddAstNodeAsPointer(decl);
     return Base::TraverseImplicitDestructorCall(decl, type);
   }
@@ -983,7 +983,7 @@ class AstFlattenerVisitor : public BaseAstVisitor<AstFlattenerVisitor> {
                           const clang::Expr* calling_expr) {
     VERRS(7) << GetSymbolAnnotation() << "[function call] "
              << static_cast<void*>(callee)
-             << (callee ? PrintableDecl(callee) : "nullptr") << "\n";
+             << PrintableDecl(callee) << "\n";
     AddAstNodeAsPointer(callee);
     return Base::HandleFunctionCall(callee, parent_type, calling_expr);
   }

--- a/iwyu.cc
+++ b/iwyu.cc
@@ -474,9 +474,8 @@ class BaseAstVisitor : public RecursiveASTVisitor<Derived> {
 
   bool VisitStmt(clang::Stmt* stmt) {
     if (ShouldPrintSymbolFromCurrentFile()) {
-      errs() << AnnotatedName(stmt->getStmtClassName()) << PrintablePtr(stmt);
-      PrintStmt(stmt);
-      errs() << "\n";
+      errs() << AnnotatedName(stmt->getStmtClassName()) << PrintablePtr(stmt)
+             << PrintableStmt(stmt) << "\n";
     }
     return true;
   }
@@ -999,9 +998,7 @@ class AstFlattenerVisitor : public BaseAstVisitor<AstFlattenerVisitor> {
   void AddCurrentAstNodeAsPointer() {
     if (ShouldPrint(7)) {
       errs() << GetSymbolAnnotation() << current_ast_node()->GetAs<void>()
-             << " ";
-      PrintASTNode(current_ast_node());
-      errs() << "\n";
+             << " " << PrintableASTNode(current_ast_node()) << "\n";
     }
     AddAstNodeAsPointer(current_ast_node()->GetAs<void>());
   }

--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -434,6 +434,9 @@ string PrintableLoc(SourceLocation loc) {
 }
 
 string PrintableDecl(const Decl* decl, bool terse/*=true*/) {
+  if (!decl)
+    return "<null decl>";
+
   // Use the terse flag to limit the level of output to one line.
   clang::PrintingPolicy policy = decl->getASTContext().getPrintingPolicy();
   policy.TerseOutput = terse;
@@ -447,6 +450,9 @@ string PrintableDecl(const Decl* decl, bool terse/*=true*/) {
 }
 
 string PrintableStmt(const Stmt* stmt) {
+  if (!stmt)
+    return "<null stmt>";
+
   std::string buffer;
   raw_string_ostream ostream(buffer);
   ASTDumper dumper(ostream, /*ShowColors=*/false);
@@ -455,6 +461,9 @@ string PrintableStmt(const Stmt* stmt) {
 }
 
 string PrintableType(const Type* type) {
+  if (!type)
+    return "<null type>";
+
   return QualType(type, 0).getAsString();
 }
 
@@ -462,8 +471,10 @@ string PrintableTypeLoc(const TypeLoc& typeloc) {
   return PrintableType(typeloc.getTypePtr());
 }
 
-string PrintableNestedNameSpecifier(
-    const NestedNameSpecifier* nns) {
+string PrintableNestedNameSpecifier(const NestedNameSpecifier* nns) {
+  if (!nns)
+    return "<null nns>";
+
   std::string buffer;  // llvm wants regular string, not our versa-string
   raw_string_ostream ostream(buffer);
   nns->print(ostream, DefaultPrintPolicy());
@@ -494,6 +505,9 @@ string PrintableTemplateArgumentLoc(const TemplateArgumentLoc& arg) {
 }
 
 string PrintableASTNode(const ASTNode* node) {
+  if (!node)
+    return "<null ast node>";
+
   std::string buffer;
   raw_string_ostream ostream(buffer);
   DumpASTNode(ostream, node);

--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -430,11 +430,7 @@ const DeclContext* GetDeclContext(const ASTNode* ast_node) {
 // --- Printers.
 
 string PrintableLoc(SourceLocation loc) {
-  if (loc.isInvalid()) {
-    return "Invalid location";
-  } else {
-    return NormalizeFilePath(loc.printToString(*GlobalSourceManager()));
-  }
+  return NormalizeFilePath(loc.printToString(*GlobalSourceManager()));
 }
 
 string PrintableDecl(const Decl* decl, bool terse/*=true*/) {

--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -458,11 +458,6 @@ string PrintableStmt(const Stmt* stmt) {
   return ostream.str();
 }
 
-void PrintStmt(const Stmt* stmt) {
-  ASTDumper dumper(llvm::errs(), /*ShowColors=*/false);
-  dumper.Visit(stmt);
-}
-
 string PrintableType(const Type* type) {
   return QualType(type, 0).getAsString();
 }
@@ -509,10 +504,15 @@ string PrintableASTNode(const ASTNode* node) {
   return ostream.str();
 }
 
-// This prints to errs().  It's useful for debugging (e.g. inside gdb).
+// These print to stderr. They're useful for debugging (e.g. inside gdb).
 void PrintASTNode(const ASTNode* node) {
   DumpASTNode(errs(), node);
   errs() << "\n";
+}
+
+void PrintStmt(const Stmt* stmt) {
+  ASTDumper dumper(llvm::errs(), /*ShowColors=*/false);
+  dumper.Visit(stmt);
 }
 
 string GetWrittenQualifiedNameAsString(const NamedDecl* named_decl) {

--- a/iwyu_ast_util.h
+++ b/iwyu_ast_util.h
@@ -436,7 +436,8 @@ string PrintableTemplateName(const clang::TemplateName& tpl_name);
 string PrintableTemplateArgument(const clang::TemplateArgument& arg);
 string PrintableTemplateArgumentLoc(const clang::TemplateArgumentLoc& arg);
 string PrintableASTNode(const ASTNode* node);
-// This prints to errs().  It's useful for debugging (e.g. inside gdb).
+
+// These print to stderr. They're useful for debugging (e.g. inside gdb).
 void PrintASTNode(const ASTNode* node);
 void PrintStmt(const clang::Stmt* stmt);
 


### PR DESCRIPTION
The example described in #989 triggers an assertion failure (or segfault if built without assertions) in IWYU's main logic.
Unfortunately, if we up the log level, it also segfaults in logging, because we attempt to convert a null pointer to a string using `PrintableDecl`.

It seems prudent to teach the `Printable...` helpers to deal with null pointers, because it's nice if logging doesn't mask other bugs.

Clean up a bunch of small things, and print null values as `<null xyz>` consistently.