### PR TITLE
Minor improvements to man page formatting

### DIFF
--- a/include-what-you-use.1
+++ b/include-what-you-use.1
@@ -47,17 +47,17 @@ This flag may be specified multiple times to specify multiple glob patterns.
 .B \-\-cxx17ns
 Suggest the more concise syntax for nested namespaces introduced in C++17.
 .TP
-.BI \-\-error [=N]
+.BR \-\-error [ =\fIN ]
 Exit with error code
 .IR N
 (defaults to 1 if omitted) if there are \(lqinclude-what-you-use\(rq
 violations.
 .TP
-.BI \-\-error_always [=N]
+.BR \-\-error_always [ =\fIN ]
 Exit with error code
 .IR N
 (defaults to 1 if omitted) whether there are \(lqinclude-what-you-use\(rq
-violations or not (for use with \fBmake(1)\fR).
+violations or not (for use with \fBmake\fR(1)).
 .TP
 .BI \-\-keep= glob
 Always keep the includes matched by
@@ -132,8 +132,7 @@ exits with zero exit code unless there's a critical error, but
 or
 .B \-\-error_always
 can be used to customize the exit code depending on invoker expectations.
-See
-.IR EXAMPLE\fR.
+For an example see below.
 
 .SH MAPPING FILES
 Sometimes headers are not meant to be included directly,
@@ -272,7 +271,9 @@ make \-k CXX=include-what-you-use CXXFLAGS="-Xiwyu --error_always"
 .EE
 .RE
 .PP
-With \fB-Xiwyu --error_always\fR the program always exits with an error code, so
+With
+.B -Xiwyu --error_always
+the program always exits with an error code, so
 the build system knows that it didn't build an object file. Hence the need for
 .BR -k .
 It only analyzes source files built by


### PR DESCRIPTION
In [=N] only N is a non-terminal, the = is a terminal and [] is neither.
When referring to another man page, only the name should be bold, not
the number in parentheses.

For referring to the example we don't need special fonts. The order and
naming of sections in a man page is standardized and examples are always
under this heading towards the end.