### PR TITLE
[clang compat] Use elaborated type specifier in CanForwardDeclareType

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -170,7 +170,6 @@ using clang::Decl;
 using clang::DeclContext;
 using clang::DeclRefExpr;
 using clang::DeducedTemplateSpecializationType;
-using clang::ElaboratedType;
 using clang::EnumConstantDecl;
 using clang::EnumDecl;
 using clang::EnumType;
@@ -2611,9 +2610,9 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
         }
 
         parent_type = GetTypeOf(decl);
-      } else if (ast_node->IsA<ElaboratedType>()) {
+      } else if (IsElaboratedTypeSpecifier(ast_node)) {
         // If it's not a ValueDecl, it must be a type decl. Elaborated types in
-        // type decls are forward-declarable.
+        // type decls are automatically forward-declarable.
         return true;
       }
     }

--- a/iwyu.cc
+++ b/iwyu.cc
@@ -4063,7 +4063,7 @@ class IwyuAstConsumer
         // Note that enums are never forward-declarable, so elaborated enums are
         // already short-circuited in CanForwardDeclareType.
         const ASTNode* parent = current_ast_node()->parent();
-        if (!IsElaborationNode(parent) || IsQualifiedNameNode(parent))
+        if (!IsElaboratedTypeSpecifier(parent) || IsQualifiedNameNode(parent))
           ReportDeclForwardDeclareUse(CurrentLoc(), type->getDecl());
       } else {
         // In C, all struct references are elaborated, so we really never need

--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -233,7 +233,7 @@ bool ASTNode::FillLocationIfKnown(SourceLocation* loc) const {
 
 // --- Utilities for ASTNode.
 
-bool IsElaborationNode(const ASTNode* ast_node) {
+bool IsElaboratedTypeSpecifier(const ASTNode* ast_node) {
   if (ast_node == nullptr)
     return false;
   const ElaboratedType* elaborated_type = ast_node->GetAs<ElaboratedType>();

--- a/iwyu_ast_util.h
+++ b/iwyu_ast_util.h
@@ -368,10 +368,10 @@ class CurrentASTNodeUpdater {
 // elaboration is 'class Foo myvar' instead of just 'Foo myvar'.)
 // We avoid 'fake' elaborations that are caused because clang also
 // uses ElaboratedType for namespaces ('ns::Foo myvar').
-bool IsElaborationNode(const ASTNode* ast_node);
+bool IsElaboratedTypeSpecifier(const ASTNode* ast_node);
 
 // Walk up to parents of the given node so long as each parent is an
-// elaboration node (in the sense of IsElaborationNode).
+// elaborated type node.
 // Can expand from a node representing 'X' to e.g. 'struct X' or 'mylib::X'.
 const ASTNode* MostElaboratedAncestor(const ASTNode* ast_node);
 


### PR DESCRIPTION
Preceding refactor to formalize terminology.