### PR TITLE
Fix the test suite for Clang AST changes

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -1466,7 +1466,7 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
       if (HasImplicitConversionConstructor(param_type)) {
         const Type* deref_param_type =
             RemovePointersAndReferencesAsWritten(param_type);
-        autocast_types.insert(deref_param_type);
+        autocast_types.insert(Desugar(deref_param_type));
       }
     }
 
@@ -2287,7 +2287,7 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
     // casted-to type.  See IwyuBaseASTVisitor::VisitFunctionDecl.
     // Explicitly written CXXTemporaryObjectExpr are ignored here.
     if (expr->getStmtClass() == Stmt::StmtClass::CXXConstructExprClass) {
-      const Type* type = expr->getType().getTypePtr();
+      const Type* type = Desugar(expr->getType().getTypePtr());
       if (current_ast_node()->template HasAncestorOfType<CallExpr>() &&
           ContainsKey(GetCallerResponsibleTypesForAutocast(current_ast_node()),
                       RemoveReferenceAsWritten(type))) {
@@ -2452,7 +2452,7 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
     // full type information for the return type of the function, but
     // in cases where it's not, we have to take responsibility.
     // TODO(csilvers): check the fn argument types as well.
-    const Type* return_type = callee->getReturnType().getTypePtr();
+    const Type* return_type = Desugar(callee->getReturnType().getTypePtr());
     if (ContainsKey(GetCallerResponsibleTypesForFnReturn(callee),
                     return_type)) {
       ReportTypeUse(CurrentLoc(), return_type);

--- a/iwyu.cc
+++ b/iwyu.cc
@@ -1586,7 +1586,8 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
       // typedef (that is, 'typedef MyTypedef OtherTypdef'), then the
       // user -- the other typedef -- is never responsible for the
       // underlying type.  Instead, users of that typedef are.
-      if (!current_ast_node()->template ParentIsA<TypedefNameDecl>()) {
+      const ASTNode* ast_node = MostElaboratedAncestor(current_ast_node());
+      if (!ast_node->ParentIsA<TypedefNameDecl>()) {
         const set<const Type*>& underlying_types
             = GetCallerResponsibleTypesForTypedef(typedef_decl);
         if (!underlying_types.empty()) {

--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -1336,7 +1336,7 @@ GetTplTypeResugarMapForClassNoComponentTypes(const clang::Type* type) {
     for (const Type* type : arg_components) {
       for (unsigned i = 0; i < num_args; ++i) {
         if (const Type* arg_type = GetTemplateArgAsType(tpl_args[i])) {
-          if (GetCanonicalType(type) == arg_type) {
+          if (GetCanonicalType(type) == GetCanonicalType(arg_type)) {
             retval[arg_type] = type;
             VERRS(6) << "Adding a template-class type of interest: "
                      << PrintableType(arg_type) << " -> " << PrintableType(type)


### PR DESCRIPTION
These final fixes should turn the test suite green when built with both Clang-15 and Clang-16 (main).

Two broad classes:

* Desugar or canonicalize types before doing identity checks
* Find the most elaborated/sugared ancestor before attempting to do type checks with `ASTNode::ParentIsA<T>()`

These were done using experimentation, logging and comparison between Clang-15 and Clang-16, and so only address issues surfaced by our test suite. There may be more changes like these necessary, but at least now we have a set of techniques to use.