### PR TITLE
Add mappings for SYS_xxx syscall macros

### DIFF
--- a/gcc.libc.imp
+++ b/gcc.libc.imp
@@ -91,7 +91,7 @@
   { include: [ "<bits/string3.h>", private, "<string.h>", public ] },
   { include: [ "<bits/stropts.h>", private, "<stropts.h>", public ] },
   { include: [ "<bits/sys_errlist.h>", private, "<stdio.h>", public ] },
-  { include: [ "<bits/syscall.h>", private, "<sys/syscall.h>", private ] },
+  { include: [ "<bits/syscall.h>", private, "<sys/syscall.h>", public ] },
   { include: [ "<bits/sysctl.h>", private, "<sys/sysctl.h>", public ] },
   { include: [ "<bits/syslog-ldbl.h>", private, "<sys/syslog.h>", private ] },
   { include: [ "<bits/syslog-path.h>", private, "<sys/syslog.h>", private ] },
@@ -169,7 +169,6 @@
   { include: [ "<bits/string.h>", private, "<string.h>", public ] },
   { include: [ "<bits/string2.h>", private, "<string.h>", public ] },
   { include: [ "<bits/string3.h>", private, "<string.h>", public ] },
-  { include: [ "<bits/syscall.h>", private, "<sys/syscall.h>", private ] },
   { include: [ "<bits/timerfd.h>", private, "<sys/timerfd.h>", public ] },
   { include: [ "<bits/typesizes.h>", private, "<sys/types.h>", public ] },
   # Top-level #includes that just forward to another file:
@@ -180,7 +179,6 @@
   # to decide which of the two files is canonical.  If neither is
   # on the POSIX.1 1998 list, I just choose the top-level one.
   { include: [ "<sys/poll.h>", private, "<poll.h>", public ] },
-  { include: [ "<sys/syscall.h>", private, "<syscall.h>", public ] },
   { include: [ "<sys/syslog.h>", private, "<syslog.h>", public ] },
   { include: [ "<sys/ustat.h>", private, "<ustat.h>", public ] },
   { include: [ "<wait.h>", private, "<sys/wait.h>", public ] },
@@ -202,7 +200,7 @@
   { include: [ "<asm/errno.h>", private, "<errno.h>", public ] },
   { include: [ "<asm/errno-base.h>", private, "<errno.h>", public ] },
   { include: [ "<asm/ptrace-abi.h>", private, "<asm/ptrace.h>", public ] },
-  { include: [ "<asm/unistd.h>", private, "<syscall.h>", public ] },
+  { include: [ "<asm/unistd.h>", private, "<sys/syscall.h>", public ] },
   { include: [ "<linux/limits.h>", private, "<limits.h>", public ] },   # PATH_MAX
   { include: [ "<linux/prctl.h>", private, "<sys/prctl.h>", public ] },
   { include: [ "<sys/ucontext.h>", private, "<ucontext.h>", public ] },

--- a/iwyu_include_picker.cc
+++ b/iwyu_include_picker.cc
@@ -460,7 +460,7 @@ const IncludeMapEntry libc_include_map[] = {
   { "<bits/string3.h>", kPrivate, "<string.h>", kPublic },
   { "<bits/stropts.h>", kPrivate, "<stropts.h>", kPublic },
   { "<bits/sys_errlist.h>", kPrivate, "<stdio.h>", kPublic },
-  { "<bits/syscall.h>", kPrivate, "<sys/syscall.h>", kPrivate },
+  { "<bits/syscall.h>", kPrivate, "<sys/syscall.h>", kPublic },
   { "<bits/sysctl.h>", kPrivate, "<sys/sysctl.h>", kPublic },
   { "<bits/syslog-ldbl.h>", kPrivate, "<sys/syslog.h>", kPrivate },
   { "<bits/syslog-path.h>", kPrivate, "<sys/syslog.h>", kPrivate },
@@ -538,7 +538,6 @@ const IncludeMapEntry libc_include_map[] = {
   { "<bits/string.h>", kPrivate, "<string.h>", kPublic },
   { "<bits/string2.h>", kPrivate, "<string.h>", kPublic },
   { "<bits/string3.h>", kPrivate, "<string.h>", kPublic },
-  { "<bits/syscall.h>", kPrivate, "<sys/syscall.h>", kPrivate },
   { "<bits/timerfd.h>", kPrivate, "<sys/timerfd.h>", kPublic },
   { "<bits/typesizes.h>", kPrivate, "<sys/types.h>", kPublic },
   // Top-level #includes that just forward to another file:
@@ -549,7 +548,6 @@ const IncludeMapEntry libc_include_map[] = {
   // to decide which of the two files is canonical.  If neither is
   // on the POSIX.1 1998 list, I just choose the top-level one.
   { "<sys/poll.h>", kPrivate, "<poll.h>", kPublic },
-  { "<sys/syscall.h>", kPrivate, "<syscall.h>", kPublic },
   { "<sys/syslog.h>", kPrivate, "<syslog.h>", kPublic },
   { "<sys/ustat.h>", kPrivate, "<ustat.h>", kPublic },
   { "<wait.h>", kPrivate, "<sys/wait.h>", kPublic },
@@ -571,7 +569,7 @@ const IncludeMapEntry libc_include_map[] = {
   { "<asm/errno.h>", kPrivate, "<errno.h>", kPublic },
   { "<asm/errno-base.h>", kPrivate, "<errno.h>", kPublic },
   { "<asm/ptrace-abi.h>", kPrivate, "<asm/ptrace.h>", kPublic },
-  { "<asm/unistd.h>", kPrivate, "<syscall.h>", kPublic },
+  { "<asm/unistd.h>", kPrivate, "<sys/syscall.h>", kPublic },
   { "<linux/limits.h>", kPrivate, "<limits.h>", kPublic },   // PATH_MAX
   { "<linux/prctl.h>", kPrivate, "<sys/prctl.h>", kPublic },
   { "<sys/ucontext.h>", kPrivate, "<ucontext.h>", kPublic },


### PR DESCRIPTION
But maybe there's a simpler way to fix this without adding hundreds of mappings.

See: <https://github.com/include-what-you-use/include-what-you-use/pull/1063>