### PR TITLE
More exact type loc for exceptions

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -1872,10 +1872,12 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
     if (CanIgnoreCurrentASTNode()) return true;
 
     if (const VarDecl* exception_decl = stmt->getExceptionDecl()) {
+      // Get the caught type from the decl via associated type source info to
+      // get more precise location info for the type use.
       TypeLoc typeloc = exception_decl->getTypeSourceInfo()->getTypeLoc();
       const Type* caught_type = typeloc.getType().getTypePtr();
 
-      // Strip off pointers/references to get to the 'base' type.
+      // Strip off pointers/references to get to the pointee type.
       caught_type = RemovePointersAndReferencesAsWritten(caught_type);
       ReportTypeUse(typeloc.getBeginLoc(), caught_type);
     } else {

--- a/iwyu.cc
+++ b/iwyu.cc
@@ -1871,10 +1871,12 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
   bool VisitCXXCatchStmt(clang::CXXCatchStmt* stmt) {
     if (CanIgnoreCurrentASTNode()) return true;
 
-    if (const Type* caught_type = stmt->getCaughtType().getTypePtrOrNull()) {
+    if (const VarDecl* exception_decl = stmt->getExceptionDecl()) {
+      TypeLoc tl = exception_decl->getTypeSourceInfo()->getTypeLoc();
       // Strip off pointers/references to get to the 'base' type.
-      caught_type = RemovePointersAndReferencesAsWritten(caught_type);
-      ReportTypeUse(CurrentLoc(), caught_type);
+      const Type* caught_type =
+          RemovePointersAndReferencesAsWritten(tl.getType().getTypePtr());
+      ReportTypeUse(tl.getBeginLoc(), caught_type);
     } else {
       // catch(...): no type to act on here.
     }

--- a/iwyu.cc
+++ b/iwyu.cc
@@ -1872,11 +1872,11 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
     if (CanIgnoreCurrentASTNode()) return true;
 
     if (const VarDecl* exception_decl = stmt->getExceptionDecl()) {
-      TypeLoc tl = exception_decl->getTypeSourceInfo()->getTypeLoc();
+      TypeLoc typeloc = exception_decl->getTypeSourceInfo()->getTypeLoc();
       // Strip off pointers/references to get to the 'base' type.
       const Type* caught_type =
-          RemovePointersAndReferencesAsWritten(tl.getType().getTypePtr());
-      ReportTypeUse(tl.getBeginLoc(), caught_type);
+          RemovePointersAndReferencesAsWritten(typeloc.getType().getTypePtr());
+      ReportTypeUse(typeloc.getBeginLoc(), caught_type);
     } else {
       // catch(...): no type to act on here.
     }

--- a/iwyu.cc
+++ b/iwyu.cc
@@ -1879,7 +1879,7 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
 
       // Strip off pointers/references to get to the pointee type.
       caught_type = RemovePointersAndReferencesAsWritten(caught_type);
-      ReportTypeUse(typeloc.getBeginLoc(), caught_type);
+      ReportTypeUse(GetLocation(&typeloc), caught_type);
     } else {
       // catch(...): no type to act on here.
     }

--- a/iwyu.cc
+++ b/iwyu.cc
@@ -1873,9 +1873,10 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
 
     if (const VarDecl* exception_decl = stmt->getExceptionDecl()) {
       TypeLoc typeloc = exception_decl->getTypeSourceInfo()->getTypeLoc();
+      const Type* caught_type = typeloc.getType().getTypePtr();
+
       // Strip off pointers/references to get to the 'base' type.
-      const Type* caught_type =
-          RemovePointersAndReferencesAsWritten(typeloc.getType().getTypePtr());
+      caught_type = RemovePointersAndReferencesAsWritten(caught_type);
       ReportTypeUse(typeloc.getBeginLoc(), caught_type);
     } else {
       // catch(...): no type to act on here.

--- a/tests/cxx/catch-exceptions-macro.h
+++ b/tests/cxx/catch-exceptions-macro.h
@@ -1,0 +1,33 @@
+//===--- catch-exceptions-macro.h - test input file for iwyu ---------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_CATCH_EXCEPTIONS_MACRO_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_CATCH_EXCEPTIONS_MACRO_H_
+
+// Named catch
+#define CHECK_THROW_1(E) \
+do { \
+    try { \
+        ; \
+    } catch (const E& ex) { \
+        (void)ex; \
+    } \
+} while (0)
+
+// Unnamed catch
+#define CHECK_THROW_2(E) \
+do { \
+    try { \
+        ; \
+    } catch (const E&) { \
+        ; \
+    } \
+} while (0)
+
+#endif // INCLUDE_WHAT_YOU_USE_TESTS_CXX_CATCH_EXCEPTIONS_MACRO_H_

--- a/tests/cxx/catch-exceptions-macro.h
+++ b/tests/cxx/catch-exceptions-macro.h
@@ -1,4 +1,4 @@
-//===--- catch-exceptions-macro.h - test input file for iwyu ---------------===//
+//===--- catch-exceptions-macro.h - test input file for iwyu --------------===//
 //
 //                     The LLVM Compiler Infrastructure
 //

--- a/tests/cxx/catch-exceptions.h
+++ b/tests/cxx/catch-exceptions.h
@@ -18,6 +18,8 @@
 #include "tests/cxx/catch-byvalue.h"  // for CatchByValye
 #include "tests/cxx/catch-elab.h"     // for CatchElab
 #include "tests/cxx/catch-logex.h"    // for LogException
+#include "tests/cxx/catch-macro-1.h"  // for CatchMacro1
+#include "tests/cxx/catch-macro-2.h"  // for CatchMacro2
 #include "tests/cxx/catch-thrown.h"   // for Thrown
 
 #include <stdio.h>

--- a/tests/cxx/catch-macro-1.h
+++ b/tests/cxx/catch-macro-1.h
@@ -1,0 +1,15 @@
+//===--- catch-macro-1.h - test input file for iwyu -----------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_CATCH_MACRO_1_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_CATCH_MACRO_1_H_
+
+class CatchMacro1 {};
+
+#endif // INCLUDE_WHAT_YOU_USE_TESTS_CXX_CATCH_MACRO_1_H_

--- a/tests/cxx/catch-macro-2.h
+++ b/tests/cxx/catch-macro-2.h
@@ -1,0 +1,15 @@
+//===--- catch-macro-2.h - test input file for iwyu -----------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_CATCH_MACRO_2_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_CATCH_MACRO_2_H_
+
+class CatchMacro2 {};
+
+#endif // INCLUDE_WHAT_YOU_USE_TESTS_CXX_CATCH_MACRO_2_H_

--- a/tests/cxx/catch.cc
+++ b/tests/cxx/catch.cc
@@ -10,6 +10,7 @@
 // IWYU_ARGS: -fcxx-exceptions -fexceptions -I .
 
 #include "tests/cxx/catch-exceptions.h"
+#include "tests/cxx/catch-exceptions-macro.h"
 
 int main() {
   try {
@@ -51,6 +52,14 @@ int main() {
     puts("Unknown exception");
   }
 
+  // IWYU: CatchMacro1 needs a declaration...*
+  // IWYU: CatchMacro1...*catch-macro-1.h
+  CHECK_THROW_1(CatchMacro1);
+
+  // IWYU: CatchMacro2 needs a declaration...*
+  // IWYU: CatchMacro2...*catch-macro-2.h
+  CHECK_THROW_2(CatchMacro2);
+
   return 0;
 }
 
@@ -63,6 +72,8 @@ tests/cxx/catch.cc should add these lines:
 #include "tests/cxx/catch-byvalue.h"
 #include "tests/cxx/catch-elab.h"
 #include "tests/cxx/catch-logex.h"
+#include "tests/cxx/catch-macro-1.h"
+#include "tests/cxx/catch-macro-2.h"
 #include "tests/cxx/catch-thrown.h"
 
 tests/cxx/catch.cc should remove these lines:
@@ -74,7 +85,10 @@ The full include-list for tests/cxx/catch.cc:
 #include "tests/cxx/catch-byref.h"  // for CatchByRef
 #include "tests/cxx/catch-byvalue.h"  // for CatchByValue
 #include "tests/cxx/catch-elab.h"  // for CatchElab
+#include "tests/cxx/catch-exceptions-macro.h"  // for CHECK_THROW_1, CHECK_THROW_2
 #include "tests/cxx/catch-logex.h"  // for LogException
+#include "tests/cxx/catch-macro-1.h"  // for CatchMacro1
+#include "tests/cxx/catch-macro-2.h"  // for CatchMacro2
 #include "tests/cxx/catch-thrown.h"  // for Thrown
 
 ***** IWYU_SUMMARY */


### PR DESCRIPTION
This adds the include for the exception type "Exc" when using macros such as BOOST_CHECK_THROW(..., Exc).