### PR TITLE
Fix opaque declaration of enum with bool underlying type

### DIFF
--- a/iwyu_output.cc
+++ b/iwyu_output.cc
@@ -30,6 +30,7 @@
 // IWYU pragma: no_include "foo/bar/baz.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/raw_ostream.h"
+#include "clang/AST/ASTContext.h"
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclBase.h"
 #include "clang/AST/DeclTemplate.h"
@@ -150,7 +151,8 @@ const FakeNamedDecl* FakeNamedDeclIfItIsOne(const clang::NamedDecl* decl) {
 std::string PrintableUnderlyingType(const EnumDecl* enum_decl) {
   if (const clang::TypeSourceInfo* type_source_info =
           enum_decl->getIntegerTypeSourceInfo()) {
-    return " : " + type_source_info->getType().getAsString();
+    return " : " + type_source_info->getType().getAsString(
+                       enum_decl->getASTContext().getPrintingPolicy());
   }
 
   return std::string();

--- a/tests/cxx/enums-d1.h
+++ b/tests/cxx/enums-d1.h
@@ -23,3 +23,5 @@ enum DirectEnum4 : int { A, B, C };
 }
 
 enum class DirectEnum5 : long { A, B, C };
+
+enum class DirectEnum6 : bool { A, B };

--- a/tests/cxx/enums.cc
+++ b/tests/cxx/enums.cc
@@ -27,6 +27,9 @@ DirectEnum2 de2;
 DirectEnum3 de3;
 ns::DirectEnum4 de4;
 DirectEnum5 de5;
+// Test that 'bool' underlying type is represented as 'bool' in opaque
+// declaration and not as '_Bool' clang builtin type.
+DirectEnum6 de6;
 
 // For an unscoped enum without explicitly specified underlying type, full
 // definition is needed.
@@ -76,6 +79,7 @@ tests/cxx/enums.cc should add these lines:
 #include "tests/cxx/enums-i4.h"
 enum class DirectEnum1;
 enum class DirectEnum2 : int;
+enum class DirectEnum6 : bool;
 enum struct DirectEnum3 : unsigned long long;
 namespace ns { enum DirectEnum4 : int; }
 
@@ -91,6 +95,7 @@ The full include-list for tests/cxx/enums.cc:
 enum class DirectEnum1;
 enum class DirectEnum2 : int;
 enum class DirectEnum5 : long;  // lines XX-XX
+enum class DirectEnum6 : bool;
 enum class Struct2::Nested;  // lines XX-XX
 enum struct DirectEnum3 : unsigned long long;
 namespace ns { enum DirectEnum4 : int; }


### PR DESCRIPTION
Boolean type is internally represented in clang as `_Bool` builtin type. In order to display it correctly taking into account language options, actual printing policy should be used.
The bug was mentioned in this comment: https://github.com/include-what-you-use/include-what-you-use/issues/1115#issuecomment-1314727796