### PR TITLE
fix: Don't always pull MacOs libcxx's header

### DIFF
--- a/iwyu_driver.cc
+++ b/iwyu_driver.cc
@@ -216,20 +216,6 @@ CompilerInstance* CreateCompilerInstance(int argc, const char **argv) {
   CompilerInvocation::CreateFromArgs(*invocation, cc_arguments, diagnostics);
   invocation->getFrontendOpts().DisableFree = false;
 
-  // Use libc++ headers bundled with Xcode.app on macOS.
-  llvm::Triple triple(invocation->getTargetOpts().Triple);
-  if (triple.isOSDarwin() && invocation->getHeaderSearchOpts().UseLibcxx) {
-    invocation->getHeaderSearchOpts().AddPath(
-        "/Library/Developer/CommandLineTools/usr/include/c++/v1/",
-        clang::frontend::CXXSystem,
-        /*IsFramework=*/false, /*IgnoreSysRoot=*/true);
-    invocation->getHeaderSearchOpts().AddPath(
-        "/Applications/Xcode.app/Contents/Developer/Toolchains/"
-        "XcodeDefault.xctoolchain/usr/include/c++/v1",
-        clang::frontend::CXXSystem,
-        /*IsFramework=*/false, /*IgnoreSysRoot=*/true);
-  }
-
   // Show the invocation, with -v.
   if (invocation->getHeaderSearchOpts().Verbose) {
     errs() << "clang invocation:\n";


### PR DESCRIPTION
Nix try hard to isolate tools to ensure reproducibility: It will use a libcxx under his control. On darwin iwyu see two libcxx and get confused so this PR allow to become optional

For further context https://github.com/NixOS/nixpkgs/issues/189753#issuecomment-1251200266