### PR TITLE
Fwd decls for explicit types only

### DIFF
--- a/tests/cxx/array.cc
+++ b/tests/cxx/array.cc
@@ -18,7 +18,6 @@ class A {
   IndirectClass *getIndirectClass(int i) {
     // IWYU: IndirectClass is...*indirect.h
     (void)sizeof(b[i]);  // requires full type
-    // IWYU: IndirectClass needs a declaration
     // IWYU: IndirectClass is...*indirect.h
     (void)sizeof(&(b[i]));  // requires full type
     // IWYU: IndirectClass is...*indirect.h
@@ -31,7 +30,6 @@ class A {
     // IWYU: IndirectTemplate is...*indirect.h
     // IWYU: IndirectClass is...*indirect.h
     (void)sizeof(t[i]);  // requires full type
-    // IWYU: IndirectTemplate needs a declaration
     // IWYU: IndirectTemplate is...*indirect.h
     // IWYU: IndirectClass is...*indirect.h
     (void)sizeof(&(t[i]));  // requires full type

--- a/tests/cxx/array.cc
+++ b/tests/cxx/array.cc
@@ -20,6 +20,11 @@ class A {
     (void)sizeof(b[i]);  // requires full type
     // IWYU: IndirectClass is...*indirect.h
     (void)sizeof(&(b[i]));  // requires full type
+
+    // Neither fwd-declaration nor full type is needed for array of pointers
+    // indexing and pointer size taking.
+    (void)sizeof(pp[i]);
+
     // IWYU: IndirectClass is...*indirect.h
     return &(b[i]);
   }
@@ -33,6 +38,11 @@ class A {
     // IWYU: IndirectTemplate is...*indirect.h
     // IWYU: IndirectClass is...*indirect.h
     (void)sizeof(&(t[i]));  // requires full type
+
+    // Neither fwd-declaration nor full type is needed for array of pointers
+    // indexing and pointer size taking.
+    (void)sizeof(ppt[i]);
+
     // IWYU: IndirectTemplate is...*indirect.h
     // IWYU: IndirectClass is...*indirect.h
     return &(t[i]);
@@ -40,9 +50,14 @@ class A {
 
   // IWYU: IndirectClass needs a declaration
   IndirectClass *b;
+  // IWYU: IndirectClass needs a declaration
+  IndirectClass **pp;
   // IWYU: IndirectTemplate needs a declaration
   // IWYU: IndirectClass needs a declaration
   IndirectTemplate<IndirectClass> *t;
+  // IWYU: IndirectTemplate needs a declaration
+  // IWYU: IndirectClass needs a declaration
+  IndirectTemplate<IndirectClass> **ppt;
 };
 
 


### PR DESCRIPTION
There is no point in reporting forward-declaration of a type when just its pointer is used and the type is not explicitly written in the source. Explicitly written pointer types are handled, e.g., in `VisitTemplateSpecializationType` and `VisitTagType`.

Similar to #1079.