### PR TITLE
[clang compat] Use getAs<> instead of dynamic cast for Types

### DIFF
--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -1283,10 +1283,10 @@ bool HasImplicitConversionConstructor(const Type* type) {
 map<const clang::Type*, const clang::Type*>
 GetTplTypeResugarMapForClassNoComponentTypes(const clang::Type* type) {
   map<const Type*, const Type*> retval;
-  type = RemoveElaboration(type);  // get rid of the class keyword
-  const TemplateSpecializationType* tpl_spec_type = DynCastFrom(type);
-  if (!tpl_spec_type)
+  const auto* tpl_spec_type = type->getAs<TemplateSpecializationType>();
+  if (!tpl_spec_type) {
     return retval;
+  }
 
   // Pull the template arguments out of the specialization type. If this is
   // a ClassTemplateSpecializationDecl specifically, we want to


### PR DESCRIPTION
Downcasting an AST Type* to a more specific type is increasingly unsafe in the
AST. In general any Type* picked out of the AST might contain so-called 'sugar',
i.e. visible or invisible structure that does not change the identity of the
underlying type, but adds information.

After Clang 15f3cd6bfc670ba6106184a903eb04be059e5977, almost every Type is
wrapped in an ElaboratedType with kind ETK_None (i.e. "no elaboration").

ElaboratedType counts as sugar, and thus needs to be stripped off before we do
dynamic type checking of Type nodes.

The recommended way to look through sugar downwards in the tree is
'type->getAs<MostDerivedType>()', which will recursively remove sugar until a
node of MostDerivedType is reached. If there is no MostDerivedType node it
returns nullptr, so it's safe to consider getAs a desugaring dynamic downcast.

There are still some places where we use DynCastFrom or isa<> on Types, I have
only modified the ones that had any effect on broken testcases. Planning to look
into the rest separately once the test suite is working.

This fixes 4 broken testcases, and is an improvement towards fixing #1092.