### PR TITLE
Add --silence_correct option for iwyu, tests, docs

### DIFF
--- a/include-what-you-use.1
+++ b/include-what-you-use.1
@@ -160,6 +160,9 @@ Print full include list with comments, even if there are no
 .BI \-\-verbose= level
 Set verbosity. At the highest level, this will dump the AST of the source file
 and explain all decisions.
+.TP
+.BI \-\-silence_correct
+Files with correct includes and forward declarations produce no output.
 .SH EXIT STATUS
 By default
 .B include-what-you-use

--- a/iwyu_globals.cc
+++ b/iwyu_globals.cc
@@ -102,6 +102,7 @@ static void PrintHelp(const char* extra_msg) {
          "        #include lines need to be added or removed.\n"
          "   --no_fwd_decls: do not use forward declarations.\n"
          "   --verbose=<level>: the higher the level, the more output.\n"
+         "   --silence_correct: no output for files with the correct includes.\n" 
          "   --quoted_includes_first: when sorting includes, place quoted\n"
          "        ones first.\n"
          "   --cxx17ns: suggests the more concise syntax introduced in C++17\n"
@@ -190,6 +191,7 @@ OptionsParser::~OptionsParser() {
 CommandlineFlags::CommandlineFlags()
     : transitive_includes_only(false),
       verbose(getenv("IWYU_VERBOSE") ? atoi(getenv("IWYU_VERBOSE")) : 1),
+      silence_correct(false),
       no_default_mappings(false),
       max_line_length(80),
       prefix_header_include_policy(CommandlineFlags::kAdd),
@@ -213,6 +215,7 @@ int CommandlineFlags::ParseArgv(int argc, char** argv) {
     {"keep", required_argument, nullptr, 'k'},  // can be specified >once
     {"transitive_includes_only", no_argument, nullptr, 't'},
     {"verbose", required_argument, nullptr, 'v'},
+    {"silence_correct", no_argument, nullptr, 's'},
     {"mapping_file", required_argument, nullptr, 'm'},
     {"no_default_mappings", no_argument, nullptr, 'n'},
     {"prefix_header_includes", required_argument, nullptr, 'x'},
@@ -237,6 +240,7 @@ int CommandlineFlags::ParseArgv(int argc, char** argv) {
       case 'k': AddGlobToKeepIncludes(optarg); break;
       case 't': transitive_includes_only = true; break;
       case 'v': verbose = atoi(optarg); break;
+      case 's': silence_correct = true; break;
       case 'm': mapping_files.push_back(optarg); break;
       case 'n': no_default_mappings = true; break;
       case 'o': no_comments = true; break;

--- a/iwyu_globals.h
+++ b/iwyu_globals.h
@@ -83,6 +83,7 @@ struct CommandlineFlags {
   set<string> keep;        // -k: globs to force-keep includes for
   bool transitive_includes_only;   // -t: don't add 'new' #includes to files
   int verbose;             // -v: how much information to emit as we parse
+  bool silence_correct;    // -s: files with correct includes/fwd decls produce no output.
   vector<string> mapping_files; // -m: mapping files
   bool no_default_mappings;     // -n: no default mappings
   // Truncate output lines to this length. No short option.

--- a/iwyu_output.cc
+++ b/iwyu_output.cc
@@ -2012,7 +2012,9 @@ size_t PrintableDiffs(const string& filename,
     }
   }
   if (no_adds_or_deletes && !GlobalFlags().update_comments) {
-    output = "\n(" + filename + " has correct #includes/fwd-decls)\n";
+    if(!GlobalFlags().silence_correct) {
+      output = "\n(" + filename + " has correct #includes/fwd-decls)\n";
+    }
     return 0;
   }
 

--- a/tests/cxx/silence_correct_invalid.cc
+++ b/tests/cxx/silence_correct_invalid.cc
@@ -1,0 +1,23 @@
+//===--- silence_correct_invalid.cc - test input file for iwyu ------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_ARGS: -Xiwyu --silence_correct -I .
+
+#include "tests/cxx/comment_style-d1.h"
+
+/***** IWYU_SUMMARY
+tests/cxx/silence_correct_invalid.cc should add these lines:
+
+tests/cxx/silence_correct_invalid.cc should remove these lines:
+- #include "tests/cxx/comment_style-d1.h"  // lines XX-XX
+
+The full include-list for tests/cxx/silence_correct_invalid.cc:
+
+****** IWYU_SUMMARY */
+

--- a/tests/cxx/silence_correct_valid.cc
+++ b/tests/cxx/silence_correct_valid.cc
@@ -1,0 +1,20 @@
+//===--- silence_correct_valid.cc - test input file for iwyu --------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_ARGS: -Xiwyu --silence_correct -I .
+
+#include "tests/cxx/comment_style-d1.h"
+
+int main() {
+  Foo::bar(1);
+  return 0;
+}
+
+/**** IWYU_SUMMARY
+***** IWYU_SUMMARY */


### PR DESCRIPTION
this was requested by #999 and #1130, it adds the
ability to suppress correct includes messages, to
reduce the noise of output generated by IWYU

wrote some tests and updated documentation to reflect the change
this nullifies all output for verbose levels <= 3