### PR TITLE
[clang compat] Add explicit -std=gnu++98 to badinc.cc

### DIFF
--- a/tests/cxx/badinc.cc
+++ b/tests/cxx/badinc.cc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// IWYU_ARGS: -Xiwyu --mapping_file=tests/cxx/badinc.imp -I .
+// IWYU_ARGS: -Xiwyu --mapping_file=tests/cxx/badinc.imp -std=gnu++98 -I .
 
 // This is a unittest for include-what-you-use.
 //


### PR DESCRIPTION
Clang recently moved to gnu++17 by default, where dynamic exception specifications are no longer supported. Upstream change: https://github.com/llvm/llvm-project/commit/3e99b8d947ac024831e59be2b604ac67a24fed94

Since badinc.cc is all pre-C++11 code, pin the language standard for it to gnu++98, which has a number of interesting benefits:

* makes it less rewarding to add new tests here
* any standard library changes have significantly lower impact
* it's about 30% faster

No functional change.