### PR TITLE
Consider null decls ignorable everywhere

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -1225,6 +1225,8 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
   // should be held responsible for a use.
   SourceLocation GetCanonicalUseLocation(SourceLocation use_loc,
                                          const NamedDecl* decl) {
+    CHECK_(decl != nullptr) << ": Need a decl to compute use location";
+
     // If we're not in a macro, just echo the use location.
     if (!use_loc.isMacroID())
       return use_loc;
@@ -2802,6 +2804,8 @@ class InstantiatedTemplateVisitor
   // instance, we're not responsible for a vector's call to
   // allocator::allocator(), because <vector> provides it for us).
   bool CanIgnoreDecl(const Decl* decl) const override {
+    if (!decl)
+      return true;
     return nodes_to_ignore_.Contains(decl);
   }
 


### PR DESCRIPTION
For instantiated templates, CanIgnoreDecl is quite sophisticated and uses a
set to ignore subtrees we've visited before.

Non-template code only allows the null decl pointer to be ignored. It's funny
it's taken so long to notice this, but there are cases in templated code where
the decl can be null as well -- most prominently for builtin types.

With this test input:

  $ cat t.cc
  #include <algorithm>
  #include <cassert>
  #include <vector>

  void f() {
    std::vector<int> v;
    assert(std::none_of(v.cbegin(), v.cend(),
                        [](auto value) { return value == 100; }));
  }

  $ include-what-you-use -stdlib=libc++ t.cc

std::vector::const_iterator collapses to a 'const int *', which has no
declaration, and so yields a null decl. Prior to this fix, that would lead to a
cast assertion or segfault attempting to cast the resulting null pointer to a
NamedDecl.

I have not found a way to capture this in a reduced testcase.

Fixes #989.