### PR TITLE
Avoid redundant enum type template args reporting

### DIFF
--- a/tests/cxx/badinc.cc
+++ b/tests/cxx/badinc.cc
@@ -1128,7 +1128,6 @@ int main() {
   Cc_typedef::NestedStruct::NestedStructTypedef Cc_typedef_nested_int = 0;
   local_h_class.a();
   // a() returns a FOO, which in this case is I2_Enum.
-  // IWYU: I2_Enum is...*badinc-i2.h
   local_d1_template_class.a();
   (void)(local_i1_enum);
   // IWYU: I1_UnnamedStruct is...*badinc-i1.h
@@ -1507,7 +1506,6 @@ int main() {
   for (std::vector<I2_Enum>::iterator it = local_enum_vector.begin();
        // IWYU: std::vector is...*<vector>
        it != local_enum_vector.end(); ++it) {
-    // IWYU: I2_Enum is...*badinc-i2.h
     // IWYU: std::vector is...*<vector>
     std::find(local_enum_vector.begin(), local_enum_vector.end(), *it);
   }
@@ -1538,7 +1536,6 @@ int main() {
   // IWYU: I1_Class is...*badinc-i1.h
   // IWYU: kI1ConstInt is...*badinc-i1.h
   I1_Class* newed_i1_class_array = new I1_Class[kI1ConstInt];
-  // IWYU: I2_Enum is...*badinc-i2.h
   // IWYU: std::vector is...*<vector>
   delete newed_vector;
   // IWYU: I1_Class is...*badinc-i1.h
@@ -1763,10 +1760,8 @@ int main() {
   H_TemplateFunction<I1_Class*>(&i1_class);
   H_TemplateFunction(&i1_class);
   // IWYU: I2_Enum is...*badinc-i2.h
-  // IWYU: I1_Enum is...*badinc-i1.h
   h_templateclass2.static_out_of_line(I22);
   // IWYU: I2_Enum is...*badinc-i2.h
-  // IWYU: I1_Enum is...*badinc-i1.h
   h_templateclass2.static_inline(I22);
   // IWYU: I2_Enum is...*badinc-i2.h
   h_templateclass2.h_nested_struct.tplnested(I22);

--- a/tests/cxx/enums.cc
+++ b/tests/cxx/enums.cc
@@ -42,6 +42,14 @@ Struct1::IndirectEnum3 ie3;
 // IWYU: UnnamedEnumItem2 is...*enums-i4.h
 auto ie4 = UnnamedEnumItem2;
 
+// No need even for opaque declaration if enumeration or enumerator isn't named
+// explicitly (the underlying type info should already be present in the
+// translation unit, probably through transitive header inclusions). No matter,
+// whether enum has fixed type or not, used in sizeof operator, pointer
+// arithmetic or whatever.
+auto p1 = &ie1 + sizeof(ie1);
+auto p2 = &ie3 + sizeof(ie3);
+
 template <typename T1, typename T2>
 struct Template {
   T1 t1;


### PR DESCRIPTION
Reporting opaque declarations or full use of non-fixed enums at location where template specialization type is explicitly written should be sufficient, except the case of nested enumerator referencing (handled through NestedNameSpecifier).