### PR TITLE
Drop -save-temps command-line args

### DIFF
--- a/iwyu_driver.cc
+++ b/iwyu_driver.cc
@@ -21,6 +21,7 @@
 
 #include "llvm/ADT/ArrayRef.h"  // IWYU pragma: keep
 #include "llvm/ADT/SmallString.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/Triple.h"
 #include "llvm/Option/ArgList.h"
 #include "llvm/Support/ErrorOr.h"
@@ -174,6 +175,12 @@ CompilerInstance* CreateCompilerInstance(int argc, const char **argv) {
   SmallVector<const char*, 256> args;
 
   ExpandArgv(argc, argv, args, SavedStrings);
+
+  // Drop -save-temps arguments to avoid multiple compilation jobs.
+  llvm::erase_if(args, [](const char *v) {
+    StringRef arg(v);
+    return arg.startswith("-save-temps") || arg.startswith("--save-temps");
+  });
 
   // FIXME: This is a hack to try to force the driver to do something we can
   // recognize. We need to extend the driver library to support this use model

--- a/tests/driver/save_temps.c
+++ b/tests/driver/save_temps.c
@@ -1,0 +1,21 @@
+//===--- save_temps.c - test input file for iwyu --------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// Run IWYU with some variations of '-save-temps' to prove that it can still run
+// to completion (see issue #1060).
+
+// IWYU_ARGS: -save-temps --save-temps -save-temps=obj
+
+struct Unused {};
+
+/**** IWYU_SUMMARY
+
+(tests/driver/save_temps.c has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
IWYU doesn't produce any outputs, so -save-temps does not have any useful
effect.

Before this patch, passing -save-temps did, however, generate multiple
compilation jobs which caused a fatal error:

  error: unable to handle compilation, expected exactly one compiler job

Filter the arguments out, similar to what Clang tools do by default.