### PR TITLE
Fix template instantiation reporting

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -2682,8 +2682,7 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
   // void fn(const S<Class>& s) { // Forward declarations are sufficient here.
   //   (void)s.t; // Full 'Class' type is needed due to template instantiation.
   // }
-  void ReportTplSpecComponentTypes(const TemplateSpecializationType*) {
-  }
+  void ReportTplSpecComponentTypes(const TemplateSpecializationType*) = delete;
 
   // Do not add any variables here!  If you do, they will not be shared
   // between the normal iwyu ast visitor and the
@@ -3234,6 +3233,12 @@ class InstantiatedTemplateVisitor
     CHECK_(actual_type && "If !CanIgnoreType(), we should be resugar-able");
     ReportTypeUse(caller_loc(), actual_type);
     return Base::VisitCXXConstructExpr(expr);
+  }
+
+  // --- Handler declared in IwyuBaseASTVisitor.
+
+  void ReportTplSpecComponentTypes(const TemplateSpecializationType* type) {
+    TraverseDataAndTypeMembersOfClassHelper(type);
   }
 
  private:

--- a/tests/cxx/array.cc
+++ b/tests/cxx/array.cc
@@ -24,8 +24,27 @@ class A {
     // IWYU: IndirectClass is...*indirect.h
     return &(b[i]);
   }
+
+  // IWYU: IndirectTemplate needs a declaration
+  // IWYU: IndirectClass needs a declaration
+  IndirectTemplate<IndirectClass> *getIndirectTemplateSpecialization(int i) {
+    // IWYU: IndirectTemplate is...*indirect.h
+    // IWYU: IndirectClass is...*indirect.h
+    (void)sizeof(t[i]);  // requires full type
+    // IWYU: IndirectTemplate needs a declaration
+    // IWYU: IndirectTemplate is...*indirect.h
+    // IWYU: IndirectClass is...*indirect.h
+    (void)sizeof(&(t[i]));  // requires full type
+    // IWYU: IndirectTemplate is...*indirect.h
+    // IWYU: IndirectClass is...*indirect.h
+    return &(t[i]);
+  }
+
   // IWYU: IndirectClass needs a declaration
   IndirectClass *b;
+  // IWYU: IndirectTemplate needs a declaration
+  // IWYU: IndirectClass needs a declaration
+  IndirectTemplate<IndirectClass> *t;
 };
 
 
@@ -38,6 +57,6 @@ tests/cxx/array.cc should remove these lines:
 - #include "tests/cxx/direct.h"  // lines XX-XX
 
 The full include-list for tests/cxx/array.cc:
-#include "tests/cxx/indirect.h"  // for IndirectClass
+#include "tests/cxx/indirect.h"  // for IndirectClass, IndirectTemplate
 
 ***** IWYU_SUMMARY */

--- a/tests/cxx/array.cc
+++ b/tests/cxx/array.cc
@@ -17,15 +17,15 @@ class A {
   // IWYU: IndirectClass needs a declaration
   IndirectClass *getIndirectClass(int i) {
     // IWYU: IndirectClass is...*indirect.h
-    (void)sizeof(_b[i]);  // requires full type
+    (void)sizeof(b[i]);  // requires full type
     // IWYU: IndirectClass needs a declaration
     // IWYU: IndirectClass is...*indirect.h
-    (void)sizeof(&(_b[i]));  // requires full type
+    (void)sizeof(&(b[i]));  // requires full type
     // IWYU: IndirectClass is...*indirect.h
-    return &(_b[i]);
+    return &(b[i]);
   }
   // IWYU: IndirectClass needs a declaration
-  IndirectClass *_b;
+  IndirectClass *b;
 };
 
 

--- a/tests/cxx/array.cc
+++ b/tests/cxx/array.cc
@@ -17,10 +17,10 @@ class A {
   // IWYU: IndirectClass needs a declaration
   IndirectClass *getIndirectClass(int i) {
     // IWYU: IndirectClass is...*indirect.h
-    (void) sizeof(_b[i]);     // requires full type
+    (void)sizeof(_b[i]);  // requires full type
     // IWYU: IndirectClass needs a declaration
     // IWYU: IndirectClass is...*indirect.h
-    (void) sizeof(&(_b[i]));  // requires full type
+    (void)sizeof(&(_b[i]));  // requires full type
     // IWYU: IndirectClass is...*indirect.h
     return &(_b[i]);
   }

--- a/tests/cxx/badinc.cc
+++ b/tests/cxx/badinc.cc
@@ -1565,17 +1565,17 @@ int main() {
   // IWYU: i1_ns::I1_NamespaceClass is...*badinc-i1.h
   I1_Class* i1_class_tpl_ctor = new I1_Class(&i1_namespace_class, 1);
 
-  // TODO(csilvers): IWYU: I2_Class needs a declaration
+  // IWYU: I2_Class is...*badinc-i2.h
   // IWYU: I2_Class::~I2_Class is...*badinc-i2-inl.h
   // IWYU: I1_Struct is...*badinc-i1.h
   // IWYU: I1_TemplateClass is...*badinc-i1.h
   delete newed_i1_template_class;
-  // TODO(csilvers): IWYU: I2_Class needs a declaration
+  // IWYU: I2_Class is...*badinc-i2.h
   // IWYU: I2_Class::~I2_Class is...*badinc-i2-inl.h
   // IWYU: I1_Struct is...*badinc-i1.h
   // IWYU: I1_TemplateClass is...*badinc-i1.h
   delete[] newed_i1_template_class_array;
-  // TODO(csilvers): IWYU: I2_Class needs a declaration
+  // IWYU: I2_Class is...*badinc-i2.h
   // IWYU: I2_Class::~I2_Class is...*badinc-i2-inl.h
   // IWYU: I1_Struct is...*badinc-i1.h
   // IWYU: I1_TemplateClass is...*badinc-i1.h

--- a/tests/cxx/indirect.h
+++ b/tests/cxx/indirect.h
@@ -25,5 +25,18 @@ class IndirectClass {
   static int statica;
 };
 
+template <typename T>
+class IndirectTemplate {
+ public:
+  void Method() const {
+  }
+  int a;
+  static void StaticMethod() {
+  }
+
+ private:
+  T t;
+};
+
 
 #endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_INDIRECT_H_

--- a/tests/cxx/indirect.h
+++ b/tests/cxx/indirect.h
@@ -17,9 +17,11 @@
 
 class IndirectClass {
  public:
-  void Method() const { }
+  void Method() const {
+  }
   int a;
-  static void StaticMethod() { }
+  static void StaticMethod() {
+  }
   static int statica;
 };
 

--- a/tests/cxx/indirect.h
+++ b/tests/cxx/indirect.h
@@ -17,9 +17,9 @@
 
 class IndirectClass {
  public:
-  void Method() const { };
+  void Method() const { }
   int a;
-  static void StaticMethod() { };
+  static void StaticMethod() { }
   static int statica;
 };
 

--- a/tests/cxx/member_expr.cc
+++ b/tests/cxx/member_expr.cc
@@ -58,6 +58,68 @@ void ViaMacro(const IndirectClass& ic) {
 }
 
 
+// Because any member expression instantiates the template, the template
+// specialization used as a member expression base requires full type info for
+// all the template type arguments that are full-type-used for member
+// initializers, non-static data members or nested typedef instantiation,
+// regardless of whether those types are part of the member expression or not.
+
+// IWYU: IndirectTemplate needs a declaration
+// IWYU: IndirectClass needs a declaration
+int RefFn(const IndirectTemplate<IndirectClass>& ic) {
+  // IWYU: IndirectTemplate is...*indirect.h
+  // IWYU: IndirectClass is...*indirect.h
+  ic.Method();
+  // IWYU: IndirectTemplate is...*indirect.h
+  // IWYU: IndirectClass is...*indirect.h
+  return ic.a;
+}
+
+// IWYU: IndirectTemplate needs a declaration
+// IWYU: IndirectClass needs a declaration
+int PtrFn(const IndirectTemplate<IndirectClass>* ic) {
+  // IWYU: IndirectTemplate is...*indirect.h
+  // IWYU: IndirectClass is...*indirect.h
+  ic->Method();
+  // IWYU: IndirectTemplate is...*indirect.h
+  // IWYU: IndirectClass is...*indirect.h
+  return ic->a;
+}
+
+void TemplateStaticFn() {
+  // IWYU: IndirectTemplate is...*indirect.h
+  // IWYU: IndirectClass needs a declaration
+  // IWYU: IndirectClass is...*indirect.h
+  IndirectTemplate<IndirectClass>::StaticMethod();
+}
+
+// IWYU: IndirectTemplate needs a declaration
+// IWYU: IndirectClass needs a declaration
+void ViaMacro(const IndirectTemplate<IndirectClass>& ic) {
+  // We should figure out we need IndirectTemplate and IndirectClass
+  // because of the 'ic.', even if the member-expr itself is in another file
+  // due to the macro.
+  // IWYU: IndirectTemplate is...*indirect.h
+  // IWYU: IndirectClass is...*indirect.h
+  ic.CALL_METHOD;
+
+  // Likewise, we 'own' this member expr because we own the dot.
+  // IWYU: IndirectTemplate is...*indirect.h
+  // IWYU: IndirectClass is...*indirect.h
+  IC.Method();
+  // IWYU: IndirectTemplate is...*indirect.h
+  // IWYU: IndirectClass is...*indirect.h
+  IC.CALL_METHOD;
+
+  IC.
+      // IWYU: IndirectTemplate is...*indirect.h
+      // IWYU: IndirectClass is...*indirect.h
+      CALL_METHOD;
+
+  // But this member-expr is entirely in the macro, so we don't own it.
+  IC_CALL_METHOD;
+}
+
 /**** IWYU_SUMMARY
 
 tests/cxx/member_expr.cc should add these lines:
@@ -67,7 +129,7 @@ tests/cxx/member_expr.cc should remove these lines:
 - #include "tests/cxx/direct.h"  // lines XX-XX
 
 The full include-list for tests/cxx/member_expr.cc:
-#include "tests/cxx/indirect.h"  // for IndirectClass
+#include "tests/cxx/indirect.h"  // for IndirectClass, IndirectTemplate
 #include "tests/cxx/member_expr-d1.h"  // for CALL_METHOD, IC, IC_CALL_METHOD
 
 ***** IWYU_SUMMARY */

--- a/tests/cxx/placement_new.cc
+++ b/tests/cxx/placement_new.cc
@@ -90,6 +90,7 @@ void PlacementNewOfTemplate() {
 
   // Make sure we handle it right when we explicitly call the dtor, as well.
   // IWYU: ClassTemplate is...*placement_new-i1.h
+  // IWYU: IndirectClass is...*indirect.h
   placement_newed_template->~ClassTemplate();
 }
 

--- a/tests/cxx/pointer_arith.cc
+++ b/tests/cxx/pointer_arith.cc
@@ -47,6 +47,47 @@ void PointerArithmetic() {
   p1 += 100;
 }
 
+// IWYU: IndirectTemplate is...*indirect.h
+// IWYU: IndirectClass needs a declaration
+// IWYU: IndirectClass is...*indirect.h
+IndirectTemplate<IndirectClass> itc1, itc2;
+
+void PointerArithmeticWithTemplates() {
+  // IWYU: IndirectTemplate needs a declaration
+  // IWYU: IndirectClass needs a declaration
+  IndirectTemplate<IndirectClass>* p1 = &itc1;
+  // IWYU: IndirectTemplate needs a declaration
+  // IWYU: IndirectClass needs a declaration
+  IndirectTemplate<IndirectClass>* p2 = &itc2;
+
+  // All the pointer arithmetic below require the full type.
+
+  // Pointer minus pointer
+  // IWYU: IndirectTemplate is...*indirect.h
+  // IWYU: IndirectClass is...*indirect.h
+  long x = p2 - p1;
+
+  // Pointer minus offset
+  // IWYU: IndirectTemplate is...*indirect.h
+  // IWYU: IndirectClass is...*indirect.h
+  void* p3 = p1 - 20;
+
+  // Pointer decrement
+  // IWYU: IndirectTemplate is...*indirect.h
+  // IWYU: IndirectClass is...*indirect.h
+  p1 -= 10;
+
+  // Pointer plus offset
+  // IWYU: IndirectTemplate is...*indirect.h
+  // IWYU: IndirectClass is...*indirect.h
+  p3 = p1 + 100;
+
+  // Pointer increment
+  // IWYU: IndirectTemplate is...*indirect.h
+  // IWYU: IndirectClass is...*indirect.h
+  p1 += 100;
+}
+
 // Make sure pointer arithmetic with builtins does not yield IWYU warnings.
 void BuiltinPointerArithmetic() {
   char c = 0;
@@ -71,6 +112,6 @@ tests/cxx/pointer_arith.cc should remove these lines:
 - #include "tests/cxx/direct.h"  // lines XX-XX
 
 The full include-list for tests/cxx/pointer_arith.cc:
-#include "tests/cxx/indirect.h"  // for IndirectClass
+#include "tests/cxx/indirect.h"  // for IndirectClass, IndirectTemplate
 
 ***** IWYU_SUMMARY */

--- a/tests/cxx/template_args.cc
+++ b/tests/cxx/template_args.cc
@@ -80,6 +80,10 @@ void PointerClassArguments() {
 
 template<typename T> struct Outer { T t; };
 template<typename T> struct Inner { T t; };
+struct StaticTemplateFieldStruct {
+  // IWYU: IndirectClass needs a declaration
+  static Inner<IndirectClass> tpl;
+};
 
 void NestedTemplateArguments() {
   // IWYU: IndirectClass needs a declaration
@@ -94,6 +98,23 @@ void NestedTemplateArguments() {
   // IWYU: IndirectClass needs a declaration
   Outer<Inner<IndirectClass> >* opi;
   (void)opi;
+
+  // Test that use of template specialization type template argument is not
+  // hidden by any sugar in the AST.
+
+  // IWYU: IndirectClass is...*indirect.h
+  Outer<decltype(StaticTemplateFieldStruct::tpl)> osi;
+  // Member referencing also requires template instantiation and nested member
+  // full-type-use reporting.
+  // IWYU: IndirectClass is...*indirect.h
+  (void)osi.t;
+
+  Outer<decltype(StaticTemplateFieldStruct::tpl)*> osip;
+  (void)osip.t;
+
+  Outer<decltype(StaticTemplateFieldStruct::tpl)>* opsi;
+  // IWYU: IndirectClass is...*indirect.h
+  (void)opsi->t;
 }
 
 // ---------------------------------------------------------------


### PR DESCRIPTION
Full template specialization type use requires full information about its template-argument-dependent fields and nested typedefs. But earlier, it wasn't reported in many cases when template specialization type isn't written explicitly in non-fwd-decl context.