### PR TITLE
Better support CRLF line endings in custom lexer

### DIFF
--- a/iwyu_lexer_utils.cc
+++ b/iwyu_lexer_utils.cc
@@ -49,7 +49,7 @@ const char* SourceManagerCharacterDataGetter::GetCharacterData(
 StringRef GetSourceTextUntilEndOfLine(
     SourceLocation start_loc, const CharacterDataGetterInterface& data_getter) {
   const char* data = data_getter.GetCharacterData(start_loc);
-  const char* line_end = strchr(data, '\n');
+  const char* line_end = strpbrk(data, "\r\n");
   if (!line_end)
     return data;
   return StringRef(data, line_end - data);


### PR DESCRIPTION
Running the tests/cxx/comment_pragmas.cc test on Windows fails saying that <some_system_header_file> is not diagnosed correctly.

Turns out to be because our custom lexer for GNU @headername comment directives did not respect Windows line endings, and failed properly identify the @headername.

Match on both CR and LF when attempting to find end of line.