### PR TITLE
Test 'autocast' to value and reference separately

### DIFF
--- a/tests/cxx/iwyu_stricter_than_cpp-autocast.h
+++ b/tests/cxx/iwyu_stricter_than_cpp-autocast.h
@@ -40,8 +40,10 @@ void Fn(
 
 // --- Now do it all again, with templates!
 
-template <typename T> struct TplDirectStruct1;
-template <typename T> struct TplIndirectStruct2;
+template <typename T>
+struct TplDirectStruct1;
+template <typename T>
+struct TplIndirectStruct2;
 
 void TplFn(
     // IWYU: TplIndirectStruct1 needs a declaration
@@ -56,8 +58,7 @@ void TplFn(
     // IWYU: TplIndirectStructForwardDeclaredInD1 needs a declaration
     // IWYU: TplIndirectStructForwardDeclaredInD1 is...*iwyu_stricter_than_cpp-i1.h.*for autocast
     const struct TplIndirectStructForwardDeclaredInD1<char>& icfdid1,
-    TplDirectStruct1<char> dc1,
-    struct TplDirectStruct2<char> dc2,
+    TplDirectStruct1<char> dc1, struct TplDirectStruct2<char> dc2,
     TplIndirectStruct2<char> ic2);
 
 // --- The rules do not apply for friend functions declarations.
@@ -69,8 +70,7 @@ struct AutocastStruct {
   friend void ClassFn2(TplIndirectStruct1<char>);
 };
 
-#endif   // IWYU_STRICTER_THAN_CPP_AUTOCAST_H_
-
+#endif  // IWYU_STRICTER_THAN_CPP_AUTOCAST_H_
 
 /**** IWYU_SUMMARY
 
@@ -79,12 +79,12 @@ tests/cxx/iwyu_stricter_than_cpp-autocast.h should add these lines:
 
 tests/cxx/iwyu_stricter_than_cpp-autocast.h should remove these lines:
 - struct DirectStruct1;  // lines XX-XX
-- template <typename T> struct TplDirectStruct1;  // lines XX-XX
+- template <typename T> struct TplDirectStruct1;  // lines XX-XX+1
 
 The full include-list for tests/cxx/iwyu_stricter_than_cpp-autocast.h:
 #include "tests/cxx/iwyu_stricter_than_cpp-d1.h"  // for DirectStruct1, DirectStruct2, TplDirectStruct1, TplDirectStruct2
 #include "tests/cxx/iwyu_stricter_than_cpp-i1.h"  // for IndirectStruct1, IndirectStructForwardDeclaredInD1, TplIndirectStruct1, TplIndirectStructForwardDeclaredInD1
 struct IndirectStruct2;  // lines XX-XX
-template <typename T> struct TplIndirectStruct2;  // lines XX-XX
+template <typename T> struct TplIndirectStruct2;  // lines XX-XX+1
 
 ***** IWYU_SUMMARY */

--- a/tests/cxx/iwyu_stricter_than_cpp-autocast.h
+++ b/tests/cxx/iwyu_stricter_than_cpp-autocast.h
@@ -23,20 +23,29 @@
 struct DirectStruct1;
 struct IndirectStruct2;
 
-void Fn(
+void FnValues(
     // Requires the full type because it does not obey rule (1)
     // IWYU: IndirectStruct1 needs a declaration
     // IWYU: IndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h.*for autocast
-    const IndirectStruct1& ic1,
+    IndirectStruct1 ic1,
     // This also does not obey rule (1): it's -d1 that does the fwd-declaring.
     // IWYU: IndirectStructForwardDeclaredInD1 is...*iwyu_stricter_than_cpp-i1.h.*for autocast
-    const struct IndirectStructForwardDeclaredInD1& icfdid1,
+    struct IndirectStructForwardDeclaredInD1 icfdid1,
     // Requires the full type because it does not obey rule (2)
     DirectStruct1 dc1,
     // Requires the full type because it does not obey rules (1) *or* (2)
     struct DirectStruct2 dc2,
     // Does not require full type because it obeys all the rules.
     IndirectStruct2 ic2);
+
+void FnRefs(
+    // IWYU: IndirectStruct1 needs a declaration
+    // IWYU: IndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h.*for autocast
+    const IndirectStruct1& ic1,
+    // IWYU: IndirectStructForwardDeclaredInD1 is...*iwyu_stricter_than_cpp-i1.h.*for autocast
+    const struct IndirectStructForwardDeclaredInD1& icfdid1,
+    const DirectStruct3& dc1, const struct DirectStruct4& dc2,
+    const IndirectStruct2& ic2);
 
 // --- Now do it all again, with templates!
 
@@ -45,10 +54,10 @@ struct TplDirectStruct1;
 template <typename T>
 struct TplIndirectStruct2;
 
-void TplFn(
+void TplFnValues(
     // IWYU: TplIndirectStruct1 needs a declaration
     // IWYU: TplIndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h.*for autocast
-    const TplIndirectStruct1<char>& ic1,
+    TplIndirectStruct1<char> ic1,
     // A bit of an asymmetry with the non-tpl case: 'struct
     // IndirectStructForwardDeclaredInD1' does not need to be
     // forward-declared because it's elaborated, but template types
@@ -57,9 +66,19 @@ void TplFn(
     // full-type requirement due to autocast, but we report both.)
     // IWYU: TplIndirectStructForwardDeclaredInD1 needs a declaration
     // IWYU: TplIndirectStructForwardDeclaredInD1 is...*iwyu_stricter_than_cpp-i1.h.*for autocast
-    const struct TplIndirectStructForwardDeclaredInD1<char>& icfdid1,
+    struct TplIndirectStructForwardDeclaredInD1<char> icfdid1,
     TplDirectStruct1<char> dc1, struct TplDirectStruct2<char> dc2,
     TplIndirectStruct2<char> ic2);
+
+void TplFnRefs(
+    // IWYU: TplIndirectStruct1 needs a declaration
+    // IWYU: TplIndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h.*for autocast
+    const TplIndirectStruct1<char>& ic1,
+    // IWYU: TplIndirectStructForwardDeclaredInD1 needs a declaration
+    // IWYU: TplIndirectStructForwardDeclaredInD1 is...*iwyu_stricter_than_cpp-i1.h.*for autocast
+    const struct TplIndirectStructForwardDeclaredInD1<char>& icfdid1,
+    const TplDirectStruct3<char>& dc1, const struct TplDirectStruct4<char>& dc2,
+    const TplIndirectStruct2<char>& ic2);
 
 // --- The rules do not apply for friend functions declarations.
 
@@ -82,7 +101,7 @@ tests/cxx/iwyu_stricter_than_cpp-autocast.h should remove these lines:
 - template <typename T> struct TplDirectStruct1;  // lines XX-XX+1
 
 The full include-list for tests/cxx/iwyu_stricter_than_cpp-autocast.h:
-#include "tests/cxx/iwyu_stricter_than_cpp-d1.h"  // for DirectStruct1, DirectStruct2, TplDirectStruct1, TplDirectStruct2
+#include "tests/cxx/iwyu_stricter_than_cpp-d1.h"  // for DirectStruct1, DirectStruct2, DirectStruct3, DirectStruct4, TplDirectStruct1, TplDirectStruct2, TplDirectStruct3, TplDirectStruct4
 #include "tests/cxx/iwyu_stricter_than_cpp-i1.h"  // for IndirectStruct1, IndirectStructForwardDeclaredInD1, TplIndirectStruct1, TplIndirectStructForwardDeclaredInD1
 struct IndirectStruct2;  // lines XX-XX
 template <typename T> struct TplIndirectStruct2;  // lines XX-XX+1

--- a/tests/cxx/iwyu_stricter_than_cpp-d1.h
+++ b/tests/cxx/iwyu_stricter_than_cpp-d1.h
@@ -15,12 +15,27 @@
 
 // Note all these structs have an 'autocast' constructor.
 
-struct DirectStruct1 { DirectStruct1(int) {} };
-struct DirectStruct2 { DirectStruct2(int) {} };
+struct DirectStruct1 {
+  DirectStruct1(int) {
+  }
+};
+struct DirectStruct2 {
+  DirectStruct2(int) {
+  }
+};
 struct IndirectStructForwardDeclaredInD1;
 
-template <typename T> struct TplDirectStruct1 { TplDirectStruct1(int) {} };
-template <typename T> struct TplDirectStruct2 { TplDirectStruct2(int) {} };
-template <typename T> struct TplIndirectStructForwardDeclaredInD1;
+template <typename T>
+struct TplDirectStruct1 {
+  TplDirectStruct1(int) {
+  }
+};
+template <typename T>
+struct TplDirectStruct2 {
+  TplDirectStruct2(int) {
+  }
+};
+template <typename T>
+struct TplIndirectStructForwardDeclaredInD1;
 
 #endif

--- a/tests/cxx/iwyu_stricter_than_cpp-d1.h
+++ b/tests/cxx/iwyu_stricter_than_cpp-d1.h
@@ -23,6 +23,14 @@ struct DirectStruct2 {
   DirectStruct2(int) {
   }
 };
+struct DirectStruct3 {
+  DirectStruct3(int) {
+  }
+};
+struct DirectStruct4 {
+  DirectStruct4(int) {
+  }
+};
 struct IndirectStructForwardDeclaredInD1;
 
 template <typename T>
@@ -33,6 +41,16 @@ struct TplDirectStruct1 {
 template <typename T>
 struct TplDirectStruct2 {
   TplDirectStruct2(int) {
+  }
+};
+template <typename T>
+struct TplDirectStruct3 {
+  TplDirectStruct3(int) {
+  }
+};
+template <typename T>
+struct TplDirectStruct4 {
+  TplDirectStruct4(int) {
   }
 };
 template <typename T>

--- a/tests/cxx/iwyu_stricter_than_cpp.cc
+++ b/tests/cxx/iwyu_stricter_than_cpp.cc
@@ -139,13 +139,19 @@ void TestTypeAliases() {
 }
 
 void TestAutocast() {
-  // We need full type of is2 because the declarer of Fn didn't
+  // We need full type of IndirectStruct2 because the declarer of FnValues and
+  // FnRefs didn't.
   // IWYU: IndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
-  Fn(1, 2, 3, 4, 5);
+  FnValues(1, 2, 3, 4, 5);
+  // IWYU: IndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
+  FnRefs(1, 2, 3, 4, 5);
 
-  // We need full type of is2 because the declarer of Fn didn't
-  // IWYU: IndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
-  TplFn(6, 7, 8, 9, 10);
+  // We need full type of TplIndirectStruct2 because the declarer of TplFnValues
+  // and TplFnRefs didn't.
+  // IWYU: TplIndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
+  TplFnValues(6, 7, 8, 9, 10);
+  // IWYU: TplIndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
+  TplFnRefs(6, 7, 8, 9, 10);
 }
 
 void TestFunctionReturn() {
@@ -217,7 +223,7 @@ tests/cxx/iwyu_stricter_than_cpp.cc should remove these lines:
 
 The full include-list for tests/cxx/iwyu_stricter_than_cpp.cc:
 #include "tests/cxx/indirect.h"  // for IndirectClass
-#include "tests/cxx/iwyu_stricter_than_cpp-autocast.h"  // for Fn, TplFn
+#include "tests/cxx/iwyu_stricter_than_cpp-autocast.h"  // for FnRefs, FnValues, TplFnRefs, TplFnValues
 #include "tests/cxx/iwyu_stricter_than_cpp-d3.h"  // for IndirectStruct3ProvidingAl, IndirectStruct3ProvidingTypedef, IndirectStruct4ProvidingAl, IndirectStruct4ProvidingTypedef
 #include "tests/cxx/iwyu_stricter_than_cpp-fnreturn.h"  // for DoesEverythingRightFn, DoesNotForwardDeclareAndIncludesFn, DoesNotForwardDeclareFn, DoesNotForwardDeclareProperlyFn, IncludesFn, TplDoesEverythingRightAgainFn, TplDoesEverythingRightFn, TplDoesNotForwardDeclareAndIncludesFn, TplDoesNotForwardDeclareFn, TplDoesNotForwardDeclareProperlyFn, TplIncludesFn
 #include "tests/cxx/iwyu_stricter_than_cpp-i2.h"  // for IndirectStruct2, TplIndirectStruct2


### PR DESCRIPTION
It is needed in order to be able to add definition to passing-by-ref function and test on it "autocast" rules, not type info requirement due to parameter variable definition.
New `DirectStruct*`s and `TplDirectStruct*`s are added because requirement to '#include' their header is tested only by that `#include`, no inline diagnostics are emitted.