### PR TITLE
Avoid reporting type for "autocast" for function definition

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -1484,6 +1484,8 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
               GetFileEntry(call_expr), GetFileEntry(*fn_redecl))) {
         continue;
       }
+      if (fn_redecl->isThisDeclarationADefinition() && !IsInHeader(*fn_redecl))
+        continue;
       for (set<const Type*>::iterator it = retval.begin();
            it != retval.end(); ) {
         if (!CodeAuthorWantsJustAForwardDeclare(*it, GetLocation(*fn_redecl))) {
@@ -1767,6 +1769,11 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
         FunctionDecl* redecl = decl;
         while ((redecl = redecl->getPreviousDecl()))
           ReportDeclUse(CurrentLoc(), redecl);
+      }
+      if (!IsInHeader(decl)) {
+        // No point in author-intent analysis of function definitions
+        // in source files.
+        return true;
       }
     } else {
       // Make all our types forward-declarable...

--- a/iwyu_location_util.cc
+++ b/iwyu_location_util.cc
@@ -10,6 +10,7 @@
 #include "iwyu_location_util.h"
 
 #include "iwyu_ast_util.h"
+#include "iwyu_port.h"
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclBase.h"
 #include "clang/AST/DeclCXX.h"
@@ -28,6 +29,7 @@ using clang::CXXMethodDecl;
 using clang::CXXOperatorCallExpr;
 using clang::ClassTemplateSpecializationDecl;
 using clang::ConditionalOperator;
+using clang::FileEntry;
 using clang::FunctionDecl;
 using clang::MemberExpr;
 using clang::SourceLocation;
@@ -168,6 +170,12 @@ SourceLocation GetLocation(const clang::TemplateArgumentLoc* argloc) {
 
 bool IsInScratchSpace(SourceLocation loc) {
   return StartsWith(PrintableLoc(GetSpellingLoc(loc)), "<scratch space>");
+}
+
+bool IsInHeader(const clang::Decl* decl) {
+  const FileEntry* containing_file = GetFileEntry(decl);
+  CHECK_(containing_file);
+  return !GlobalSourceManager()->isMainFile(*containing_file);
 }
 
 }  // namespace include_what_you_use

--- a/iwyu_location_util.h
+++ b/iwyu_location_util.h
@@ -228,6 +228,9 @@ inline bool IsBeforeInSameFile(const T& a, const U& b) {
   return IsBeforeInTranslationUnit(a, b);
 }
 
+// Returns true if the given declaration is located in a header file.
+bool IsInHeader(const clang::Decl*);
+
 }  // namespace include_what_you_use
 
 #endif  // INCLUDE_WHAT_YOU_USE_IWYU_LOCATION_UTIL_H_

--- a/tests/cxx/implicit_ctor-d1.h
+++ b/tests/cxx/implicit_ctor-d1.h
@@ -22,6 +22,14 @@ int ImplicitCtorFn(IndirectWithImplicitCtor);
 // IWYU: IndirectWithImplicitCtor is...*implicit_ctor-i2.h.*for autocast
 int ImplicitCtorRefFn(const IndirectWithImplicitCtor&);
 
+// Reporting types for "autocast" for header-defined functions still makes sense
+// as opposed to function definitions in source files.
+// IWYU: IndirectWithImplicitCtor needs a declaration
+// IWYU: IndirectWithImplicitCtor is...*implicit_ctor-i2.h.*for autocast
+inline int InlineImplicitCtorRefFn(const IndirectWithImplicitCtor&) {
+  return 1;
+}
+
 // Test parameter type uses that do not require special handling for "autocast".
 int NoAutocastFn(
     // A subtle c++ point: forward-declaring is ok for nonconst, because

--- a/tests/cxx/implicit_ctor.cc
+++ b/tests/cxx/implicit_ctor.cc
@@ -22,6 +22,18 @@
 
 #include "tests/cxx/implicit_ctor-d1.h"
 
+// No reporting types for "autocast" for .cpp-file-local functions...
+// IWYU: IndirectWithImplicitCtor needs a declaration
+static int LocalFn(const IndirectWithImplicitCtor&) {
+  return 1;
+}
+
+// ... or for .cpp-file-definitions of functions declared in a header.
+// IWYU: IndirectWithImplicitCtor needs a declaration
+int ImplicitCtorRefFn(const IndirectWithImplicitCtor&) {
+  return 2;
+}
+
 // We don't need IndirectWithImplicitCtor even though we must convert to it.
 int a = ImplicitCtorFn(1);
 int b = ImplicitCtorRefFn(2);
@@ -31,6 +43,13 @@ int b = ImplicitCtorRefFn(2);
 int c = ImplicitCtorFn(IndirectWithImplicitCtor(3));
 // IWYU: IndirectWithImplicitCtor is...*implicit_ctor-i2.h
 int d = ImplicitCtorRefFn(IndirectWithImplicitCtor(4));
+
+// LocalFn doesn't provide IndirectWithImplicitCtor type info.
+// IWYU: IndirectWithImplicitCtor is...*implicit_ctor-i2.h
+int e = LocalFn(5);
+// InlineImplicitCtorRefFn should provide parameter type info,
+// hence no reporting.
+int f = InlineImplicitCtorRefFn(6);
 
 // Make sure we are responsible for the conversion when it's not for a
 // function call.
@@ -48,7 +67,7 @@ tests/cxx/implicit_ctor.cc should add these lines:
 tests/cxx/implicit_ctor.cc should remove these lines:
 
 The full include-list for tests/cxx/implicit_ctor.cc:
-#include "tests/cxx/implicit_ctor-d1.h"  // for ImplicitCtorFn, ImplicitCtorRefFn
+#include "tests/cxx/implicit_ctor-d1.h"  // for ImplicitCtorFn, ImplicitCtorRefFn, InlineImplicitCtorRefFn
 #include "tests/cxx/implicit_ctor-i2.h"  // for IndirectWithImplicitCtor
 
 ***** IWYU_SUMMARY */

--- a/tests/cxx/implicit_ctor.cc
+++ b/tests/cxx/implicit_ctor.cc
@@ -10,13 +10,13 @@
 // IWYU_ARGS: -Xiwyu --check_also="tests/cxx/*-d1.h" -I .
 
 // If you define an API that accepts an argument of class type or
-// const reference to a class type with an implicit constructor, you
-// must provide the definition for the class.
+// const reference to a class type with an implicit constructor which takes
+// exactly one argument, you must provide the definition for the class.
 //
-// If you use an API and that use triggers an implicit constructor
+// If you use an API and that use triggers such an implicit constructor
 // call, you are *not* considered to have used that constructor,
 // relying on the previous rule to make the code complete definition
-// available.
+// available. This is so called "autocast".
 //
 // This tests that logic.
 

--- a/tests/cxx/iwyu_stricter_than_cpp-autocast.h
+++ b/tests/cxx/iwyu_stricter_than_cpp-autocast.h
@@ -47,6 +47,16 @@ void FnRefs(
     const DirectStruct3& dc1, const struct DirectStruct4& dc2,
     const IndirectStruct2& ic2);
 
+inline void HeaderDefinedFnRefs(
+    // IWYU: IndirectStruct1 needs a declaration
+    // IWYU: IndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h.*for autocast
+    const IndirectStruct1& ic1,
+    // IWYU: IndirectStructForwardDeclaredInD1 is...*iwyu_stricter_than_cpp-i1.h.*for autocast
+    const struct IndirectStructForwardDeclaredInD1& icfdid1,
+    const DirectStruct5& dc1, const struct DirectStruct6& dc2,
+    const IndirectStruct2& ic2) {
+}
+
 // --- Now do it all again, with templates!
 
 template <typename T>
@@ -80,6 +90,17 @@ void TplFnRefs(
     const TplDirectStruct3<char>& dc1, const struct TplDirectStruct4<char>& dc2,
     const TplIndirectStruct2<char>& ic2);
 
+inline void HeaderDefinedTplFnRefs(
+    // IWYU: TplIndirectStruct1 needs a declaration
+    // IWYU: TplIndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h.*for autocast
+    const TplIndirectStruct1<char>& ic1,
+    // IWYU: TplIndirectStructForwardDeclaredInD1 needs a declaration
+    // IWYU: TplIndirectStructForwardDeclaredInD1 is...*iwyu_stricter_than_cpp-i1.h.*for autocast
+    const struct TplIndirectStructForwardDeclaredInD1<char>& icfdid1,
+    const TplDirectStruct5<char>& dc1, const struct TplDirectStruct6<char>& dc2,
+    const TplIndirectStruct2<char>& ic2) {
+}
+
 // --- The rules do not apply for friend functions declarations.
 
 struct AutocastStruct {
@@ -101,7 +122,7 @@ tests/cxx/iwyu_stricter_than_cpp-autocast.h should remove these lines:
 - template <typename T> struct TplDirectStruct1;  // lines XX-XX+1
 
 The full include-list for tests/cxx/iwyu_stricter_than_cpp-autocast.h:
-#include "tests/cxx/iwyu_stricter_than_cpp-d1.h"  // for DirectStruct1, DirectStruct2, DirectStruct3, DirectStruct4, TplDirectStruct1, TplDirectStruct2, TplDirectStruct3, TplDirectStruct4
+#include "tests/cxx/iwyu_stricter_than_cpp-d1.h"  // for DirectStruct1, DirectStruct2, DirectStruct3, DirectStruct4, DirectStruct5, DirectStruct6, TplDirectStruct1, TplDirectStruct2, TplDirectStruct3, TplDirectStruct4, TplDirectStruct5, TplDirectStruct6
 #include "tests/cxx/iwyu_stricter_than_cpp-i1.h"  // for IndirectStruct1, IndirectStructForwardDeclaredInD1, TplIndirectStruct1, TplIndirectStructForwardDeclaredInD1
 struct IndirectStruct2;  // lines XX-XX
 template <typename T> struct TplIndirectStruct2;  // lines XX-XX+1

--- a/tests/cxx/iwyu_stricter_than_cpp-d1.h
+++ b/tests/cxx/iwyu_stricter_than_cpp-d1.h
@@ -31,6 +31,14 @@ struct DirectStruct4 {
   DirectStruct4(int) {
   }
 };
+struct DirectStruct5 {
+  DirectStruct5(int) {
+  }
+};
+struct DirectStruct6 {
+  DirectStruct6(int) {
+  }
+};
 struct IndirectStructForwardDeclaredInD1;
 
 template <typename T>
@@ -51,6 +59,16 @@ struct TplDirectStruct3 {
 template <typename T>
 struct TplDirectStruct4 {
   TplDirectStruct4(int) {
+  }
+};
+template <typename T>
+struct TplDirectStruct5 {
+  TplDirectStruct5(int) {
+  }
+};
+template <typename T>
+struct TplDirectStruct6 {
+  TplDirectStruct6(int) {
   }
 };
 template <typename T>

--- a/tests/cxx/iwyu_stricter_than_cpp.cc
+++ b/tests/cxx/iwyu_stricter_than_cpp.cc
@@ -139,23 +139,30 @@ void TestTypeAliases() {
 }
 
 void TestAutocast() {
-  // We need full type of IndirectStruct2 because the declarer of FnValues and
-  // FnRefs didn't.
+  // We need full type of IndirectStruct2 because the declarer of the following
+  // functions didn't.
   FnValues(1, 2, 3, 4,
            // IWYU: IndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
            5);
   FnRefs(1, 2, 3, 4,
          // IWYU: IndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
          5);
+  HeaderDefinedFnRefs(1, 2, 3, 4,
+                      // IWYU: IndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
+                      5);
 
-  // We need full type of TplIndirectStruct2 because the declarer of TplFnValues
-  // and TplFnRefs didn't.
+  // We need full type of TplIndirectStruct2 because the declarer
+  // of the following functions didn't.
   TplFnValues(6, 7, 8, 9,
               // IWYU: TplIndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
               10);
   TplFnRefs(6, 7, 8, 9,
             // IWYU: TplIndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
             10);
+  HeaderDefinedTplFnRefs(
+      6, 7, 8, 9,
+      // IWYU: TplIndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
+      10);
 }
 
 void TestFunctionReturn() {
@@ -227,7 +234,7 @@ tests/cxx/iwyu_stricter_than_cpp.cc should remove these lines:
 
 The full include-list for tests/cxx/iwyu_stricter_than_cpp.cc:
 #include "tests/cxx/indirect.h"  // for IndirectClass
-#include "tests/cxx/iwyu_stricter_than_cpp-autocast.h"  // for FnRefs, FnValues, TplFnRefs, TplFnValues
+#include "tests/cxx/iwyu_stricter_than_cpp-autocast.h"  // for FnRefs, FnValues, HeaderDefinedFnRefs, HeaderDefinedTplFnRefs, TplFnRefs, TplFnValues
 #include "tests/cxx/iwyu_stricter_than_cpp-d3.h"  // for IndirectStruct3ProvidingAl, IndirectStruct3ProvidingTypedef, IndirectStruct4ProvidingAl, IndirectStruct4ProvidingTypedef
 #include "tests/cxx/iwyu_stricter_than_cpp-fnreturn.h"  // for DoesEverythingRightFn, DoesNotForwardDeclareAndIncludesFn, DoesNotForwardDeclareFn, DoesNotForwardDeclareProperlyFn, IncludesFn, TplDoesEverythingRightAgainFn, TplDoesEverythingRightFn, TplDoesNotForwardDeclareAndIncludesFn, TplDoesNotForwardDeclareFn, TplDoesNotForwardDeclareProperlyFn, TplIncludesFn
 #include "tests/cxx/iwyu_stricter_than_cpp-i2.h"  // for IndirectStruct2, TplIndirectStruct2


### PR DESCRIPTION
A function may just transmit passed-by-reference parameter to somewhere.
Requirement to explicitly write forward declaration in the same file (.cpp-file) to avoid `#include` suggestion is impractical when that type is already fwd-declared in the corresponding header.

I'm not sure about this change. Autocast to parameter of defined function still makes sense when the function definition is in header:
```cpp
inline void ProcessString(const StringWrapper& sw)
{
  stringProcessor.process(sw); // passed by reference
}
```
Maybe, to check whether the function is inline? Or there may be some better heuristics?