### PR TITLE
Don't attempt to canonicalize '<stdin>'

### DIFF
--- a/iwyu_path_util.cc
+++ b/iwyu_path_util.cc
@@ -86,7 +86,7 @@ string Basename(const string& path) {
 string GetCanonicalName(string file_path) {
   // For this special 'path' we just return it.
   // Note that we leave the 'quotes' to make it different from regular paths.
-  if (file_path == "<built-in>")
+  if (file_path == "<built-in>" || file_path == "<stdin>")
     return file_path;
 
   CHECK_(!IsQuotedInclude(file_path));


### PR DESCRIPTION
This little beauty would cause an assertion failure in GetCanonicalName:

    printf "#include <stdio.h>" | include-what-you-use -c -x c -

Special-case '`<stdin>`' like we do with '`<built-in>`'.

Fixes issue #1105.