### PR TITLE
[ci] Upgrade to actions/checkout@v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,20 @@ jobs:
                libclang$LLVM_TAG-dev \
                clang$LLVM_TAG
 
-      - name: Check out default branch
-        uses: actions/checkout@v2
+      - name: Select checkout ref (PR)
+        if: github.event_name == 'pull_request'
+        run: |
+          echo "IWYU_CHECKOUT_REF=${{github.event.pull_request.head.sha}}" >> $GITHUB_ENV
+
+      - name: Select checkout ref (push/schedule)
+        if: github.event_name == 'push' || github.event_name == 'schedule'
+        run: |
+          echo "IWYU_CHECKOUT_REF=${{github.sha}}" >> $GITHUB_ENV
+
+      - name: Check out branch
+        uses: actions/checkout@v3
+        with:
+          ref: ${{env.IWYU_CHECKOUT_REF}}
 
       - name: Build include-what-you-use
         run: |


### PR DESCRIPTION
The v2 action depends on deprecated Node.js 12, as indicated by warning from GitHub Actions:

    Node.js 12 actions are deprecated. For more information see:
    https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
    Please update the following actions to use Node.js 16:
      actions/checkout@v2

(see
e.g. https://github.com/include-what-you-use/include-what-you-use/actions/runs/3718310359)

Upgrade to newer version.