### PR TITLE
create ```--comment_style``` arg for IWYU to allow people to adjust verbosity of 'why' comments

### DIFF
--- a/fix_includes.py
+++ b/fix_includes.py
@@ -2373,8 +2373,8 @@ def main(argv):
   parser.add_option('--nocomments', action='store_false', dest='comments')
 
   parser.add_option('--update_comments', action='store_true', default=False,
-                    help=('Update #include comments, even if no #include lines'
-                          ' are added or removed'))
+                    help=('Replace \'why\' comments with the ones provided by'
+                          ' IWYU'))
   parser.add_option('--noupdate_comments', action='store_false',
                     dest='update_comments')
 

--- a/include-what-you-use.1
+++ b/include-what-you-use.1
@@ -76,6 +76,10 @@ length can still be exceeded with long filenames (default: 80).
 Do not add comments after includes about which symbols the header was required
 for.
 .TP
+.BI \-\-update_comments
+Print full include list with comments, even if there are no
+\(lqinclude-what-you-use\(rq violations.
+.TP
 .B \-\-no_default_mappings
 Do not use the default mappings.
 .TP

--- a/include-what-you-use.1
+++ b/include-what-you-use.1
@@ -72,6 +72,24 @@ Maximum line length for includes.
 Note that this only affects the comments and their alignment, the maximum line
 length can still be exceeded with long filenames (default: 80).
 .TP
+.BI \-\-comment_style= verbosity
+Controls the style and verbosity of \(lqwhy\(rq comments at the end of
+suggested includes.
+.IR verbosity
+options are:
+.RS
+.TP
+.B none 
+No \(lqwhy\(rq comments.
+.TP 
+.B short 
+\(lqWhy\(rq comments include symbol names, but no namespaces.
+This is the default.
+.TP 
+.B long  
+\(lqWhy\(rq comments include function/class names with namespaces. 
+.RE
+.TP
 .B \-\-no_comments
 Do not add comments after includes about which symbols the header was required
 for.

--- a/include-what-you-use.1
+++ b/include-what-you-use.1
@@ -74,9 +74,9 @@ length can still be exceeded with long filenames (default: 80).
 .TP
 .BI \-\-comment_style= verbosity
 Controls the style and verbosity of \(lqwhy\(rq comments at the end of
-suggested includes.
-.IR verbosity
-options are:
+suggested includes. Options for
+.I verbosity
+are:
 .RS
 .TP
 .B none 

--- a/iwyu_globals.cc
+++ b/iwyu_globals.cc
@@ -91,7 +91,7 @@ static void PrintHelp(const char* extra_msg) {
          "        the maximum line length can still be exceeded with long\n"
          "        file names (default: 80).\n"
          "   --no_comments: do not add 'why' comments.\n"
-         "   --update_comments: always add 'why' comments, even if no\n"
+         "   --update_comments: update and insert 'why' comments, even if no\n"
          "        #include lines need to be added or removed.\n"
          "   --no_fwd_decls: do not use forward declarations.\n"
          "   --verbose=<level>: the higher the level, the more output.\n"

--- a/iwyu_globals.cc
+++ b/iwyu_globals.cc
@@ -90,6 +90,12 @@ static void PrintHelp(const char* extra_msg) {
          "        Note that this only affects comments and alignment thereof,\n"
          "        the maximum line length can still be exceeded with long\n"
          "        file names (default: 80).\n"
+         "   --comment_style=<level> set verbosity of 'why' comments to\n"
+         "        one of the following values:\n"
+         "          none:  do not add 'why' comments.\n"
+         "          short: 'why' comments do not include namespaces.\n"
+         "          long:  'why' comments include namespaces.\n"
+         "        Default value is 'short'.\n"
          "   --no_comments: do not add 'why' comments.\n"
          "   --update_comments: update and insert 'why' comments, even if no\n"
          "        #include lines need to be added or removed.\n"
@@ -185,6 +191,7 @@ CommandlineFlags::CommandlineFlags()
       pch_in_code(false),
       no_comments(false),
       update_comments(false),
+      comments_with_namespace(false),
       no_fwd_decls(false),
       quoted_includes_first(false),
       cxx17ns(false),
@@ -205,6 +212,7 @@ int CommandlineFlags::ParseArgv(int argc, char** argv) {
     {"prefix_header_includes", required_argument, nullptr, 'x'},
     {"pch_in_code", no_argument, nullptr, 'h'},
     {"max_line_length", required_argument, nullptr, 'l'},
+    {"comment_style", required_argument, nullptr, 'i'},
     {"no_comments", no_argument, nullptr, 'o'},
     {"update_comments", no_argument, nullptr, 'u'},
     {"no_fwd_decls", no_argument, nullptr, 'f'},
@@ -225,6 +233,18 @@ int CommandlineFlags::ParseArgv(int argc, char** argv) {
       case 'n': no_default_mappings = true; break;
       case 'o': no_comments = true; break;
       case 'u': update_comments = true; break;
+      case 'i':
+        if (strcmp(optarg, "none") == 0) {
+          no_comments = true;
+        } else if (strcmp(optarg, "short") == 0) {
+          comments_with_namespace = false;
+        } else if (strcmp(optarg, "long") == 0) {
+          comments_with_namespace = true;
+        } else {
+          PrintHelp("FATAL ERROR: unknown comment style.");
+          exit(EXIT_FAILURE);
+        }
+        break;
       case 'f': no_fwd_decls = true; break;
       case 'x':
         if (strcmp(optarg, "add") == 0) {

--- a/iwyu_globals.h
+++ b/iwyu_globals.h
@@ -90,6 +90,7 @@ struct CommandlineFlags {
   bool pch_in_code;   // Treat the first seen include as a PCH. No short option.
   bool no_comments;   // Disable 'why' comments. No short option.
   bool update_comments; // Force 'why' comments. No short option.
+  bool comments_with_namespace; // Show namespace in 'why' comments.
   bool no_fwd_decls;  // Disable forward declarations.
   bool quoted_includes_first; // Place quoted includes first in sort order.
   bool cxx17ns; // -C: C++17 nested namespace syntax

--- a/iwyu_output.cc
+++ b/iwyu_output.cc
@@ -1747,7 +1747,11 @@ void CalculateDesiredIncludesAndForwardDeclares(
       auto range = include_map.equal_range(use.suggested_header());
       for (auto it = range.first; it != range.second; ++it) {
         it->second->set_desired();
-        it->second->AddSymbolUse(use.short_symbol_name());
+        if (GlobalFlags().comments_with_namespace) {
+          it->second->AddSymbolUse(use.symbol_name());
+        } else {
+          it->second->AddSymbolUse(use.short_symbol_name());
+        }
       }
     }
   }

--- a/tests/cxx/comment_style-d1.h
+++ b/tests/cxx/comment_style-d1.h
@@ -1,0 +1,17 @@
+//===--- comment_style-d1.h - test input file for iwyu --------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// this file exists to verify --comment_style works
+#include "tests/cxx/comment_style-i2.h"  // Transitive include
+
+namespace Foo {
+  int bar(int x) {
+    return x;
+  }
+};

--- a/tests/cxx/comment_style-i2.h
+++ b/tests/cxx/comment_style-i2.h
@@ -1,0 +1,14 @@
+//===--- comment_style-i2.h - test input file for iwyu --------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+namespace Bar {
+  int foo(int x) {
+    return x;
+  }
+};

--- a/tests/cxx/comment_style_long.cc
+++ b/tests/cxx/comment_style_long.cc
@@ -1,0 +1,32 @@
+//===--- comment_style_long.cc - test input file for iwyu -----------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_ARGS: -Xiwyu --comment_style=long -I .
+
+// Test behavior is right with long comments
+
+#include "tests/cxx/comment_style-d1.h" // for bar
+
+int main() {
+  Foo::bar(1);
+  // IWYU: Bar::foo is...*"tests/cxx/comment_style-i2.h"
+  Bar::foo(2);
+  return 0;
+}
+
+/**** IWYU_SUMMARY
+tests/cxx/comment_style_long.cc should add these lines:
+#include "tests/cxx/comment_style-i2.h"
+
+tests/cxx/comment_style_long.cc should remove these lines:
+
+The full include-list for tests/cxx/comment_style_long.cc:
+#include "tests/cxx/comment_style-d1.h"  // for Foo::bar
+#include "tests/cxx/comment_style-i2.h"  // for Bar::foo
+***** IWYU_SUMMARY */

--- a/tests/cxx/comment_style_none.cc
+++ b/tests/cxx/comment_style_none.cc
@@ -1,0 +1,32 @@
+//===--- comment_style_none.cc - test input file for iwyu -----------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_ARGS: -Xiwyu --comment_style=none -I .
+
+// check that --comment_style=none adds no comments
+
+#include "tests/cxx/comment_style-d1.h"
+
+int main() {
+  Foo::bar(1);
+  // IWYU: Bar::foo is...*"tests/cxx/comment_style-i2.h"
+  Bar::foo(2);
+  return 0;
+}
+
+/**** IWYU_SUMMARY
+tests/cxx/comment_style_none.cc should add these lines:
+#include "tests/cxx/comment_style-i2.h"
+
+tests/cxx/comment_style_none.cc should remove these lines:
+
+The full include-list for tests/cxx/comment_style_none.cc:
+#include "tests/cxx/comment_style-d1.h"
+#include "tests/cxx/comment_style-i2.h"
+***** IWYU_SUMMARY */

--- a/tests/cxx/comment_style_short.cc
+++ b/tests/cxx/comment_style_short.cc
@@ -1,0 +1,32 @@
+//===--- comment_style_short.cc - test input file for iwyu ----------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_ARGS: -Xiwyu --comment_style=short -I .
+
+// check that --comment_style=short adds short comments
+
+#include "tests/cxx/comment_style-d1.h" // some Comment
+
+int main() {
+  Foo::bar(1);
+  // IWYU: Bar::foo is...*"tests/cxx/comment_style-i2.h"
+  Bar::foo(2);
+  return 0;
+}
+
+/**** IWYU_SUMMARY
+tests/cxx/comment_style_short.cc should add these lines:
+#include "tests/cxx/comment_style-i2.h"
+
+tests/cxx/comment_style_short.cc should remove these lines:
+
+The full include-list for tests/cxx/comment_style_short.cc:
+#include "tests/cxx/comment_style-d1.h"  // for bar
+#include "tests/cxx/comment_style-i2.h"  // for foo
+***** IWYU_SUMMARY */

--- a/tests/cxx/comment_style_update_long.cc
+++ b/tests/cxx/comment_style_update_long.cc
@@ -1,0 +1,34 @@
+//===--- comment_style_update_long.cc - test input file for iwyu ----------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_ARGS: -Xiwyu --update_comments -Xiwyu --comment_style=long -I .
+
+// Test that passing --update_comments respects comment style.
+
+#include "tests/cxx/comment_style-d1.h"
+
+int main() {
+  // IWYU: Bar::foo is...*"tests/cxx/comment_style-i2.h"
+  Bar::foo(123);
+  Foo::bar(456);
+  return 0;
+}
+
+/**** IWYU_SUMMARY
+
+tests/cxx/comment_style_update_long.cc should add these lines:
+#include "tests/cxx/comment_style-i2.h"
+
+tests/cxx/comment_style_update_long.cc should remove these lines:
+
+The full include-list for tests/cxx/comment_style_update_long.cc:
+#include "tests/cxx/comment_style-d1.h"  // for Foo::bar
+#include "tests/cxx/comment_style-i2.h"  // for Bar::foo
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/comment_style_update_none.cc
+++ b/tests/cxx/comment_style_update_none.cc
@@ -1,0 +1,34 @@
+//===--- comment_style_update_none.cc - test input file for iwyu ----------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_ARGS: -Xiwyu --update_comments -Xiwyu --comment_style=none -I .
+
+// Test that --update_comments respects comment style.
+
+#include "tests/cxx/comment_style-d1.h" // for foo, bar
+
+int main() {
+  // IWYU: Bar::foo is...*"tests/cxx/comment_style-i2.h"
+  Bar::foo(123);
+  Foo::bar(456);
+  return 0;
+}
+
+/**** IWYU_SUMMARY
+
+tests/cxx/comment_style_update_none.cc should add these lines:
+#include "tests/cxx/comment_style-i2.h"
+
+tests/cxx/comment_style_update_none.cc should remove these lines:
+
+The full include-list for tests/cxx/comment_style_update_none.cc:
+#include "tests/cxx/comment_style-d1.h"
+#include "tests/cxx/comment_style-i2.h"
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
In a project that I am working on it is required that I have the namespace that a function/class belongs to in the ```\\ for xyz``` comment. I figured that somebody else somewhere may need to do the same.