### PR TITLE
Ignore uses of declarations from inside of functions

### DIFF
--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -1507,4 +1507,9 @@ string GetKindName(const TypeLoc typeloc) {
   return string(typeloc.getTypePtr()->getTypeClassName()) + "TypeLoc";
 }
 
+bool IsDeclaredInsideFunction(const Decl* decl) {
+  const DeclContext* decl_ctx = decl->getDeclContext();
+  return isa<FunctionDecl>(decl_ctx);
+}
+
 }  // namespace include_what_you_use

--- a/iwyu_ast_util.h
+++ b/iwyu_ast_util.h
@@ -839,6 +839,10 @@ std::string GetKindName(const clang::Stmt* stmt);
 std::string GetKindName(const clang::Type* type);
 std::string GetKindName(const clang::TypeLoc typeloc);
 
+// Returns true if decl is entirely inside a function, which implies it's only
+// visible from said function.
+bool IsDeclaredInsideFunction(const clang::Decl* decl);
+
 }  // namespace include_what_you_use
 
 #endif  // INCLUDE_WHAT_YOU_USE_IWYU_AST_UTIL_H_

--- a/tests/cxx/decl_inside_func-d1.h
+++ b/tests/cxx/decl_inside_func-d1.h
@@ -1,0 +1,10 @@
+//===--- decl_inside_func-d1.h - test input file for iwyu -----------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/decl_inside_func-i1.h"

--- a/tests/cxx/decl_inside_func-i1.h
+++ b/tests/cxx/decl_inside_func-i1.h
@@ -1,0 +1,34 @@
+//===--- decl_inside_func-i1.h - test input file for iwyu -----------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// Reduced/derived/copied from Quill 1.6.3:
+// https://github.com/odygrd/quill/blob/v1.6.3/quill/include/quill/PatternFormatter.h#L35
+
+// This macro defines a lambda containing a function-local declaration of a
+// union X, which is cleverly returned from the lambda.
+//
+// Declarations inside a function are only directly visible from the function
+// itself, so any uses of X should be ignored -- the only way to get in any
+// contact with X is to use MACRO, so this header will be desired already.
+
+#define MACRO(str)                    \
+  [] {                                \
+    union X {                         \
+      static constexpr auto value() { \
+        return str;                   \
+      }                               \
+    };                                \
+    return X{};                       \
+  }()
+
+/**** IWYU_SUMMARY
+
+(tests/cxx/decl_inside_func-i1.h has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/decl_inside_func.cc
+++ b/tests/cxx/decl_inside_func.cc
@@ -1,0 +1,41 @@
+//===--- decl_inside_func.cc - test input file for iwyu -------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// A declaration inside a function can sometimes escape (see implementation of
+// MACRO), and while such a declaration may look like it's independently used
+// here, the only way to make contact with it is through its containing
+// function.
+// Since we must have a declaration of _the function_ in order to call it, the
+// contained declaration will have followed along and we can ignore any direct
+// uses of the contained decl.
+// This used to lead to the contained declaration being fwd-decl used, and IWYU
+// crashing when trying to format a printable forward-decl. Ignoring it
+// completely avoids that malfunction.
+
+// IWYU_ARGS: -I . -Xiwyu --check_also="tests/cxx/decl_inside_func-i1.h"
+
+#include "tests/cxx/decl_inside_func-d1.h"
+
+const char* f() {
+  // IWYU: MACRO is ...*decl_inside_func-i1.h
+  return MACRO("bleh").value();
+}
+
+/**** IWYU_SUMMARY
+
+tests/cxx/decl_inside_func.cc should add these lines:
+#include "tests/cxx/decl_inside_func-i1.h"
+
+tests/cxx/decl_inside_func.cc should remove these lines:
+- #include "tests/cxx/decl_inside_func-d1.h"  // lines XX-XX
+
+The full include-list for tests/cxx/decl_inside_func.cc:
+#include "tests/cxx/decl_inside_func-i1.h"  // for MACRO
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
Using type deduction, a function can define a local type and return it:

    auto func() {
      struct X {};
      return X();
    }

Before this change, IWYU would register X as a use for callers of func.

In certain situations (union inside lambda inside macro) this would lead
to a forward-declare use trying to format a forward-declaration of the
type local to the function in PrintForwardDeclare. This led to a crash
since the lambda was unnamed, but there's really no point trying to
forward-declare a type that is private to a function.

Generalize this so we ignore all uses of symbols declared inside a
function. In order to get in contact with that symbol, we must already
have access to the function, so the containing header must already be
included.

Fixes issue: #795