### PR TITLE
Mark std::less<> specializations in tests const

### DIFF
--- a/tests/cxx/precomputed_tpl_args-d1.h
+++ b/tests/cxx/precomputed_tpl_args-d1.h
@@ -17,7 +17,7 @@ class D1SpecializationClass { };
 namespace std {
 template<> class less<D1SpecializationClass> {
  public:
-  bool operator()(const D1SpecializationClass&, const D1SpecializationClass&) {
+  bool operator()(const D1SpecializationClass&, const D1SpecializationClass&) const {
     return true;
   }
 };

--- a/tests/cxx/precomputed_tpl_args-i1.h
+++ b/tests/cxx/precomputed_tpl_args-i1.h
@@ -17,7 +17,7 @@ class SpecializationClass { };
 namespace std {
 template<> class less<SpecializationClass> {
  public:
-  bool operator()(const SpecializationClass&, const SpecializationClass&) {
+  bool operator()(const SpecializationClass&, const SpecializationClass&) const {
     return true;
   }
 };


### PR DESCRIPTION
Some standard libraries require that any std::less<> specializations have a
const operator(). That seems hygienic anyway, so add a const qualifier.

Fixes the precomputed_tpl_args test on FreeBSD (and probably Mac).