### PR TITLE
Allow forward-declaration of elaborated types in type decls

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -168,6 +168,7 @@ using clang::Decl;
 using clang::DeclContext;
 using clang::DeclRefExpr;
 using clang::DeducedTemplateSpecializationType;
+using clang::ElaboratedType;
 using clang::EnumConstantDecl;
 using clang::EnumDecl;
 using clang::EnumType;
@@ -2598,6 +2599,10 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
         }
 
         parent_type = GetTypeOf(decl);
+      } else if (ast_node->IsA<ElaboratedType>()) {
+        // If it's not a ValueDecl, it must be a type decl. Elaborated types in
+        // type decls are forward-declarable.
+        return true;
       }
     }
 

--- a/tests/c/elaborated_struct.c
+++ b/tests/c/elaborated_struct.c
@@ -28,6 +28,14 @@ int UseStruct(struct Struct* s);
 struct ForwardDeclared;
 void UseForwardDeclared(struct ForwardDeclared*);
 
+// If a forward-declaration is seen before an actual struct declaration in the
+// same file, no diagnostic is expected (see issue #1065).
+typedef struct local_struct local_struct_t;
+struct local_struct {
+  int x;
+  local_struct_t* next;
+};
+
 /**** IWYU_SUMMARY
 
 tests/c/elaborated_struct.c should add these lines:


### PR DESCRIPTION
This covers the common C pattern of declaring a typedef for a struct before the
struct itself, e.g.

   typedef struct foo foo_t;

   struct foo {
     int value;
     foo_t *next;
   };

Fixes issue #1065.