### PR TITLE
Add GetKindName AST util

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -476,15 +476,15 @@ class BaseAstVisitor : public RecursiveASTVisitor<Derived> {
   // particular decl).
   bool VisitDecl(clang::Decl* decl) {
     if (ShouldPrintSymbolFromCurrentFile()) {
-      errs() << AnnotatedName(string(decl->getDeclKindName()) + "Decl")
-             << PrintablePtr(decl) << PrintableDecl(decl) << "\n";
+      errs() << AnnotatedName(GetKindName(decl)) << PrintablePtr(decl)
+             << PrintableDecl(decl) << "\n";
     }
     return true;
   }
 
   bool VisitStmt(clang::Stmt* stmt) {
     if (ShouldPrintSymbolFromCurrentFile()) {
-      errs() << AnnotatedName(stmt->getStmtClassName()) << PrintablePtr(stmt)
+      errs() << AnnotatedName(GetKindName(stmt)) << PrintablePtr(stmt)
              << PrintableStmt(stmt) << "\n";
     }
     return true;
@@ -492,8 +492,8 @@ class BaseAstVisitor : public RecursiveASTVisitor<Derived> {
 
   bool VisitType(clang::Type* type) {
     if (ShouldPrintSymbolFromCurrentFile()) {
-      errs() << AnnotatedName(string(type->getTypeClassName()) + "Type")
-             << PrintablePtr(type) << PrintableType(type) << "\n";
+      errs() << AnnotatedName(GetKindName(type)) << PrintablePtr(type)
+             << PrintableType(type) << "\n";
     }
     return true;
   }
@@ -501,9 +501,8 @@ class BaseAstVisitor : public RecursiveASTVisitor<Derived> {
   // Make sure our logging message shows we're in the TypeLoc hierarchy.
   bool VisitTypeLoc(clang::TypeLoc typeloc) {
     if (ShouldPrintSymbolFromCurrentFile()) {
-      errs() << AnnotatedName(string(typeloc.getTypePtr()->getTypeClassName())
-                              + "TypeLoc")
-             << PrintableTypeLoc(typeloc) << "\n";
+      errs() << AnnotatedName(GetKindName(typeloc)) << PrintableTypeLoc(typeloc)
+             << "\n";
     }
     return true;
   }

--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -133,24 +133,24 @@ namespace {
 
 void DumpASTNode(llvm::raw_ostream& ostream, const ASTNode* node) {
   if (const Decl *decl = node->GetAs<Decl>()) {
-    ostream << "[" << decl->getDeclKindName() << "Decl] "
-            << PrintableDecl(decl);
+    ostream << "[" << GetKindName(decl) << "] " << PrintableDecl(decl);
   } else if (const Stmt *stmt = node->GetAs<Stmt>()) {
-    ostream << "[" << stmt->getStmtClassName() << "] " << PrintableStmt(stmt);
-  } else if (const Type *type = node->GetAs<Type>()) { // +typeloc
-    ostream << "[" << type->getTypeClassName()
-            << (node->IsA<TypeLoc>() ? "TypeLoc" : "Type") << "] "
-            << PrintableType(type);
-  } else if (const NestedNameSpecifier *nns =
+    ostream << "[" << GetKindName(stmt) << "] " << PrintableStmt(stmt);
+  } else if (const TypeLoc* typeloc = node->GetAs<TypeLoc>()) {
+    ostream << "[" << GetKindName(*typeloc) << "] "
+            << PrintableTypeLoc(*typeloc);
+  } else if (const Type* type = node->GetAs<Type>()) {  // +typeloc
+    ostream << "[" << GetKindName(type) << "] " << PrintableType(type);
+  } else if (const NestedNameSpecifier* nns =
                  node->GetAs<NestedNameSpecifier>()) {
     ostream << "[NestedNameSpecifier] " << PrintableNestedNameSpecifier(nns);
-  } else if (const TemplateName *tpl_name = node->GetAs<TemplateName>()) {
+  } else if (const TemplateName* tpl_name = node->GetAs<TemplateName>()) {
     ostream << "[TemplateName] " << PrintableTemplateName(*tpl_name);
-  } else if (const TemplateArgumentLoc *tpl_argloc =
+  } else if (const TemplateArgumentLoc* tpl_argloc =
                  node->GetAs<TemplateArgumentLoc>()) {
     ostream << "[TemplateArgumentLoc] "
             << PrintableTemplateArgumentLoc(*tpl_argloc);
-  } else if (const TemplateArgument *tpl_arg =
+  } else if (const TemplateArgument* tpl_arg =
                  node->GetAs<TemplateArgument>()) {
     ostream << "[TemplateArgument] " << PrintableTemplateArgument(*tpl_arg);
   } else {
@@ -422,8 +422,7 @@ string PrintableType(const Type* type) {
 
   string typestr = QualType(type, 0).getAsString();
   if (GlobalFlags().HasDebugFlag("printtypeclass")) {
-    string typeclass = type->getTypeClassName();
-    typestr = typeclass + "Type:" + typestr;
+    typestr = GetKindName(type) + ":" + typestr;
   }
   return typestr;
 }
@@ -1491,6 +1490,22 @@ TemplateArgumentListInfo GetExplicitTplArgs(const Expr* expr) {
   else if (const DependentScopeDeclRefExpr* dependent_decl_ref = DynCastFrom(expr))
     dependent_decl_ref->copyTemplateArgumentsInto(explicit_tpl_args);
   return explicit_tpl_args;
+}
+
+string GetKindName(const Decl* decl) {
+  return string(decl->getDeclKindName()) + "Decl";
+}
+
+string GetKindName(const Stmt* stmt) {
+  return stmt->getStmtClassName();
+}
+
+string GetKindName(const Type* type) {
+  return string(type->getTypeClassName()) + "Type";
+}
+
+string GetKindName(const TypeLoc typeloc) {
+  return string(typeloc.getTypePtr()->getTypeClassName()) + "TypeLoc";
 }
 
 }  // namespace include_what_you_use

--- a/iwyu_ast_util.h
+++ b/iwyu_ast_util.h
@@ -833,6 +833,12 @@ const clang::FunctionType* GetCalleeFunctionType(clang::CallExpr* expr);
 // such a concept (declrefexpr, memberexpr), and empty list if none is present.
 clang::TemplateArgumentListInfo GetExplicitTplArgs(const clang::Expr* expr);
 
+// Return the kind- or class-name for various AST node types.
+std::string GetKindName(const clang::Decl* decl);
+std::string GetKindName(const clang::Stmt* stmt);
+std::string GetKindName(const clang::Type* type);
+std::string GetKindName(const clang::TypeLoc typeloc);
+
 }  // namespace include_what_you_use
 
 #endif  // INCLUDE_WHAT_YOU_USE_IWYU_AST_UTIL_H_


### PR DESCRIPTION
The core AST nodes (Decl, Stmt, Type, TypeLoc) all have a kind denoting their specific derived type, and a corresponding function to get a printable string for the kind.

Implement a polymorphic GetKindName that calls the right function dependning on type, and also adds a suffix to mirror the class name.

Make all uses of the get...Name functions call these wrappers instead.

No visible change intended.