### PR TITLE
Forward-declaration suggestions for enumerations

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -1246,7 +1246,7 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
              << "'. Looking for fwd-decl hint...\n";
 
     const NamedDecl* fwd_decl = nullptr;
-    for (const NamedDecl* redecl : GetClassRedecls(decl)) {
+    for (const NamedDecl* redecl : GetTagRedecls(decl)) {
       if (GetFileEntry(redecl) == macro_def_file && IsForwardDecl(redecl)) {
         fwd_decl = redecl;
         break;
@@ -1346,9 +1346,9 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
     // If we're a template specialization, we also accept
     // forward-declarations of the underlying template (vector<T>, not
     // vector<int>).
-    set<const NamedDecl*> redecls = GetClassRedecls(decl);
+    set<const NamedDecl*> redecls = GetTagRedecls(decl);
     if (const ClassTemplateSpecializationDecl* spec_decl = DynCastFrom(decl)) {
-      InsertAllInto(GetClassRedecls(spec_decl->getSpecializedTemplate()),
+      InsertAllInto(GetTagRedecls(spec_decl->getSpecializedTemplate()),
                     &redecls);
     }
 
@@ -1368,7 +1368,7 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
     // semantics we want.  Note if there's no definition anywhere, we
     // say the author does not want the full type (which is a good
     // thing, since there isn't one!)
-    if (const NamedDecl* dfn = GetDefinitionForClass(decl)) {
+    if (const NamedDecl* dfn = GetTagDefinition(decl)) {
       if (IsBeforeInSameFile(dfn, use_loc))
         return false;
       if (preprocessor_info().PublicHeaderIntendsToProvide(
@@ -3819,7 +3819,7 @@ class IwyuAstConsumer
       // enclosing class.  If the nested class is actually defined in
       // the enclosing class, then we're fine; if not, we need to keep
       // the first forward-declaration.
-      } else if (IsNestedClassAsWritten(current_ast_node())) {
+      } else if (IsNestedTagAsWritten(current_ast_node())) {
         if (!decl->getDefinition() || decl->getDefinition()->isOutOfLine()) {
           // TODO(kimgr): Member class redeclarations are illegal, per C++
           // standard DR85, so this check for first redecl can be removed.

--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -1346,6 +1346,10 @@ map<const clang::Type*, const clang::Type*> GetTplTypeResugarMapForClass(
       GetTplTypeResugarMapForClassNoComponentTypes(type));
 }
 
+bool CanBeOpaqueDeclared(const clang::EnumType* type) {
+  return type->getDecl()->isFixed();
+}
+
 // --- Utilities for Stmt.
 
 bool IsAddressOf(const Expr* expr) {

--- a/iwyu_ast_util.h
+++ b/iwyu_ast_util.h
@@ -772,6 +772,12 @@ map<const clang::Type*, const clang::Type*> GetTplTypeResugarMapForClass(
 map<const clang::Type*, const clang::Type*>
 GetTplTypeResugarMapForClassNoComponentTypes(const clang::Type* type);
 
+// Returns true if, for the given enumeration type, opaque (i.e. forward,
+// in fact) declarations are allowed. It means that the enumeration should be
+// either scoped or unscoped with explicitly stated underlying type,
+// according to the standard.
+bool CanBeOpaqueDeclared(const clang::EnumType* type);
+
 // --- Utilities for Stmt.
 
 // Returns true if the given expr is '&<something>'.

--- a/iwyu_ast_util.h
+++ b/iwyu_ast_util.h
@@ -390,11 +390,11 @@ bool IsNodeInsideCXXMethodBody(const ASTNode* ast_node);
 // These flags provide context around the use to help later IWYU analysis,
 UseFlags ComputeUseFlags(const ASTNode* ast_node);
 
-// Return true if we're a nested class as written, that is, we're a
-// class decl inside another class decl.  The parent class may be
+// Return true if we're a nested tag type as written, that is, we're a
+// class or enum decl inside another class decl.  The parent class may be
 // templated, but we should not be.  (We could extend the function to
 // handle that case, but there's been no need yet.)
-bool IsNestedClassAsWritten(const ASTNode* ast_node);
+bool IsNestedTagAsWritten(const ASTNode* ast_node);
 
 // Is ast_node the 'D' in the following:
 //    template<template <typename A> class T = D> class C { ... }
@@ -496,9 +496,9 @@ bool HasImplicitConversionCtor(const clang::CXXRecordDecl* cxx_class);
 // compared to its base.
 bool HasCovariantReturnType(const clang::CXXMethodDecl* method_decl);
 
-// If this decl is a (possibly templatized) class, return the decl
+// If this decl is a (possibly templatized) tag decl, return the decl
 // that defines the class, if present.  Otherwise return nullptr.
-const clang::RecordDecl* GetDefinitionForClass(const clang::Decl* decl);
+const clang::TagDecl* GetTagDefinition(const clang::Decl* decl);
 
 // Given a class, returns a SourceRange that encompasses the beginning
 // of the class declaration (including template<> prefix, etc) to the
@@ -596,7 +596,7 @@ bool IsInInlineNamespace(const clang::Decl* decl);
 bool IsForwardDecl(const clang::NamedDecl* decl);
 
 // Returns true if this decl is defined inside another class/struct.
-// Unlike IsNestedClassAsWritten(), which works on an ASTNode, this
+// Unlike IsNestedTagAsWritten(), which works on an ASTNode, this
 // function considers decl to be nested even if it's not syntactically
 // written inside its outer class (that is, 'class Foo::Bar {...}' is
 // considered nested, even though it's not written inside Foo).
@@ -612,20 +612,20 @@ bool HasDefaultTemplateParameters(const clang::TemplateDecl* decl);
 // treats classes different from other redeclarable types, it has
 // its own separate function.  (If that proves to be annoying, we
 // can merge them.)
-set<const clang::NamedDecl*> GetNonclassRedecls(const clang::NamedDecl* decl);
+set<const clang::NamedDecl*> GetNonTagRedecls(const clang::NamedDecl* decl);
 
 // Given a class, returns a set of all declarations of that class
 // (forward-declarations and, if present, the definition).  This
-// accepts both RecordDecls and ClassTemplateDecls -- the return Decls
+// accepts both TagDecls and ClassTemplateDecls -- the return Decls
 // are guaranteed to be of the same type as the input Decl.  Returns
-// the empty set if the input is not a RecordDecl or
-// ClassTemplateDecl.  Otherwise, always returns at least one element
-// (since the input decl is its own redecl).
-set<const clang::NamedDecl*> GetClassRedecls(const clang::NamedDecl* decl);
+// the empty set if the input is not a TagDecl or ClassTemplateDecl.
+// Otherwise, always returns at least one element (since the input
+// decl is its own redecl).
+set<const clang::NamedDecl*> GetTagRedecls(const clang::NamedDecl* decl);
 
 // Returns the redecl of decl that occurs first in the translation
 // unit (that is, is the first one you'd see if you did 'cc -E').
-// Returns nullptr if the input is not a RecordDecl or ClassTemplateDecl.
+// Returns nullptr if the input is not a TagDecl or ClassTemplateDecl.
 const clang::NamedDecl* GetFirstRedecl(const clang::NamedDecl* decl);
 
 // Given a class or class template, returns the declaration of that
@@ -634,7 +634,7 @@ const clang::NamedDecl* GetFirstRedecl(const clang::NamedDecl* decl);
 const clang::ClassTemplateDecl* GetClassRedeclSpecifyingDefaultTplArgs(
     const clang::ClassTemplateDecl* decl);
 
-// Picks one redecl from GetClassRedecls() arbitrarily.
+// Picks one redecl from GetTagRedecls() arbitrarily.
 // This is used to recover from the clang bug that mixes friend decls
 // with 'real' redecls (http://llvm.org/bugs/show_bug.cgi?id=8669);
 // this function returns a 'real' redecl.  If the input decl is a

--- a/tests/c/enum-direct.h
+++ b/tests/c/enum-direct.h
@@ -1,0 +1,10 @@
+//===--- enum-direct.h - test input file for iwyu -------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/c/enum-indirect.h"

--- a/tests/c/enum-indirect.h
+++ b/tests/c/enum-indirect.h
@@ -1,0 +1,10 @@
+//===--- enum-indirect.h - test input file for iwyu -----------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+enum Enum { A, B, C };

--- a/tests/c/enum.c
+++ b/tests/c/enum.c
@@ -1,0 +1,30 @@
+//===--- enum.c - test input file for iwyu --------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_ARGS: -I .
+
+// Test that IWYU doesn't suggest to forward-declare C-style enumeration.
+
+#include "tests/c/enum-direct.h"
+
+// IWYU: Enum is...*enum-indirect.h
+enum Enum e;
+
+/**** IWYU_SUMMARY
+
+tests/c/enum.c should add these lines:
+#include "tests/c/enum-indirect.h"
+
+tests/c/enum.c should remove these lines:
+- #include "tests/c/enum-direct.h"  // lines XX-XX
+
+The full include-list for tests/c/enum.c:
+#include "tests/c/enum-indirect.h"  // for Enum
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/badinc.cc
+++ b/tests/cxx/badinc.cc
@@ -293,19 +293,17 @@ struct Cc_DeclOrderStruct {
 };
 
 // IWYU: I1_Enum is...*badinc-i1.h
-// IWYU: I11 is...*badinc-i1.h
 template<class T, I1_Enum E = I11> struct Cc_TemplateStruct { };
 // IWYU: I1_Enum is...*badinc-i1.h
 // IWYU: I1_Class needs a declaration
 // IWYU: I1_Class is...*badinc-i1.h
 template<I1_Enum E> struct Cc_TemplateStruct<I1_Class, E> { I1_Class i; };
 // IWYU: I1_Class needs a declaration
-// IWYU: I12 is...*badinc-i1.h
+// IWYU: I1_Enum is...*badinc-i1.h
 template<> struct Cc_TemplateStruct<I1_Class, I12> { I1_Class* i; };
 // TODO(csilvers): I1_Class is technically forward-declarable.
 // IWYU: I1_Class is...*badinc-i1.h
 // IWYU: I1_Enum is...*badinc-i1.h
-// IWYU: I11 is...*badinc-i1.h
 template<class T = I1_Class, I1_Enum E = I11> class Cc_DeclareOnlyTemplateClass;
 
 // I2_Class has a non-explicit constructor (actually, two), so we need
@@ -342,11 +340,11 @@ const I2_Class& Cc_Function(
 // IWYU: I1_Enum is...*badinc-i1.h
 template<class T, I1_Enum E> int Cc_TemplateFunction() { return T().a(); }
 // IWYU: I1_Class needs a declaration
-// IWYU: I12 is...*badinc-i1.h
+// IWYU: I1_Enum is...*badinc-i1.h
 template<> int Cc_TemplateFunction<I1_Class, I12>() { return 3; }
 // IWYU: I1_Class needs a declaration
 // IWYU: I1_Class is...*badinc-i1.h
-// IWYU: I13 is...*badinc-i1.h
+// IWYU: I1_Enum is...*badinc-i1.h
 template<> int Cc_TemplateFunction<I1_Class, I13>() { return I1_Class().a(); }
 // IWYU: I1_Enum is...*badinc-i1.h
 template<class T, I1_Enum E> T Cc_DeclareOnlyTemplateFunction();
@@ -457,7 +455,6 @@ struct Cc_ImplicitDestructorStruct {
 // IWYU: EmptyDestructorClass is...*badinc-i1.h
 EmptyDestructorClass::~EmptyDestructorClass() { }
 // IWYU: I2_Enum is...*badinc-i2.h
-// IWYU: I22 is...*badinc-i2.h
 I2_Enum H_Class::ff_ = I22;
 // IWYU: I2_Enum is...*badinc-i2.h
 int H_Class::f(I2_Enum i2_enum) { return 1; }
@@ -557,13 +554,12 @@ Cc_Subclass cc_subclass;
 MultipleInheritanceSubclass cc_multipleinheritancesubclass;
 // IWYU: I1_Class needs a declaration
 // IWYU: I1_Class is...*badinc-i1.h
-// IWYU: I11 is...*badinc-i1.h
+// IWYU: I1_Enum is...*badinc-i1.h
 int cc_template_function_val = Cc_TemplateFunction<I1_Class, I11>();
 int cc_tricky_template_function_val =
     // IWYU: I1_Class needs a declaration
     // IWYU: kI1ConstInt is...*badinc-i1.h
-    // IWYU: I12 is...*badinc-i1.h
-    // IWYU: I13 is...*badinc-i1.h
+    // IWYU: I1_Enum is...*badinc-i1.h
     Cc_TemplateFunction<I1_Class, kI1ConstInt == 4 ? I12 : I13>();  // is I13
 // IWYU: I1_Class needs a declaration
 // IWYU: I1_Class is...*badinc-i1.h
@@ -592,7 +588,6 @@ H_Class h_class2(2);
 H_StructPtr h_structptr;
 H_TemplateClass<H_Enum> h_templateclass1(H1);
 // IWYU: I1_Enum is...*badinc-i1.h
-// IWYU: I11 is...*badinc-i1.h
 H_TemplateClass<I1_Enum> h_templateclass2(I11);
 // IWYU: I1_Struct needs a declaration
 H_TemplateStruct<I1_Struct> h_template_struct;
@@ -639,7 +634,6 @@ InlH_FunctionPtr inlh_functionptr = InlH_Function();  // badinc-inl.h
 D1_Class d1_class;       // badinc-d1.h
 D1_TemplateClass<D1_Enum> d1_templateclass1(D11);
 // IWYU: I2_Enum is...*badinc-i2.h
-// IWYU: I2_LAST is...*badinc-i2.h
 D1_TemplateClass<I2_Enum> d1_templateclass2(I2_LAST);
 // IWYU: I2_Enum is...*badinc-i2.h
 D1_TemplateClass<I2_Enum> *d1_templateclass2_ptr;
@@ -718,7 +712,6 @@ I1_Base *i1_base_ptr;
 // the I1_TemplateClass<I1_Enum> object, and once in the constructor.
 // IWYU: I1_TemplateClass is...*badinc-i1.h
 // IWYU: I1_Enum is...*badinc-i1.h
-// IWYU: I11 is...*badinc-i1.h
 I1_TemplateClass<I1_Enum> i1_templateclass(I11);
 // IWYU: I1_TemplateClass is...*badinc-i1.h
 I1_TemplateClass<int> i1_templateclass2(10);
@@ -1072,10 +1065,8 @@ int main() {
   Cc_string local_cc_string;
   H_Class local_h_class;
   // IWYU: I2_Enum is...*badinc-i2.h
-  // IWYU: I21 is...*badinc-i2.h
   D1_TemplateClass<I2_Enum> local_d1_template_class(I21);
   // IWYU: I1_Enum is...*badinc-i1.h
-  // IWYU: I11 is...*badinc-i1.h
   I1_Enum local_i1_enum = I11;
   // IWYU: I1_UnnamedStruct is...*badinc-i1.h
   I1_UnnamedStruct local_i1_unnamed_struct = {};
@@ -1102,7 +1093,7 @@ int main() {
   isascii('a');   // declared in <ctype.h> which is #included by badinc.h
   (void)(errno);  // declared in <errno.h> which is #included by badinc.h
   // Test we don't give an iwyu warning for the built-in __builtin_expect
-  // IWYU: I11 is...*badinc-i1.h
+  // IWYU: I1_Enum is...*badinc-i1.h
   if (__builtin_expect(local_i1_enum == I11, false)) (void)local_i1_enum;
 
   // IWYU: i1_int_global is...*badinc-i1.h
@@ -1367,7 +1358,7 @@ int main() {
   (*h_scoped_ptr).a();
   // IWYU: I1_Class is...*badinc-i1.h
   h_scoped_ptr->a();
-  // IWYU: I12 is...*badinc-i1.h
+  // IWYU: I1_Enum is...*badinc-i1.h
   D1Function(I12);
   // TODO(csilvers): should we be warning about I2_Struct?
   // IWYU: I1_Union is...*badinc-i1.h
@@ -1509,7 +1500,6 @@ int main() {
   std::vector<I2_Enum> local_enum_vector;
   // IWYU: I2_Enum is...*badinc-i2.h
   // IWYU: std::vector is...*<vector>
-  // IWYU: I21 is...*badinc-i2.h
   local_enum_vector.push_back(I21);
   // IWYU: std::vector is...*<vector>
   // IWYU: I2_Enum is...*badinc-i2.h
@@ -1764,26 +1754,25 @@ int main() {
 
   // Test templatized functions.
   H_TemplateFunction(1);
-  // IWYU: I11 is...*badinc-i1.h
   // IWYU: I1_Enum is...*badinc-i1.h
   H_TemplateFunction(I11);
-  // IWYU: I11 is...*badinc-i1.h
+  // IWYU: I1_Enum is...*badinc-i1.h
   H_TemplateFunction<int>(I11);
   // IWYU: I1_Class needs a declaration
   H_TemplateFunction<I1_Class*>(&i1_class);
   H_TemplateFunction(&i1_class);
-  // IWYU: I22 is...*badinc-i2.h
+  // IWYU: I2_Enum is...*badinc-i2.h
   // IWYU: I1_Enum is...*badinc-i1.h
   h_templateclass2.static_out_of_line(I22);
-  // IWYU: I22 is...*badinc-i2.h
+  // IWYU: I2_Enum is...*badinc-i2.h
   // IWYU: I1_Enum is...*badinc-i1.h
   h_templateclass2.static_inline(I22);
-  // IWYU: I22 is...*badinc-i2.h
+  // IWYU: I2_Enum is...*badinc-i2.h
   h_templateclass2.h_nested_struct.tplnested(I22);
   // TODO: I1_Enum should be reported here as a full use but isn't,
   // because we are not properly handling the dependent type FOO in
   // the nested struct.
-  // IWYU: I22 is...*badinc-i2.h
+  // IWYU: I2_Enum is...*badinc-i2.h
   h_templateclass2.h_nested_struct.static_tplnested(I22);
   // This should not cause warnings for the i2_class destructor
   h_templateclass2.uses_i2class();
@@ -1813,9 +1802,9 @@ int main() {
   I1_Class::I1_StaticClassTemplateFunction<I1_Struct*>(&i1_struct);
 
   // Test default (compiler-defined) copy constructor/operator=/operator==
-  // IWYU: I11 is...*badinc-i1.h
+  // IWYU: I1_Enum is...*badinc-i1.h
   D1_CopyClass local_d1_copy_class(D1CopyClassFn(I11));
-  // IWYU: I12 is...*badinc-i1.h
+  // IWYU: I1_Enum is...*badinc-i1.h
   local_d1_copy_class = D1CopyClassFn(I12);
   local_d1_copy_class.a();
 
@@ -1875,9 +1864,9 @@ The full include-list for tests/cxx/badinc.cc:
 #include <list>  // for list
 #include <string>  // for basic_string, operator+, string
 #include <typeinfo>  // for type_info
-#include "tests/cxx/badinc-d1.h"  // for D11, D1CopyClassFn, D1Function, D1_Class, D1_CopyClass, D1_Enum, D1_I1_Typedef, D1_StructPtr, D1_Subclass, D1_TemplateClass, D1_TemplateStructWithDefaultParam, MACRO_CALLING_I4_FUNCTION
+#include "tests/cxx/badinc-d1.h"  // for D1CopyClassFn, D1Function, D1_Class, D1_CopyClass, D1_Enum, D1_I1_Typedef, D1_StructPtr, D1_Subclass, D1_TemplateClass, D1_TemplateStructWithDefaultParam, MACRO_CALLING_I4_FUNCTION
 #include "tests/cxx/badinc-d4.h"  // for D4_ClassForOperator, operator<<
-#include "tests/cxx/badinc-i1.h"  // for EmptyDestructorClass, H_Class::H_Class_DefinedInI1, I11, I12, I13, I1_And_I2_OverloadedFunction, I1_Base, I1_Class, I1_ClassPtr, I1_Enum, I1_Function, I1_FunctionPtr, I1_I2_Class_Typedef, I1_MACRO_LOGGING_CLASS, I1_MACRO_SYMBOL_WITHOUT_VALUE, I1_MACRO_SYMBOL_WITH_VALUE, I1_MACRO_SYMBOL_WITH_VALUE0, I1_MACRO_SYMBOL_WITH_VALUE2, I1_ManyPtrStruct (ptr only), I1_MemberPtr, I1_NamespaceClass, I1_NamespaceStruct, I1_NamespaceTemplateFn, I1_OverloadedFunction, I1_PtrAndUseOnSameLine, I1_PtrDereferenceClass, I1_PtrDereferenceStatic, I1_PtrDereferenceStruct, I1_SiblingClass, I1_StaticMethod, I1_Struct, I1_Subclass, I1_SubclassesI2Class, I1_TemplateClass, I1_TemplateClassFwdDeclaredInD2 (ptr only), I1_TemplateFunction, I1_TemplateMethodOnlyClass, I1_TemplateSubclass, I1_Typedef, I1_TypedefOnly_Class, I1_Union, I1_UnnamedStruct, I1_UnusedNamespaceStruct (ptr only), I1_const_ptr, I2_OperatorDefinedInI1Class::operator<<, MACRO_CALLING_I6_FUNCTION, OperateOn, i1_GlobalFunction, i1_int, i1_int_global, i1_int_global2, i1_int_global2sub, i1_int_global3, i1_int_global3sub, i1_int_global4, i1_int_global4sub, i1_int_globalsub, i1_ns2, i1_ns4, i1_ns5, kI1ConstInt, operator==
+#include "tests/cxx/badinc-i1.h"  // for EmptyDestructorClass, H_Class::H_Class_DefinedInI1, I1_And_I2_OverloadedFunction, I1_Base, I1_Class, I1_ClassPtr, I1_Enum, I1_Function, I1_FunctionPtr, I1_I2_Class_Typedef, I1_MACRO_LOGGING_CLASS, I1_MACRO_SYMBOL_WITHOUT_VALUE, I1_MACRO_SYMBOL_WITH_VALUE, I1_MACRO_SYMBOL_WITH_VALUE0, I1_MACRO_SYMBOL_WITH_VALUE2, I1_ManyPtrStruct (ptr only), I1_MemberPtr, I1_NamespaceClass, I1_NamespaceStruct, I1_NamespaceTemplateFn, I1_OverloadedFunction, I1_PtrAndUseOnSameLine, I1_PtrDereferenceClass, I1_PtrDereferenceStatic, I1_PtrDereferenceStruct, I1_SiblingClass, I1_StaticMethod, I1_Struct, I1_Subclass, I1_SubclassesI2Class, I1_TemplateClass, I1_TemplateClassFwdDeclaredInD2 (ptr only), I1_TemplateFunction, I1_TemplateMethodOnlyClass, I1_TemplateSubclass, I1_Typedef, I1_TypedefOnly_Class, I1_Union, I1_UnnamedStruct, I1_UnusedNamespaceStruct (ptr only), I1_const_ptr, I2_OperatorDefinedInI1Class::operator<<, MACRO_CALLING_I6_FUNCTION, OperateOn, i1_GlobalFunction, i1_int, i1_int_global, i1_int_global2, i1_int_global2sub, i1_int_global3, i1_int_global3sub, i1_int_global4, i1_int_global4sub, i1_int_globalsub, i1_ns2, i1_ns4, i1_ns5, kI1ConstInt, operator==
 #include "tests/cxx/badinc2.c"
 class D2_Class;
 class D2_ForwardDeclareClass;

--- a/tests/cxx/badinc.cc
+++ b/tests/cxx/badinc.cc
@@ -1547,7 +1547,7 @@ int main() {
   // IWYU: I1_Class is...*badinc-i1.h
   // IWYU: kI1ConstInt is...*badinc-i1.h
   I1_Class* newed_i1_class_array = new I1_Class[kI1ConstInt];
-  // TODO(csilvers): IWYU: I2_Enum is...*badinc-i2.h
+  // IWYU: I2_Enum is...*badinc-i2.h
   // IWYU: std::vector is...*<vector>
   delete newed_vector;
   // IWYU: I1_Class is...*badinc-i1.h

--- a/tests/cxx/badinc.h
+++ b/tests/cxx/badinc.h
@@ -126,9 +126,9 @@ class H_Class {
     if (q.empty()) return s.length();
     // IWYU: I2_Enum is...*badinc-i2.h
     switch (static_cast<I2_Enum>(a_)) {
-      // IWYU: I21 is...*badinc-i2.h
+      // IWYU: I2_Enum is...*badinc-i2.h
       case I21: return 21;
-        // IWYU: I22 is...*badinc-i2.h
+        // IWYU: I2_Enum is...*badinc-i2.h
       case I22: return 22;
       default: return errno;
     }
@@ -178,7 +178,6 @@ class H_Class {
   H_Class(const H_Class&);
 };
 // IWYU: I2_Enum is...*badinc-i2.h
-// IWYU: I21 is...*badinc-i2.h
 I2_Enum H_Class::ee_ = I21;
 
 template<typename FOO>
@@ -237,7 +236,6 @@ class H_TemplateClass {
   H_TemplateClass(const H_TemplateClass&);
 };
 // IWYU: I2_Enum is...*badinc-i2.h
-// IWYU: I21 is...*badinc-i2.h
 template<typename FOO> I2_Enum H_TemplateClass<FOO>::h_template_i2_static_ = I21;
 H_TemplateClass<int>* h_templateclass_var;
 
@@ -251,7 +249,6 @@ class H_TemplateTemplateClass {
   // TODO(csilvers): attribute this use here, not at the caller sites.
   // TODO(csilvers): IWYU: I2_TemplateClass::~I2_TemplateClass<.*> is...*badinc-i2-inl.h
   // IWYU: I2_Enum is...*badinc-i2.h
-  // IWYU: I21 is...*badinc-i2.h
   H_TemplateTemplateClass() : t(T<I2_Enum>(I21)) {}
   // IWYU: I2_Enum is...*badinc-i2.h
   T<I2_Enum> t;
@@ -313,7 +310,7 @@ H_Enum H_Function(H_Class* c) {
 // IWYU: I2_Class needs a declaration
 // IWYU: I2_Enum is...*badinc-i2.h
 I2_Enum H_Function_I(I2_Class*) {
-  // IWYU: I21 is...*badinc-i2.h
+  // IWYU: I2_Enum is...*badinc-i2.h
   return I21;
 }
 
@@ -366,7 +363,6 @@ H_Enum h_h_enum;
 I2_Class h_i2_class;
 H_TemplateClass<D3_Enum> h_d3_template_class(D31);
 // IWYU: I2_Enum is...*badinc-i2.h
-// IWYU: I22 is...*badinc-i2.h
 H_TemplateClass<I2_Enum> h_i2_template_class(I22);
 // TODO(csilvers): this should be attributed to the .h, since it comes
 // via a default template argument.
@@ -400,9 +396,9 @@ The full include-list for tests/cxx/badinc.h:
 #include <set>  // for set
 #include <string>  // for string
 #include <vector>  // for vector
-#include "tests/cxx/badinc-d3.h"  // for D31, D3_Enum
+#include "tests/cxx/badinc-d3.h"  // for D3_Enum
 #include "tests/cxx/badinc-i2-inl.h"  // for I2_Class::I2_Class, I2_Class::InlFileFn, I2_Class::InlFileStaticFn, I2_Class::InlFileTemplateFn, I2_Class::~I2_Class, I2_TemplateClass::I2_TemplateClass<FOO>, I2_TemplateClass::InlFileTemplateClassFn, I2_TemplateClass::~I2_TemplateClass<FOO>
-#include "tests/cxx/badinc-i2.h"  // for I21, I22, I2_Class, I2_Enum, I2_EnumForTypedefs, I2_MACRO, I2_Struct, I2_TemplateClass, I2_Typedef, I2_TypedefOnly_Class (ptr only), TemplateForHClassTplFn (ptr only)
+#include "tests/cxx/badinc-i2.h"  // for I2_Class, I2_Enum, I2_EnumForTypedefs, I2_MACRO, I2_Struct, I2_TemplateClass, I2_Typedef, I2_TypedefOnly_Class (ptr only), TemplateForHClassTplFn (ptr only)
 class Cc_Class;  // lines XX-XX
 // TODO(csilvers): this should change to struct Cc_Struct.
 class Cc_Struct;  // lines XX-XX

--- a/tests/cxx/enums-d1.h
+++ b/tests/cxx/enums-d1.h
@@ -1,0 +1,25 @@
+//===--- enums-d1.h - test input file for iwyu ----------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/enums-i1.h"
+#include "tests/cxx/enums-i2.h"
+#include "tests/cxx/enums-i3.h"
+#include "tests/cxx/enums-i4.h"
+
+enum class DirectEnum1 { A, B, C };
+
+enum class DirectEnum2 : int { A, B, C };
+
+enum struct DirectEnum3 : unsigned long long { A, B, C };
+
+namespace ns {
+enum DirectEnum4 : int { A, B, C };
+}
+
+enum class DirectEnum5 : long { A, B, C };

--- a/tests/cxx/enums-i1.h
+++ b/tests/cxx/enums-i1.h
@@ -1,0 +1,15 @@
+//===--- enums-i1.h - test input file for iwyu ----------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_ENUMS_I1_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_ENUMS_I1_H_
+
+enum IndirectEnum1 { A, B, C };
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_ENUMS_I1_H_

--- a/tests/cxx/enums-i2.h
+++ b/tests/cxx/enums-i2.h
@@ -1,0 +1,15 @@
+//===--- enums-i2.h - test input file for iwyu ----------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_ENUMS_I2_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_ENUMS_I2_H_
+
+enum class IndirectEnum2 : int { A, B, C };
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_ENUMS_I2_H_

--- a/tests/cxx/enums-i3.h
+++ b/tests/cxx/enums-i3.h
@@ -1,0 +1,17 @@
+//===--- enums-i3.h - test input file for iwyu ----------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_ENUMS_I3_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_ENUMS_I3_H_
+
+struct Struct1 {
+  enum class IndirectEnum3 { A, B, C };
+};
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_ENUMS_I3_H_

--- a/tests/cxx/enums-i4.h
+++ b/tests/cxx/enums-i4.h
@@ -1,0 +1,15 @@
+//===--- enums-i4.h - test input file for iwyu ----------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_ENUMS_I4_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_ENUMS_I4_H_
+
+enum { UnnamedEnumItem1, UnnamedEnumItem2, UnnamedEnumItem3 };
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_ENUMS_I4_H_

--- a/tests/cxx/enums.cc
+++ b/tests/cxx/enums.cc
@@ -1,0 +1,90 @@
+//===--- enums.cc - test input file for iwyu ------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_ARGS: -I .
+
+// Test enumeration forward (opaque) declarations.
+
+#include "tests/cxx/enums-d1.h"
+
+// Test that IWYU considers this as a forward declaration
+// which should be kept.
+enum class DirectEnum5 : long;
+// Test that opaque redeclaration should not lead to ignoring
+// of IndirectEnum2::A use.
+enum class IndirectEnum2 : int;
+
+// For scoped and unscoped enums with fixed underlying type, opaque declaration
+// is sufficient.
+DirectEnum1 de1;
+DirectEnum2 de2;
+DirectEnum3 de3;
+ns::DirectEnum4 de4;
+DirectEnum5 de5;
+
+// For an unscoped enum without explicitly specified underlying type, full
+// definition is needed.
+// IWYU: IndirectEnum1 is...*enums-i1.h
+IndirectEnum1 ie1;
+// When an enum item is mentioned, full definition of the enum is needed.
+// IWYU: IndirectEnum2 is...*enums-i2.h
+IndirectEnum2 ie2 = IndirectEnum2::A;
+// In order to mention a nested enum, full type of the owning class is needed.
+// IWYU: Struct1 is...*enums-i3.h
+Struct1::IndirectEnum3 ie3;
+// For unnamed enumeration, enumerators are reported.
+// IWYU: UnnamedEnumItem2 is...*enums-i4.h
+auto ie4 = UnnamedEnumItem2;
+
+template <typename T1, typename T2>
+struct Template {
+  T1 t1;
+  T2 t2 = T2::B;
+};
+
+// Only IndirectEnum2 item is used inside Template specialization.
+// IWYU: IndirectEnum2 is...*enums-i2.h
+Template<DirectEnum1, IndirectEnum2> t;
+
+struct Struct2 {
+  // Test that IWYU doesn't suggest to remove this declaration.
+  enum class Nested;
+};
+
+enum class Struct2::Nested { A, B, C };
+
+/**** IWYU_SUMMARY
+
+tests/cxx/enums.cc should add these lines:
+#include "tests/cxx/enums-i1.h"
+#include "tests/cxx/enums-i2.h"
+#include "tests/cxx/enums-i3.h"
+#include "tests/cxx/enums-i4.h"
+enum class DirectEnum1;
+enum class DirectEnum2 : int;
+enum struct DirectEnum3 : unsigned long long;
+namespace ns { enum DirectEnum4 : int; }
+
+tests/cxx/enums.cc should remove these lines:
+- #include "tests/cxx/enums-d1.h"  // lines XX-XX
+- enum class IndirectEnum2 : int;  // lines XX-XX
+
+The full include-list for tests/cxx/enums.cc:
+#include "tests/cxx/enums-i1.h"  // for IndirectEnum1
+#include "tests/cxx/enums-i2.h"  // for IndirectEnum2
+#include "tests/cxx/enums-i3.h"  // for Struct1
+#include "tests/cxx/enums-i4.h"  // for UnnamedEnumItem2
+enum class DirectEnum1;
+enum class DirectEnum2 : int;
+enum class DirectEnum5 : long;  // lines XX-XX
+enum class Struct2::Nested;  // lines XX-XX
+enum struct DirectEnum3 : unsigned long long;
+namespace ns { enum DirectEnum4 : int; }
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/fwd_declare_enum.cc
+++ b/tests/cxx/fwd_declare_enum.cc
@@ -25,6 +25,12 @@ Bar bar;
 
 /**** IWYU_SUMMARY
 
-(tests/cxx/fwd_declare_enum.cc has correct #includes/fwd-decls)
+tests/cxx/fwd_declare_enum.cc should add these lines:
+
+tests/cxx/fwd_declare_enum.cc should remove these lines:
+- enum Bar;  // lines XX-XX
+- enum Foo;  // lines XX-XX
+
+The full include-list for tests/cxx/fwd_declare_enum.cc:
 
 ***** IWYU_SUMMARY */


### PR DESCRIPTION
Forward declarations are allowed for scoped enumerations and unscoped ones with underlying type explicitly specified. To be fully correct, they aren't "forward", but "opaque" declarations, but using of existing facilities is tempting.

Because enumerations are now treated almost similarly as classes and structs, `clang::RecordDecl` is replaced by `clang::TagDecl` in many places.

Reporting of distinct enum items is replaced by reporting of the whole enum type.