### PR TITLE
Add another mapping for NULL

### DIFF
--- a/gcc.symbols.imp
+++ b/gcc.symbols.imp
@@ -249,6 +249,7 @@
   { symbol: [ "NULL", private, "<stdlib.h>", public ] },
   { symbol: [ "NULL", private, "<string.h>", public ] },
   { symbol: [ "NULL", private, "<time.h>", public ] },
+  { symbol: [ "NULL", private, "<unistd.h>", public ] },
   { symbol: [ "NULL", private, "<wchar.h>", public ] },
 
   # Kludge time: almost all STL types take an allocator, but they

--- a/iwyu_include_picker.cc
+++ b/iwyu_include_picker.cc
@@ -328,6 +328,7 @@ const IncludeMapEntry libc_symbol_map[] = {
   { "NULL", kPrivate, "<stdlib.h>", kPublic },
   { "NULL", kPrivate, "<string.h>", kPublic },
   { "NULL", kPrivate, "<time.h>", kPublic },
+  { "NULL", kPrivate, "<unistd.h>", kPublic },
   { "NULL", kPrivate, "<wchar.h>", kPublic },
 };
 


### PR DESCRIPTION
POSIX defines NULL in <unistd.h> too.

Signed-off-by: Alejandro Colomar <alx.manpages@gmail.com>