### PR TITLE
add a flag to workaround cyclic include issues

### DIFF
--- a/include-what-you-use.1
+++ b/include-what-you-use.1
@@ -160,6 +160,9 @@ Print full include list with comments, even if there are no
 .BI \-\-verbose= level
 Set verbosity. At the highest level, this will dump the AST of the source file
 and explain all decisions.
+.TP
+.B \-\-ignore-cycles
+Do not assert on cyclic includes.
 .SH EXIT STATUS
 By default
 .B include-what-you-use

--- a/iwyu_globals.cc
+++ b/iwyu_globals.cc
@@ -112,6 +112,7 @@ static void PrintHelp(const char* extra_msg) {
          "   --regex=<dialect>: use specified regex dialect in IWYU:\n"
          "          llvm:       fast and simple (default)\n"
          "          ecmascript: slower, but more feature-complete\n"
+         "   --ignore_cycles: don't assert on cyclic includes\n"
          "\n"
          "In addition to IWYU-specific options you can specify the following\n"
          "options without -Xiwyu prefix:\n"
@@ -202,7 +203,8 @@ CommandlineFlags::CommandlineFlags()
       cxx17ns(false),
       exit_code_error(EXIT_SUCCESS),
       exit_code_always(EXIT_SUCCESS),
-      regex_dialect(RegexDialect::LLVM) {
+      regex_dialect(RegexDialect::LLVM),
+      ignore_cycles(false) {
   // Always keep Qt .moc includes; its moc compiler does its own IWYU analysis.
   keep.emplace("*.moc");
 }
@@ -228,6 +230,7 @@ int CommandlineFlags::ParseArgv(int argc, char** argv) {
     {"error_always", optional_argument, nullptr, 'a'},
     {"debug", required_argument, nullptr, 'd'},
     {"regex", required_argument, nullptr, 'r'},
+    {"ignore_cycles", no_argument, nullptr, 'y'},
     {nullptr, 0, nullptr, 0}
   };
   static const char shortopts[] = "v:c:m:d:nr";
@@ -308,6 +311,7 @@ int CommandlineFlags::ParseArgv(int argc, char** argv) {
           exit(EXIT_FAILURE);
         }
         break;
+      case 'y': ignore_cycles = true; break;
       case -1: return optind;   // means 'no more input'
       default:
         PrintHelp("FATAL ERROR: unknown flag.");

--- a/iwyu_globals.h
+++ b/iwyu_globals.h
@@ -100,6 +100,7 @@ struct CommandlineFlags {
   int exit_code_always;  // Always exit with this exit code.
   set<string> dbg_flags; // Debug flags.
   RegexDialect regex_dialect;  // Dialect for regular expression processing.
+  bool ignore_cycles; // -y: don't assert on cyclic includes
 };
 
 const CommandlineFlags& GlobalFlags();

--- a/iwyu_include_picker.cc
+++ b/iwyu_include_picker.cc
@@ -1101,11 +1101,17 @@ void MakeNodeTransitive(IncludePicker::IncludeMap* filename_map,
     }
   }
   if (status == kCalculating) {
-    VERRS(0) << "Cycle in include-mapping:\n";
-    for (const string& node : *node_stack)
-      VERRS(0) << "  " << node << " ->\n";
-    VERRS(0) << "  " << key << "\n";
-    CHECK_UNREACHABLE_("Cycle in include-mapping");  // cycle is a fatal error
+
+    if (GlobalFlags().ignore_cycles) {
+      VERRS(0) << "Ignoring a cyclical mapping involving " << key << "\n";
+      return;
+    } else {
+      VERRS(0) << "Cycle in include-mapping:\n";
+      for (const string& node : *node_stack)
+        VERRS(0) << "  " << node << " ->\n";
+      VERRS(0) << "  " << key << "\n";
+      CHECK_UNREACHABLE_("Cycle in include-mapping");  // cycle is a fatal error
+    }
   }
   if (status == kDone)
     return;

--- a/tests/cxx/include_cycle-d1.h
+++ b/tests/cxx/include_cycle-d1.h
@@ -1,0 +1,21 @@
+//===--- include_cycle-d1.h - test input file for iwyu --------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_CYCLE_D1_H
+#define INCLUDE_CYCLE_D1_H
+
+// Include itself (cycle length 1)
+#include "tests/cxx/include_cycle-d1.h"
+
+// Include another file that includes itself (cycle length 2)
+#include "tests/cxx/include_cycle-i1.h"
+
+struct IncludeCycleD1 {};
+
+#endif  /* #ifndef INCLUDE_CYCLE_D1_H */

--- a/tests/cxx/include_cycle-i1.h
+++ b/tests/cxx/include_cycle-i1.h
@@ -1,0 +1,15 @@
+//===--- include_cycle-i1.h - test input file for iwyu --------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_CYCLE_I1_H
+#define INCLUDE_CYCLE_I1_H
+
+#include "tests/cxx/include_cycle-d1.h"
+
+#endif  /* #ifndef INCLUDE_CYCLE_I1_H */

--- a/tests/cxx/include_cycle_external.cc
+++ b/tests/cxx/include_cycle_external.cc
@@ -1,0 +1,23 @@
+//===--- include_cycle.cc - test input file for iwyu ----------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_ARGS: -I .
+
+// Tests that we properly handle the case of include-cycles (header files
+// including themselves, possibly indirectly)
+
+#include "tests/cxx/include_cycle-d1.h"
+
+IncludeCycleD1 d1;
+
+// no output is expected because iwyu asserts on include-cycles
+
+/**** IWYU_SUMMARY
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/include_cycle_ignore.cc
+++ b/tests/cxx/include_cycle_ignore.cc
@@ -1,0 +1,23 @@
+//===--- include_cycle.cc - test input file for iwyu ----------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_ARGS: -I . -Xiwyu --ignore_cycles
+
+// Tests that we properly handle the case of include-cycles (header files
+// including themselves, possibly indirectly)
+
+#include "tests/cxx/include_cycle-d1.h"
+
+IncludeCycleD1 d1;
+
+/**** IWYU_SUMMARY
+
+(tests/cxx/include_cycle_ignore.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
this is an attemps to workaround this issue:
https://github.com/include-what-you-use/include-what-you-use/issues/424

Signed-off-by: yuval Lifshitz <ylifshit@redhat.com>