### PR TITLE
Desugaring refactors

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -2820,7 +2820,7 @@ class InstantiatedTemplateVisitor
     // Among all subst-type params, we only want those in the resugar-map. If
     // we're not in the resugar-map at all, we're not a type corresponding to
     // the template being instantiated, so we can be ignored.
-    type = RemoveSubstTemplateTypeParm(type);
+    type = Desugar(type);
     return ContainsKey(resugar_map_, type);
   }
 
@@ -3234,7 +3234,7 @@ class InstantiatedTemplateVisitor
     return GetLocOfTemplateThatProvides(decl).isValid();
   }
   bool IsProvidedByTemplate(const Type* type) const {
-    type = RemoveSubstTemplateTypeParm(type);
+    type = Desugar(type);
     type = RemovePointersAndReferences(type);  // get down to the decl
     if (const NamedDecl* decl = TypeToDeclAsWritten(type)) {
       decl = GetDefinitionAsWritten(decl);
@@ -3248,7 +3248,7 @@ class InstantiatedTemplateVisitor
   // class was instantiated) or not.  We store this in resugar_map by
   // having the value be nullptr.
   bool IsDefaultTemplateParameter(const Type* type) const {
-    type = RemoveSubstTemplateTypeParm(type);
+    type = Desugar(type);
     return ContainsKeyValue(resugar_map_, type, static_cast<Type*>(nullptr));
   }
 
@@ -3257,7 +3257,7 @@ class InstantiatedTemplateVisitor
   // If we're not in the resugar-map, then we weren't canonicalized,
   // so we can just use the input type unchanged.
   const Type* ResugarType(const Type* type) const {
-    type = RemoveSubstTemplateTypeParm(type);
+    type = Desugar(type);
     // If we're the resugar-map but with a value of nullptr, it means
     // we're a default template arg, which means we don't have anything
     // to resugar to.  So just return the input type.

--- a/iwyu.cc
+++ b/iwyu.cc
@@ -1433,7 +1433,7 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
 
     const Type* deref_type
         = RemovePointersAndReferencesAsWritten(underlying_type);
-    if (isa<SubstTemplateTypeParmType>(deref_type) ||
+    if (isa<SubstTemplateTypeParmType>(underlying_type) ||
         CodeAuthorWantsJustAForwardDeclare(deref_type, GetLocation(decl))) {
       retval.insert(deref_type);
       // TODO(csilvers): include template type-args if appropriate.

--- a/iwyu.cc
+++ b/iwyu.cc
@@ -1503,8 +1503,7 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
   set<const Type*> GetCallerResponsibleTypesForFnReturn(
       const FunctionDecl* decl) {
     set<const Type*> retval;
-    const Type* return_type
-        = RemoveElaboration(decl->getReturnType().getTypePtr());
+    const Type* return_type = Desugar(decl->getReturnType().getTypePtr());
     if (CodeAuthorWantsJustAForwardDeclare(return_type, GetLocation(decl))) {
       retval.insert(return_type);
       // TODO(csilvers): include template type-args if appropriate.
@@ -1783,8 +1782,7 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
       return true;
 
     // ...except the return value.
-    const Type* return_type
-        = RemoveElaboration(decl->getReturnType().getTypePtr());
+    const Type* return_type = Desugar(decl->getReturnType().getTypePtr());
     const bool is_responsible_for_return_type
         = (!CanIgnoreType(return_type) &&
            !IsPointerOrReferenceAsWritten(return_type) &&
@@ -3317,7 +3315,7 @@ class InstantiatedTemplateVisitor
     //    class S; int main() { C<S> c; }
     if (isa<CXXConstructorDecl>(fn_decl)) {
       CHECK_(parent_type && "How can a constructor have no parent?");
-      parent_type = RemoveElaboration(parent_type);
+      parent_type = Desugar(parent_type);
       if (!TraverseDataAndTypeMembersOfClassHelper(
               dyn_cast<TemplateSpecializationType>(parent_type)))
         return false;

--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -1218,12 +1218,9 @@ const Type* RemovePointersAndReferences(const Type* type) {
 }
 
 static const NamedDecl* TypeToDeclImpl(const Type* type, bool as_written) {
-  // Get past all the 'class' and 'struct' prefixes, and namespaces.
-  type = Desugar(type);
-
-  // Read past SubstTemplateTypeParmType (this can happen if a
-  // template function returns the tpl-arg type: e.g. for
-  // 'T MyFn<T>() {...}; MyFn<X>.a', the type of MyFn<X> will be a Subst.
+  // Read past SubstTemplateTypeParmType (this can happen if a function
+  // template returns the tpl-arg type: e.g. for 'T MyFn<T>() {...}; MyFn<X>.a',
+  // the type of MyFn<X> will be a substitution) as well as any elaboration.
   type = Desugar(type);
 
   CHECK_(!isa<ObjCObjectType>(type) && "IWYU doesn't support Objective-C");

--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -1156,8 +1156,9 @@ bool IsTemplatizedType(const Type* type) {
 }
 
 bool IsClassType(const clang::Type* type) {
-  return (type && (isa<TemplateSpecializationType>(Desugar(type)) ||
-                   isa<RecordType>(Desugar(type))));
+  type = Desugar(type);
+  return (type &&
+          (isa<TemplateSpecializationType>(type) || isa<RecordType>(type)));
 }
 
 bool InvolvesTypeForWhich(const Type* type,

--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -1160,16 +1160,9 @@ bool IsClassType(const clang::Type* type) {
                    isa<RecordType>(Desugar(type))));
 }
 
-const Type* RemoveSubstTemplateTypeParm(const Type* type) {
-  if (const SubstTemplateTypeParmType* subst_type = DynCastFrom(type))
-    return subst_type->getReplacementType().getTypePtr();
-  else
-    return type;
-}
-
 bool InvolvesTypeForWhich(const Type* type,
                           std::function<bool(const Type*)> pred) {
-  type = RemoveSubstTemplateTypeParm(type);
+  type = Desugar(type);
   if (pred(type))
     return true;
   const Decl* decl = TypeToDeclAsWritten(type);
@@ -1231,7 +1224,7 @@ static const NamedDecl* TypeToDeclImpl(const Type* type, bool as_written) {
   // Read past SubstTemplateTypeParmType (this can happen if a
   // template function returns the tpl-arg type: e.g. for
   // 'T MyFn<T>() {...}; MyFn<X>.a', the type of MyFn<X> will be a Subst.
-  type = RemoveSubstTemplateTypeParm(type);
+  type = Desugar(type);
 
   CHECK_(!isa<ObjCObjectType>(type) && "IWYU doesn't support Objective-C");
 

--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -1151,20 +1151,13 @@ const Type* Desugar(const Type* type) {
   }
 }
 
-const Type* RemoveElaboration(const Type* type) {
-  if (const ElaboratedType* elaborated_type = DynCastFrom(type))
-    return elaborated_type->getNamedType().getTypePtr();
-  else
-    return type;
-}
-
 bool IsTemplatizedType(const Type* type) {
-  return (type && isa<TemplateSpecializationType>(RemoveElaboration(type)));
+  return (type && isa<TemplateSpecializationType>(Desugar(type)));
 }
 
 bool IsClassType(const clang::Type* type) {
-  return (type && (isa<TemplateSpecializationType>(RemoveElaboration(type)) ||
-                   isa<RecordType>(RemoveElaboration(type))));
+  return (type && (isa<TemplateSpecializationType>(Desugar(type)) ||
+                   isa<RecordType>(Desugar(type))));
 }
 
 const Type* RemoveSubstTemplateTypeParm(const Type* type) {
@@ -1195,12 +1188,12 @@ bool InvolvesTypeForWhich(const Type* type,
 }
 
 bool IsPointerOrReferenceAsWritten(const Type* type) {
-  type = RemoveElaboration(type);
+  type = Desugar(type);
   return isa<PointerType>(type) || isa<LValueReferenceType>(type);
 }
 
 const Type* RemovePointersAndReferencesAsWritten(const Type* type) {
-  type = RemoveElaboration(type);
+  type = Desugar(type);
   while (isa<PointerType>(type) ||
          isa<LValueReferenceType>(type)) {
     type = type->getPointeeType().getTypePtr();
@@ -1215,7 +1208,7 @@ const Type* RemovePointerFromType(const Type* type) {
   if (!IsPointerOrReferenceAsWritten(type)) {
     return nullptr;
   }
-  type = RemoveElaboration(type);
+  type = Desugar(type);
   type = type->getPointeeType().getTypePtr();
   return type;
 }
@@ -1233,7 +1226,7 @@ const Type* RemovePointersAndReferences(const Type* type) {
 
 static const NamedDecl* TypeToDeclImpl(const Type* type, bool as_written) {
   // Get past all the 'class' and 'struct' prefixes, and namespaces.
-  type = RemoveElaboration(type);
+  type = Desugar(type);
 
   // Read past SubstTemplateTypeParmType (this can happen if a
   // template function returns the tpl-arg type: e.g. for
@@ -1294,7 +1287,7 @@ const Type* RemoveReferenceAsWritten(const Type* type) {
 }
 
 bool HasImplicitConversionConstructor(const Type* type) {
-  type = RemoveElaboration(type);  // get rid of the class keyword
+  type = Desugar(type);
   if (isa<PointerType>(type))
     return false;  // can't implicitly convert to a pointer
   if (isa<LValueReferenceType>(type) &&

--- a/iwyu_ast_util.h
+++ b/iwyu_ast_util.h
@@ -681,12 +681,6 @@ bool IsTemplatizedType(const clang::Type* type);
 // Returns true if the type is a RecordType or a TemplateSpecializationType.
 bool IsClassType(const clang::Type* type);
 
-// Read past SubstTemplateTypeParmType to the underlying type, if type
-// is itself a SubstTemplateTypeParmType.  Thus: T is converted to int
-// if we are parsing a template instantiated with T being int.
-// However, vector<T> is *not* converted to vector<int>.
-const clang::Type* RemoveSubstTemplateTypeParm(const clang::Type* type);
-
 // Returns true if any type involved (recursively examining template
 // arguments) satisfies the given predicate.
 bool InvolvesTypeForWhich(const clang::Type* type,

--- a/iwyu_ast_util.h
+++ b/iwyu_ast_util.h
@@ -663,6 +663,13 @@ const clang::Type* GetTypeOf(const clang::TypeDecl* decl);
 // Template parameters are always reduced to the canonical type.
 const clang::Type* GetCanonicalType(const clang::Type* type);
 
+// Use Desugar to walk down the AST skipping type sugar nodes until a non-sugar
+// node is found, much like Type::getUnqualifiedDesugaredType.
+// IWYU has a slightly more liberal notion of sugar than Clang does:
+// typedefs, using types and template specializations are not considered sugar,
+// because they need to be respected in IWYU analysis.
+const clang::Type* Desugar(const clang::Type* type);
+
 // A 'component' of a type is a type beneath it in the AST tree.
 // So 'Foo*' has component 'Foo', as does 'vector<Foo>', while
 // vector<pair<Foo, Bar>> has components pair<Foo,Bar>, Foo, and Bar.

--- a/iwyu_ast_util.h
+++ b/iwyu_ast_util.h
@@ -675,14 +675,6 @@ const clang::Type* Desugar(const clang::Type* type);
 // vector<pair<Foo, Bar>> has components pair<Foo,Bar>, Foo, and Bar.
 set<const clang::Type*> GetComponentsOfType(const clang::Type* type);
 
-// The ElaborationType -- which says whether a type is preceded by
-// 'class' or 'struct' ('class Foo'), or whether the type-name has a
-// namespace ('ns::Foo') -- often pops where it's not wanted.  This
-// removes the elaboration if it exists, else it's a noop.  Note that
-// if the type has both kinds of elaborations ('struct ns::Foo'), they
-// will both be removed.
-const clang::Type* RemoveElaboration(const clang::Type* type);
-
 // Returns true if the type has any template arguments.
 bool IsTemplatizedType(const clang::Type* type);
 

--- a/tests/cxx/badinc.cc
+++ b/tests/cxx/badinc.cc
@@ -198,6 +198,7 @@ typedef I1_Class Cc_typedef_array[kI1ConstInt];
 // IWYU: I2_Class needs a declaration
 // IWYU: I1_TemplateClass is...*badinc-i1.h.*#included\.
 // IWYU: I1_TemplateClass is...*badinc-i1.h.*for autocast
+// IWYU: I1_TemplateClass is...*badinc-i1.h.*for fn return type
 // IWYU: I1_Class is...*badinc-i1.h
 // IWYU: I2_Class is...*badinc-i2.h
 // IWYU: I2_Class::~I2_Class is...*badinc-i2-inl.h


### PR DESCRIPTION
This is a big one, to prepare for actual fixes for #1092.

https://github.com/llvm/llvm-project/commit/15f3cd6bfc670ba6106184a903eb04be059e5977 reshaped the AST quite significantly, by wrapping most `Type` nodes in an `ElaboratedType` node with `ETK_None`, to clearly indicate that the type does _not_ have an elaborated type specifier.

After careful analysis and help from the discussion on https://reviews.llvm.org/D112374, I have a much better understanding of type sugar in Clang and IWYU.

As far as Clang is concerned, all sugar is disposable, except for diagnostics. So `typedef int MyInt;` is functionally equivalent with `int`. So when Clang desugars a type, it sees through all the nodes that have no bearing on the type identity of the underlying type, to be able to do type checking on the desugared type. But in IWYU, we care deeply about the difference between typedefs/type aliases and underlying types, because they can live in different headers.

Thus:

* perform a type check for `SubstTemplateTypeParm` _before_ desugaring, as stronger desugaring would strip off that type
* institute a new `Desugar` function in IWYU, that desugars much like Clang, but stops at `TypedefType`, `UsingType` and `TemplateSpecializationType`, all of which are necessary for IWYU's more source-code oriented analysis.
* `sed` all uses of `RemoveElaboration` to `Desugar`, which is now a functional superset
* `sed` all uses of `RemoveSubstTemplateTypeParm` to `Desugar`, which is now a functional superset
* (fix up a test assertion in badinc.cc, where better sugar handling uncovered a new diagnostic, yay!)
* clean up a few oddities from the mechanical rewrites

This sets the scene for actually fixing a bunch of bugs where IWYU would overlook sugar and break with Clang 15f3cd6b. Coming in a later PR.