### PR TITLE
IWYU self-care

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -109,10 +109,7 @@
 #include "iwyu_output.h"
 #include "iwyu_path_util.h"
 #include "iwyu_port.h"  // for CHECK_
-// This is needed for
-// preprocessor_info().PublicHeaderIntendsToProvide().  Somehow IWYU
-// removes it mistakenly.
-#include "iwyu_preprocessor.h"  // IWYU pragma: keep
+#include "iwyu_preprocessor.h"
 #include "iwyu_stl_util.h"
 #include "iwyu_string_util.h"
 #include "iwyu_use_flags.h"

--- a/iwyu_driver.cc
+++ b/iwyu_driver.cc
@@ -28,13 +28,13 @@
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "clang/Basic/DiagnosticOptions.h"
+#include "clang/Basic/DiagnosticFrontend.h"
 #include "clang/Driver/Compilation.h"
 #include "clang/Driver/Driver.h"
 #include "clang/Driver/Tool.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Frontend/CompilerInvocation.h"
 #include "clang/Frontend/FrontendAction.h"
-#include "clang/Frontend/FrontendDiagnostic.h"  // IWYU pragma: keep
 #include "clang/Frontend/TextDiagnosticPrinter.h"
 
 namespace llvm {

--- a/iwyu_driver.cc
+++ b/iwyu_driver.cc
@@ -19,7 +19,6 @@
 #include <string>
 #include <utility>
 
-#include "llvm/ADT/ArrayRef.h"  // IWYU pragma: keep
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/Triple.h"

--- a/iwyu_output.cc
+++ b/iwyu_output.cc
@@ -22,12 +22,10 @@
 #include "iwyu_include_picker.h"
 #include "iwyu_location_util.h"
 #include "iwyu_path_util.h"
-#include "iwyu_preprocessor.h"  // IWYU pragma: keep
+#include "iwyu_preprocessor.h"
 #include "iwyu_stl_util.h"
 #include "iwyu_string_util.h"
 #include "iwyu_verrs.h"
-// TODO(wan): remove this once the IWYU bug is fixed.
-// IWYU pragma: no_include "foo/bar/baz.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/raw_ostream.h"
 #include "clang/AST/ASTContext.h"

--- a/iwyu_output.cc
+++ b/iwyu_output.cc
@@ -11,8 +11,7 @@
 
 #include <algorithm>                    // for sort, find
 #include <cstdio>                       // for snprintf
-// TODO(wan): make sure IWYU doesn't suggest <iterator>.
-#include <iterator>                     // for find
+#include <iterator>                     // for inserter
 #include <map>                          // for _Rb_tree_const_iterator, etc
 #include <utility>                      // for pair, make_pair, operator>
 #include <vector>                       // for vector, vector<>::iterator, etc

--- a/iwyu_preprocessor.cc
+++ b/iwyu_preprocessor.cc
@@ -27,8 +27,6 @@
 #include "iwyu_stl_util.h"
 #include "iwyu_string_util.h"
 #include "iwyu_verrs.h"
-// TODO(wan): remove this once the IWYU bug is fixed.
-// IWYU pragma: no_include "foo/bar/baz.h"
 #include "llvm/Support/raw_ostream.h"
 #include "clang/Basic/IdentifierTable.h"
 #include "clang/Lex/MacroInfo.h"


### PR DESCRIPTION
Clean out a bunch of old IWYU pragmas in IWYU itself, and do minimal manual cleanup.

This is in preparation for playing with running `include-what-you-use` on itself.