### PR TITLE
Never report ignored types

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -1652,8 +1652,7 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
   // with the warning message that iwyu emits.
   virtual void ReportTypeUse(SourceLocation used_loc, const Type* type,
                              const char* comment = nullptr) {
-    // TODO(csilvers): figure out if/when calling CanIgnoreType() is correct.
-    if (!type)
+    if (CanIgnoreType(type))
       return;
 
     // Enum type uses can be ignored. Their size is known (either implicitly
@@ -2999,6 +2998,9 @@ class InstantiatedTemplateVisitor
     // clang desugars template types, so Foo<MyTypedef>() gets turned
     // into Foo<UnderlyingType>().  Try to convert back.
     type = ResugarType(type);
+    if (CanIgnoreType(type))
+      return;
+
     for (CacheStoringScope* storer : cache_storers_)
       storer->NoteReportedType(type);
     Base::ReportTypeUse(caller_loc(), type, comment);

--- a/iwyu.cc
+++ b/iwyu.cc
@@ -2900,6 +2900,9 @@ class InstantiatedTemplateVisitor
 
   bool CanIgnoreType(const Type* type, IgnoreKind ignore_kind =
                                            IgnoreKind::ForUse) const override {
+    if (!type)
+      return true;
+
     if (!IsTypeInteresting(type))
       return true;
 

--- a/tests/cxx/tpl_spill_nested-d1.h
+++ b/tests/cxx/tpl_spill_nested-d1.h
@@ -1,0 +1,19 @@
+//===--- tpl_spill_nested-d1.h - test input file for iwyu ------*- C++ -*--===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/tpl_spill_nested-d2.h"
+
+template <class T>
+struct Outer {
+  Inner<T> inner;
+
+  typename Inner<T>::value_type& operator[](int index) {
+    return *(inner.begin() + index);
+  }
+};

--- a/tests/cxx/tpl_spill_nested-d2.h
+++ b/tests/cxx/tpl_spill_nested-d2.h
@@ -1,0 +1,32 @@
+//===--- tpl_spill_nested-d2.h - test input file for iwyu ------*- C++ -*--===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/tpl_spill_nested-d3.h"
+
+template <class T>
+struct Inner {
+  typedef T value_type;
+  typedef value_type* iterator;
+  iterator begin();
+  iterator end();
+
+  Inner()
+      // Use an internal type.
+      : size(sizeof(detail::Detail)) {
+    // Throw in a few statements that exercise type reporting.
+    try {
+    } catch (const Inner<T>&) {
+    }
+
+    for (const value_type& x : *this) {
+    }
+  }
+
+  unsigned long long size;
+};

--- a/tests/cxx/tpl_spill_nested-d3.h
+++ b/tests/cxx/tpl_spill_nested-d3.h
@@ -1,0 +1,12 @@
+//===--- tpl_spill_nested-d3.h - test input file for iwyu ------*- C++ -*--===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+namespace detail {
+struct Detail {};
+}  // namespace detail

--- a/tests/cxx/tpl_spill_nested.cc
+++ b/tests/cxx/tpl_spill_nested.cc
@@ -1,0 +1,26 @@
+//===--- tpl_spill_nested.cc - test input file for iwyu -------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/tpl_spill_nested-d1.h"
+
+// IWYU_ARGS: -I .
+
+void Instantiate() {
+  // No diagnostic expected.
+  Outer<int> o;
+
+  // No diagnostic expected.
+  o[100] = 1;
+}
+
+/**** IWYU_SUMMARY
+
+(tests/cxx/tpl_spill_nested.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
@bolshakov-a Your `CanIgnoreType` call stuck in the back of my head, and I eventually got around to generalizing it. This seems to work well (as in: no tests fail).

If the approach makes sense to you, I'll try and cook up some test cases to lock this down.

Should fix: #1004 and #1110. For some reason all the other related problems no longer reproduce on master.

Let me know what you think.