### PR TITLE
Fix autocast to reference

### DIFF
--- a/tests/cxx/iwyu_stricter_than_cpp-d2.h
+++ b/tests/cxx/iwyu_stricter_than_cpp-d2.h
@@ -21,9 +21,7 @@ void CallTwiceDeclaredFunction() {
   // IWYU: IndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
   TwiceDeclaredFunction(1);
 
-  // This *should* be exactly the same, but doesn't seem to be:
-  // clang leaves out the constructor-conversion AST node.
-  // TODO(csilvers): IWYU: IndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
+  // IWYU: IndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
   TwiceDeclaredRefFunction(1);
 }
 


### PR DESCRIPTION
CastExpr for constructor conversion is absent in the AST in such a case.