### PR TITLE
Class member reporting improvements

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -3532,12 +3532,6 @@ class IwyuAstConsumer
     if (CanIgnoreLocation(current_ast_node()->GetLocation()))
       return true;
 
-    // If we're a field of a typedef type, ignore us: our rule is that
-    // the author of the typedef is responsible for everything
-    // involving the typedef.
-    if (IsMemberOfATypedef(current_ast_node()))
-      return true;
-
     // TODO(csilvers): if we're a type, call CanIgnoreType().
 
     return false;

--- a/iwyu_ast_util.h
+++ b/iwyu_ast_util.h
@@ -413,11 +413,6 @@ bool IsCXXConstructExprInNewExpr(const ASTNode* ast_node);
 // comes before the ::), return that, else return nullptr.
 const clang::NestedNameSpecifier* GetQualifier(const ASTNode* ast_node);
 
-// Returns true if any parent is a typedef: my_typedef.a, or
-// MyTypedef::a, or MyTypedef::subclass::a, etc.  Note it does
-// *not* return true if the ast_node itself is a typedef.
-bool IsMemberOfATypedef(const ASTNode* ast_node);
-
 // Returns the decl-context of the deepest decl in the ast-chain.
 const clang::DeclContext* GetDeclContext(const ASTNode* ast_node);
 

--- a/iwyu_output.cc
+++ b/iwyu_output.cc
@@ -1258,11 +1258,11 @@ void ProcessFullUse(OneUse* use,
     }
   }
 
-  // (B4) Discard symbol uses for member functions in the same file as parent.
-  if (const CXXMethodDecl* method_dfn = DynCastFrom(use->decl())) {
+  // (B4) Discard symbol uses for class members in the same file as parent.
+  if (const CXXRecordDecl* parent_decl =
+          DynCastFrom(use->decl()->getDeclContext())) {
     // See if we also recorded a use of the parent.
-    const NamedDecl* parent_dfn
-        = GetDefinitionAsWritten(method_dfn->getParent());
+    const NamedDecl* parent_dfn = GetDefinitionAsWritten(parent_decl);
 
     const FileEntry* decl_file_entry = GetFileEntry(use->decl_loc());
     const FileEntry* parent_file_entry =
@@ -1276,14 +1276,14 @@ void ProcessFullUse(OneUse* use,
     // mapping to choose, and it's important we use the one that iwyu
     // will pick later).  TODO(csilvers): figure out that case too.
     const IncludePicker& picker = GlobalIncludePicker();
-    const vector<MappedInclude>& method_dfn_files =
+    const vector<MappedInclude>& member_dfn_files =
         picker.GetCandidateHeadersForFilepath(GetFilePath(decl_file_entry));
     const vector<MappedInclude>& parent_dfn_files =
         picker.GetCandidateHeadersForFilepath(GetFilePath(parent_file_entry));
     bool same_file;
-    if (method_dfn_files.size() == 1 && parent_dfn_files.size() == 1) {
-      same_file = (method_dfn_files[0].quoted_include ==
-          parent_dfn_files[0].quoted_include);
+    if (member_dfn_files.size() == 1 && parent_dfn_files.size() == 1) {
+      same_file = (member_dfn_files[0].quoted_include ==
+                   parent_dfn_files[0].quoted_include);
     } else {
       // Fall back on just checking the filenames: can't figure out public.
       same_file = (decl_file_entry == parent_file_entry);

--- a/tests/cxx/badinc.cc
+++ b/tests/cxx/badinc.cc
@@ -706,10 +706,8 @@ I1_Class::NestedStruct *i1_nestedstruct_ptr;
 // Even adding an explicit 'struct' doesn't make it fwd-declarable.
 // IWYU: I1_Class is...*badinc-i1.h
 struct I1_Class::NestedStruct *i1_nestedstruct_ptr2;
-// IWYU: I1_Class::NestedStruct is...*badinc-i1.h
 // IWYU: I1_Class is...*badinc-i1.h
 I1_Class::NestedStruct i1_nestedstruct;
-// IWYU: I1_Class::NestedStruct is...*badinc-i1.h
 // IWYU: I1_Class is...*badinc-i1.h
 struct I1_Class::NestedStruct i1_nestedstruct2;
 
@@ -792,7 +790,6 @@ I1_TemplateClass<I2_Struct> i1_templateclass_tpl_ctor(i1_class, true);
 // The trick here is that the NNS doesn't have its own location info.
 #define CC_DEFINE_VAR(typ)  typ cc_define_var ## __LINE__
 // IWYU: I1_TemplateClass is...*badinc-i1.h
-// IWYU: I1_TemplateClass<.*>::I1_TemplateClass_int is...*badinc-i1.h
 // IWYU: I2_Class is...*badinc-i2.h
 // IWYU: I2_Class needs a declaration
 CC_DEFINE_VAR(I1_TemplateClass<I2_Class>::I1_TemplateClass_int);
@@ -813,7 +810,6 @@ I1_TypedefOnly_Class<I1_Class> i1_typedefonly_class;
 // IWYU: I1_Class needs a declaration
 // IWYU: I1_Class is...*badinc-i1.h
 // IWYU: I1_TypedefOnly_Class is...*badinc-i1.h
-// IWYU: I1_TypedefOnly_Class<.*>::i is...*badinc-i1.h
 I1_TypedefOnly_Class<I1_Class>::i i1_typedefonly_class_int;
 // IWYU: I1_I2_Class_Typedef is...*badinc-i1.h
 int i1_i2_class_typedef_int = I1_I2_Class_Typedef::s;
@@ -1517,10 +1513,8 @@ int main() {
   local_enum_vector.push_back(I21);
   // IWYU: std::vector is...*<vector>
   // IWYU: I2_Enum is...*badinc-i2.h
-  // IWYU: std::vector<.*>::iterator is...*<vector>
   for (std::vector<I2_Enum>::iterator it = local_enum_vector.begin();
        // IWYU: std::vector is...*<vector>
-       // IWYU: std::vector<.*>::iterator is...*<vector>
        it != local_enum_vector.end(); ++it) {
     // IWYU: I2_Enum is...*badinc-i2.h
     // IWYU: std::vector is...*<vector>
@@ -1692,59 +1686,44 @@ int main() {
   // IWYU: std::set is...*<set>
   std::set<int> localset;
   // IWYU: std::set is...*<set>
-  // IWYU: std::set<.*>::iterator is...*<set>
   std::set<int>::iterator it_set = localset.begin();
 
   // Lots of weird stuff can happen with iterators, especially regarding const.
   // IWYU: std::vector is...*<vector>
   std::vector<float> float_vector;
   // IWYU: std::vector is...*<vector>
-  // IWYU: std::vector<.*>::const_iterator is...*<vector>
   std::vector<float>::const_iterator float_it = float_vector.begin();
   // IWYU: std::vector is...*<vector>
-  // IWYU: std::vector<.*>::const_iterator is...*<vector>
   const std::vector<float>::const_iterator float_constit = float_vector.begin();
   // IWYU: std::vector is...*<vector>
   (void)(float_it == float_constit);
   // IWYU: std::vector is...*<vector>
-  // IWYU: std::vector<.*>::const_iterator is...*<vector>
   (void)(float_constit == float_it);
   // IWYU: std::vector is...*<vector>
-  // IWYU: std::vector<.*>::const_iterator is...*<vector>
   std::vector<float>::const_iterator float_forit;
   // IWYU: std::vector is...*<vector>
-  // IWYU: std::vector<.*>::const_iterator is...*<vector>
   for (float_forit = float_vector.begin(); ;) ;
   // IWYU: std::vector is...*<vector>
-  // IWYU: std::vector<.*>::const_iterator is...*<vector>
   for (std::vector<float>::const_iterator it = float_vector.begin(); ;) ;
   // IWYU: std::vector is...*<vector>
-  // IWYU: std::vector<.*>::const_iterator is...*<vector>
   for (const std::vector<float>::const_iterator it = float_vector.begin(); ;) ;
   // We special-case vector<>::iterator.  Make sure it holds for
   // reverse_iterator too.
   // IWYU: std::vector is...*<vector>
-  // IWYU: std::vector<.*>::reverse_iterator is...*<vector>
   for (std::vector<float>::reverse_iterator
            // IWYU: std::vector is...*<vector>
            float_reverse_it = float_vector.rbegin();
        // IWYU: std::vector is...*<vector>
        float_reverse_it != float_vector.rbegin();
        // IWYU: std::vector is...*<vector>
-       // IWYU: std::vector<.*>::reverse_iterator is...*<vector>
        ++float_reverse_it) ;
   // IWYU: std::vector is...*<vector>
-  // IWYU: std::vector<.*>::const_reverse_iterator is...*<vector>
   for (std::vector<float>::const_reverse_iterator
-           // We need const_reverse_iterator here because of the
-           // conversion from reverse_iterator (from rbegin()).
-           // IWYU: std::vector<.*>::const_reverse_iterator is...*<vector>
            // IWYU: std::vector is...*<vector>
            float_const_reverse_it = float_vector.rbegin();
        // IWYU: std::vector is...*<vector>
        float_const_reverse_it != float_vector.rend();
        // IWYU: std::vector is...*<vector>
-       // IWYU: std::vector<.*>::const_reverse_iterator is...*<vector>
        ++float_const_reverse_it) ;
 
   // Also test while and if initializers.
@@ -1894,11 +1873,11 @@ The full include-list for tests/cxx/badinc.cc:
 #include <algorithm>  // for find
 #include <fstream>  // for fstream
 #include <list>  // for list
-#include <string>  // for basic_string, basic_string<>::iterator, operator+, string
+#include <string>  // for basic_string, operator+, string
 #include <typeinfo>  // for type_info
 #include "tests/cxx/badinc-d1.h"  // for D11, D1CopyClassFn, D1Function, D1_Class, D1_CopyClass, D1_Enum, D1_I1_Typedef, D1_StructPtr, D1_Subclass, D1_TemplateClass, D1_TemplateStructWithDefaultParam, MACRO_CALLING_I4_FUNCTION
 #include "tests/cxx/badinc-d4.h"  // for D4_ClassForOperator, operator<<
-#include "tests/cxx/badinc-i1.h"  // for EmptyDestructorClass, H_Class::H_Class_DefinedInI1, I11, I12, I13, I1_And_I2_OverloadedFunction, I1_Base, I1_Class, I1_Class::NestedStruct, I1_ClassPtr, I1_Enum, I1_Function, I1_FunctionPtr, I1_I2_Class_Typedef, I1_MACRO_LOGGING_CLASS, I1_MACRO_SYMBOL_WITHOUT_VALUE, I1_MACRO_SYMBOL_WITH_VALUE, I1_MACRO_SYMBOL_WITH_VALUE0, I1_MACRO_SYMBOL_WITH_VALUE2, I1_ManyPtrStruct (ptr only), I1_MemberPtr, I1_NamespaceClass, I1_NamespaceStruct, I1_NamespaceTemplateFn, I1_OverloadedFunction, I1_PtrAndUseOnSameLine, I1_PtrDereferenceClass, I1_PtrDereferenceStatic, I1_PtrDereferenceStruct, I1_SiblingClass, I1_StaticMethod, I1_Struct, I1_Subclass, I1_SubclassesI2Class, I1_TemplateClass, I1_TemplateClass<>::I1_TemplateClass_int, I1_TemplateClassFwdDeclaredInD2 (ptr only), I1_TemplateFunction, I1_TemplateMethodOnlyClass, I1_TemplateSubclass, I1_Typedef, I1_TypedefOnly_Class, I1_TypedefOnly_Class<>::i, I1_Union, I1_UnnamedStruct, I1_UnusedNamespaceStruct (ptr only), I1_const_ptr, I2_OperatorDefinedInI1Class::operator<<, MACRO_CALLING_I6_FUNCTION, OperateOn, i1_GlobalFunction, i1_int, i1_int_global, i1_int_global2, i1_int_global2sub, i1_int_global3, i1_int_global3sub, i1_int_global4, i1_int_global4sub, i1_int_globalsub, i1_ns2, i1_ns4, i1_ns5, kI1ConstInt, operator==
+#include "tests/cxx/badinc-i1.h"  // for EmptyDestructorClass, H_Class::H_Class_DefinedInI1, I11, I12, I13, I1_And_I2_OverloadedFunction, I1_Base, I1_Class, I1_ClassPtr, I1_Enum, I1_Function, I1_FunctionPtr, I1_I2_Class_Typedef, I1_MACRO_LOGGING_CLASS, I1_MACRO_SYMBOL_WITHOUT_VALUE, I1_MACRO_SYMBOL_WITH_VALUE, I1_MACRO_SYMBOL_WITH_VALUE0, I1_MACRO_SYMBOL_WITH_VALUE2, I1_ManyPtrStruct (ptr only), I1_MemberPtr, I1_NamespaceClass, I1_NamespaceStruct, I1_NamespaceTemplateFn, I1_OverloadedFunction, I1_PtrAndUseOnSameLine, I1_PtrDereferenceClass, I1_PtrDereferenceStatic, I1_PtrDereferenceStruct, I1_SiblingClass, I1_StaticMethod, I1_Struct, I1_Subclass, I1_SubclassesI2Class, I1_TemplateClass, I1_TemplateClassFwdDeclaredInD2 (ptr only), I1_TemplateFunction, I1_TemplateMethodOnlyClass, I1_TemplateSubclass, I1_Typedef, I1_TypedefOnly_Class, I1_Union, I1_UnnamedStruct, I1_UnusedNamespaceStruct (ptr only), I1_const_ptr, I2_OperatorDefinedInI1Class::operator<<, MACRO_CALLING_I6_FUNCTION, OperateOn, i1_GlobalFunction, i1_int, i1_int_global, i1_int_global2, i1_int_global2sub, i1_int_global3, i1_int_global3sub, i1_int_global4, i1_int_global4sub, i1_int_globalsub, i1_ns2, i1_ns4, i1_ns5, kI1ConstInt, operator==
 #include "tests/cxx/badinc2.c"
 class D2_Class;
 class D2_ForwardDeclareClass;

--- a/tests/cxx/iwyu_stricter_than_cpp-d3.h
+++ b/tests/cxx/iwyu_stricter_than_cpp-d3.h
@@ -1,0 +1,17 @@
+//===--- iwyu_stricter_than_cpp-d3.h - test input file for iwyu -----------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/iwyu_stricter_than_cpp-i3.h"
+#include "tests/cxx/iwyu_stricter_than_cpp-i4.h"
+
+typedef IndirectStruct3 IndirectStruct3ProvidingTypedef;
+typedef IndirectStruct4 IndirectStruct4ProvidingTypedef;
+
+using IndirectStruct3ProvidingAl = IndirectStruct3;
+using IndirectStruct4ProvidingAl = IndirectStruct4;

--- a/tests/cxx/iwyu_stricter_than_cpp-i3.h
+++ b/tests/cxx/iwyu_stricter_than_cpp-i3.h
@@ -1,0 +1,16 @@
+//===--- iwyu_stricter_than_cpp-i3.h - test input file for iwyu -----------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/indirect.h"
+
+struct IndirectStruct3 {
+  typedef IndirectClass IndirectClassProvidingTypedef;
+
+  using IndirectClassProvidingAl = IndirectClass;
+};

--- a/tests/cxx/iwyu_stricter_than_cpp-i4.h
+++ b/tests/cxx/iwyu_stricter_than_cpp-i4.h
@@ -1,0 +1,16 @@
+//===--- iwyu_stricter_than_cpp-i4.h - test input file for iwyu -----------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+class IndirectClass;
+
+struct IndirectStruct4 {
+  typedef IndirectClass IndirectClassNonProvidingTypedef;
+
+  using IndirectClassNonProvidingAl = IndirectClass;
+};

--- a/tests/cxx/iwyu_stricter_than_cpp-type_alias.h
+++ b/tests/cxx/iwyu_stricter_than_cpp-type_alias.h
@@ -57,6 +57,14 @@ using TplDoesEverythingRightAl = TplIndirectStruct2<int>;
 template <> struct TplIndirectStruct2<float>;
 using TplDoesEverythingRightAgainAl = TplIndirectStruct2<float>;
 
+// --- Special aliases, for nested name testing
+
+struct IndirectStruct3;
+using IndirectStruct3NonProvidingAl = IndirectStruct3;
+
+struct IndirectStruct4;
+using IndirectStruct4NonProvidingAl = IndirectStruct4;
+
 
 /**** IWYU_SUMMARY
 
@@ -71,6 +79,8 @@ The full include-list for tests/cxx/iwyu_stricter_than_cpp-type_alias.h:
 #include "tests/cxx/iwyu_stricter_than_cpp-d1.h"  // for DirectStruct1, DirectStruct2, TplDirectStruct1, TplDirectStruct2
 #include "tests/cxx/iwyu_stricter_than_cpp-i1.h"  // for IndirectStruct1, IndirectStructForwardDeclaredInD1, TplIndirectStruct1, TplIndirectStructForwardDeclaredInD1
 struct IndirectStruct2;  // lines XX-XX
+struct IndirectStruct3;  // lines XX-XX
+struct IndirectStruct4;  // lines XX-XX
 template <typename T> struct TplIndirectStruct2;  // lines XX-XX
 
 ***** IWYU_SUMMARY */

--- a/tests/cxx/iwyu_stricter_than_cpp-typedefs.h
+++ b/tests/cxx/iwyu_stricter_than_cpp-typedefs.h
@@ -57,6 +57,14 @@ typedef TplIndirectStruct2<int> TplDoesEverythingRight;
 template <> struct TplIndirectStruct2<float>;
 typedef TplIndirectStruct2<float> TplDoesEverythingRightAgain;
 
+// --- Special typedefs, for nested name testing
+
+struct IndirectStruct3;
+typedef IndirectStruct3 IndirectStruct3NonProvidingTypedef;
+
+struct IndirectStruct4;
+typedef IndirectStruct4 IndirectStruct4NonProvidingTypedef;
+
 
 /**** IWYU_SUMMARY
 
@@ -71,6 +79,8 @@ The full include-list for tests/cxx/iwyu_stricter_than_cpp-typedefs.h:
 #include "tests/cxx/iwyu_stricter_than_cpp-d1.h"  // for DirectStruct1, DirectStruct2, TplDirectStruct1, TplDirectStruct2
 #include "tests/cxx/iwyu_stricter_than_cpp-i1.h"  // for IndirectStruct1, IndirectStructForwardDeclaredInD1, TplIndirectStruct1, TplIndirectStructForwardDeclaredInD1
 struct IndirectStruct2;  // lines XX-XX
+struct IndirectStruct3;  // lines XX-XX
+struct IndirectStruct4;  // lines XX-XX
 template <typename T> struct TplIndirectStruct2;  // lines XX-XX
 
 ***** IWYU_SUMMARY */

--- a/tests/cxx/iwyu_stricter_than_cpp.cc
+++ b/tests/cxx/iwyu_stricter_than_cpp.cc
@@ -36,6 +36,7 @@
 // This test tests that the iwyu requirement is correctly suppressed
 // when these two conditions are met, and not otherwise.
 
+#include "tests/cxx/direct.h"
 #include "tests/cxx/iwyu_stricter_than_cpp-typedefs.h"
 #include "tests/cxx/iwyu_stricter_than_cpp-type_alias.h"
 #include "tests/cxx/iwyu_stricter_than_cpp-autocast.h"
@@ -44,6 +45,7 @@
 // is visible in the translation unit (but not by -d2.h)
 #include "tests/cxx/iwyu_stricter_than_cpp-autocast2.h"
 #include "tests/cxx/iwyu_stricter_than_cpp-d2.h"
+#include "tests/cxx/iwyu_stricter_than_cpp-d3.h"
 
 typedef DoesEverythingRight DoubleTypedef;
 
@@ -78,6 +80,16 @@ void TestTypedefs() {
   // ...at least until we dereference the pointer
   // IWYU: IndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
   (void) dor_ptr->a;
+
+  // Nested name testing
+  IndirectStruct3ProvidingTypedef::IndirectClassProvidingTypedef pp;
+  // IWYU: IndirectClass is...*indirect.h
+  IndirectStruct4ProvidingTypedef::IndirectClassNonProvidingTypedef pn;
+  // IWYU: IndirectStruct3 is...*iwyu_stricter_than_cpp-i3.h
+  IndirectStruct3NonProvidingTypedef::IndirectClassProvidingTypedef np;
+  // IWYU: IndirectStruct4 is...*iwyu_stricter_than_cpp-i4.h
+  // IWYU: IndirectClass is...*indirect.h
+  IndirectStruct4NonProvidingTypedef::IndirectClassNonProvidingTypedef nn;
 
   // TODO(csilvers): test template types where we need some (but not
   // all) of the template args as well.
@@ -114,6 +126,16 @@ void TestTypeAliases() {
   // ...at least until we dereference the pointer
   // IWYU: IndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
   (void) dor_ptr->a;
+
+  // Nested name testing
+  IndirectStruct3ProvidingAl::IndirectClassProvidingAl pp;
+  // IWYU: IndirectClass is...*indirect.h
+  IndirectStruct4ProvidingAl::IndirectClassNonProvidingAl pn;
+  // IWYU: IndirectStruct3 is...*iwyu_stricter_than_cpp-i3.h
+  IndirectStruct3NonProvidingAl::IndirectClassProvidingAl np;
+  // IWYU: IndirectStruct4 is...*iwyu_stricter_than_cpp-i4.h
+  // IWYU: IndirectClass is...*indirect.h
+  IndirectStruct4NonProvidingAl::IndirectClassNonProvidingAl nn;
 }
 
 void TestAutocast() {
@@ -176,7 +198,10 @@ void TestFunctionReturn() {
 /**** IWYU_SUMMARY
 
 tests/cxx/iwyu_stricter_than_cpp.cc should add these lines:
+#include "tests/cxx/indirect.h"
 #include "tests/cxx/iwyu_stricter_than_cpp-i2.h"
+#include "tests/cxx/iwyu_stricter_than_cpp-i3.h"
+#include "tests/cxx/iwyu_stricter_than_cpp-i4.h"
 struct DirectStruct1;
 struct DirectStruct2;
 struct IndirectStruct1;
@@ -187,15 +212,20 @@ template <typename T> struct TplIndirectStruct1;
 template <typename T> struct TplIndirectStructForwardDeclaredInD1;
 
 tests/cxx/iwyu_stricter_than_cpp.cc should remove these lines:
+- #include "tests/cxx/direct.h"  // lines XX-XX
 - #include "tests/cxx/iwyu_stricter_than_cpp-autocast2.h"  // lines XX-XX
 - #include "tests/cxx/iwyu_stricter_than_cpp-d2.h"  // lines XX-XX
 
 The full include-list for tests/cxx/iwyu_stricter_than_cpp.cc:
+#include "tests/cxx/indirect.h"  // for IndirectClass
 #include "tests/cxx/iwyu_stricter_than_cpp-autocast.h"  // for Fn, TplFn
+#include "tests/cxx/iwyu_stricter_than_cpp-d3.h"  // for IndirectStruct3ProvidingAl, IndirectStruct3ProvidingTypedef, IndirectStruct4ProvidingAl, IndirectStruct4ProvidingTypedef
 #include "tests/cxx/iwyu_stricter_than_cpp-fnreturn.h"  // for DoesEverythingRightFn, DoesNotForwardDeclareAndIncludesFn, DoesNotForwardDeclareFn, DoesNotForwardDeclareProperlyFn, IncludesFn, TplDoesEverythingRightAgainFn, TplDoesEverythingRightFn, TplDoesNotForwardDeclareAndIncludesFn, TplDoesNotForwardDeclareFn, TplDoesNotForwardDeclareProperlyFn, TplIncludesFn
 #include "tests/cxx/iwyu_stricter_than_cpp-i2.h"  // for IndirectStruct2, TplIndirectStruct2
-#include "tests/cxx/iwyu_stricter_than_cpp-type_alias.h"  // for DoesEverythingRightAl, DoesNotForwardDeclareAl, DoesNotForwardDeclareAndIncludesAl, DoesNotForwardDeclareProperlyAl, IncludesAl, TplDoesEverythingRightAgainAl, TplDoesEverythingRightAl, TplDoesNotForwardDeclareAl, TplDoesNotForwardDeclareAndIncludesAl, TplDoesNotForwardDeclareProperlyAl, TplIncludesAl
-#include "tests/cxx/iwyu_stricter_than_cpp-typedefs.h"  // for DoesEverythingRight, DoesNotForwardDeclare, DoesNotForwardDeclareAndIncludes, DoesNotForwardDeclareProperly, Includes, TplDoesEverythingRight, TplDoesEverythingRightAgain, TplDoesNotForwardDeclare, TplDoesNotForwardDeclareAndIncludes, TplDoesNotForwardDeclareProperly, TplIncludes
+#include "tests/cxx/iwyu_stricter_than_cpp-i3.h"  // for IndirectStruct3
+#include "tests/cxx/iwyu_stricter_than_cpp-i4.h"  // for IndirectStruct4
+#include "tests/cxx/iwyu_stricter_than_cpp-type_alias.h"  // for DoesEverythingRightAl, DoesNotForwardDeclareAl, DoesNotForwardDeclareAndIncludesAl, DoesNotForwardDeclareProperlyAl, IncludesAl, IndirectStruct3NonProvidingAl, IndirectStruct4NonProvidingAl, TplDoesEverythingRightAgainAl, TplDoesEverythingRightAl, TplDoesNotForwardDeclareAl, TplDoesNotForwardDeclareAndIncludesAl, TplDoesNotForwardDeclareProperlyAl, TplIncludesAl
+#include "tests/cxx/iwyu_stricter_than_cpp-typedefs.h"  // for DoesEverythingRight, DoesNotForwardDeclare, DoesNotForwardDeclareAndIncludes, DoesNotForwardDeclareProperly, Includes, IndirectStruct3NonProvidingTypedef, IndirectStruct4NonProvidingTypedef, TplDoesEverythingRight, TplDoesEverythingRightAgain, TplDoesNotForwardDeclare, TplDoesNotForwardDeclareAndIncludes, TplDoesNotForwardDeclareProperly, TplIncludes
 struct DirectStruct1;
 struct DirectStruct2;
 struct IndirectStruct1;

--- a/tests/cxx/iwyu_stricter_than_cpp.cc
+++ b/tests/cxx/iwyu_stricter_than_cpp.cc
@@ -79,7 +79,7 @@ void TestTypedefs() {
   TplDoesEverythingRightAgain* tdora_ptr = 0;
   // ...at least until we dereference the pointer
   // IWYU: IndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
-  (void) dor_ptr->a;
+  (void)dor_ptr->a;
 
   // Nested name testing
   IndirectStruct3ProvidingTypedef::IndirectClassProvidingTypedef pp;
@@ -125,7 +125,7 @@ void TestTypeAliases() {
   TplDoesEverythingRightAgainAl* tdora_ptr = 0;
   // ...at least until we dereference the pointer
   // IWYU: IndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
-  (void) dor_ptr->a;
+  (void)dor_ptr->a;
 
   // Nested name testing
   IndirectStruct3ProvidingAl::IndirectClassProvidingAl pp;
@@ -193,7 +193,6 @@ void TestFunctionReturn() {
   // IWYU: TplIndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
   const TplIndirectStruct2<float>& tis2b = TplDoesEverythingRightAgainFn();
 }
-
 
 /**** IWYU_SUMMARY
 

--- a/tests/cxx/typedef_chain_no_follow.cc
+++ b/tests/cxx/typedef_chain_no_follow.cc
@@ -48,7 +48,7 @@ tests/cxx/typedef_chain_no_follow.cc should remove these lines:
 
 The full include-list for tests/cxx/typedef_chain_no_follow.cc:
 #include "tests/cxx/typedef_chain_no_follow-d1.h"  // for TypedefChainTypedef
-#include "tests/cxx/typedef_chain_no_follow-d2.h"  // for NonContainer1, NonContainer1::value_type
-#include "tests/cxx/typedef_chain_no_follow-d3.h"  // for NonContainer2, NonContainer2::value_type
+#include "tests/cxx/typedef_chain_no_follow-d2.h"  // for NonContainer1
+#include "tests/cxx/typedef_chain_no_follow-d3.h"  // for NonContainer2
 
 ***** IWYU_SUMMARY */


### PR DESCRIPTION
- Don't redundantly report all class/struct/union member uses, not only methods.
- Obsolete code removed, which led to ignoring typedef-prefixed names.
In fact, typedef-defining files may or may not provide full aliased type info. This change fixes a bug with absense of reporting a type under a nested typedef, enclosing class of which is referred to with another typedef (test case added).

Besides visual noise suppression and bugfix, these changes are needed for further improving of typedef handling. (I intend to make a PR after this one).