### PR TITLE
Add some infrastructure for quick&dirty debug flags

### DIFF
--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -428,7 +428,12 @@ string PrintableType(const Type* type) {
   if (!type)
     return "<null type>";
 
-  return QualType(type, 0).getAsString();
+  string typestr = QualType(type, 0).getAsString();
+  if (GlobalFlags().HasDebugFlag("printtypeclass")) {
+    string typeclass = type->getTypeClassName();
+    typestr = typeclass + "Type:" + typestr;
+  }
+  return typestr;
 }
 
 string PrintableTypeLoc(const TypeLoc& typeloc) {

--- a/iwyu_globals.h
+++ b/iwyu_globals.h
@@ -76,6 +76,7 @@ struct CommandlineFlags {
   enum PrefixHeaderIncludePolicy { kAdd, kKeep, kRemove };
   CommandlineFlags();                     // sets flags to default values
   int ParseArgv(int argc, char** argv);   // parses flags from argv
+  bool HasDebugFlag(const char* flag) const;
 
   set<string> check_also;  // -c: globs to report iwyu violations for
   set<string> keep;        // -k: globs to force-keep includes for
@@ -96,6 +97,7 @@ struct CommandlineFlags {
   bool cxx17ns; // -C: C++17 nested namespace syntax
   int exit_code_error;   // Exit with this code for iwyu violations.
   int exit_code_always;  // Always exit with this exit code.
+  set<string> dbg_flags; // Debug flags.
 };
 
 const CommandlineFlags& GlobalFlags();


### PR DESCRIPTION
The `printtypeclass` behavior was absolutely indispensable when troubleshooting #1092. But I don't feel comfortable adding that as default behavior, so add support for simple debug flags, and add a flag for toggling the extended printing.