### PR TITLE
Add sugared type components into resugar_map

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -1858,7 +1858,7 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
         continue;
       const Type* deref_param_type =
           RemovePointersAndReferencesAsWritten(param_type);
-      if (CanIgnoreType(param_type) && CanIgnoreType(deref_param_type))
+      if (CanIgnoreType(deref_param_type))
         continue;
 
       // TODO(csilvers): remove this 'if' check when we've resolved the
@@ -2127,7 +2127,7 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
     CHECK_(base_type && "Member's base does not have a type?");
     const Type* deref_base_type  // For myvar->a, base-type will have a *
         = expr->isArrow() ? RemovePointerFromType(base_type) : base_type;
-    if (CanIgnoreType(base_type) && CanIgnoreType(deref_base_type))
+    if (CanIgnoreType(deref_base_type))
       return true;
     if (const TypedefType* typedef_type = DynCastFrom(deref_base_type)) {
       deref_base_type = DesugarDependentTypedef(typedef_type);
@@ -2232,7 +2232,7 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
       const TypeLoc& arg_tl = expr->getArgumentTypeInfo()->getTypeLoc();
       if (const auto* reftype = arg_tl.getTypePtr()->getAs<ReferenceType>()) {
         const Type* dereftype = reftype->getPointeeTypeAsWritten().getTypePtr();
-        if (!CanIgnoreType(reftype) || !CanIgnoreType(dereftype))
+        if (!CanIgnoreType(dereftype))
           ReportTypeUse(GetLocation(&arg_tl), dereftype);
       } else {
         // No need to report on non-ref types, RecursiveASTVisitor will get 'em.
@@ -2281,7 +2281,7 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
     // actual type being deleted.
     const Type* delete_ptr_type = GetTypeOf(delete_arg);
     const Type* delete_type = RemovePointerFromType(delete_ptr_type);
-    if (CanIgnoreType(delete_ptr_type) && CanIgnoreType(delete_type))
+    if (CanIgnoreType(delete_type))
       return true;
 
     if (delete_type && !IsPointerOrReferenceAsWritten(delete_type))

--- a/tests/cxx/member_expr.cc
+++ b/tests/cxx/member_expr.cc
@@ -128,6 +128,15 @@ void MemberExprInside() {
   (*t)->Method();
 }
 
+template <typename T>
+void MemberExprWithDerefInside() {
+  T t;
+  auto& r = *t;
+  // A type after dereferencing t should be in the resugaring map in order
+  // to be reported.
+  r.Method();
+}
+
 class IndirectClass;  // IndirectClassPtr doesn't provide IndirectClass.
 typedef IndirectClass* IndirectClassPtr;
 
@@ -139,6 +148,8 @@ void Fn() {
   // IndirectClass is hidden by a pointer and (at least) two levels of sugar.
   // IWYU: IndirectClass is...*indirect.h
   MemberExprInside<ns::IndirectClassPtr>();
+  // IWYU: IndirectClass is...*indirect.h
+  MemberExprWithDerefInside<IndirectClassPtr>();
 }
 
 /**** IWYU_SUMMARY

--- a/tests/cxx/template_args-d1.h
+++ b/tests/cxx/template_args-d1.h
@@ -1,0 +1,28 @@
+//===--- template_args-d1.h - test input file for iwyu --------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// Aliases in this file provide TplInI1 declaration because it is directly
+// included, but don't provide IndirectClass.
+
+#include "tests/cxx/template_args-i1.h"
+
+class IndirectClass;
+
+struct StructInD1 {
+  static TplInI1<IndirectClass> t;
+};
+
+typedef decltype(StructInD1::t) ProvidingTypedef;
+
+namespace ns_in_d1 {
+using ::ProvidingTypedef;
+}
+
+template <int>
+using ProvidingAlias = ns_in_d1::ProvidingTypedef;

--- a/tests/cxx/template_args-d2.h
+++ b/tests/cxx/template_args-d2.h
@@ -1,0 +1,28 @@
+//===--- template_args-d2.h - test input file for iwyu --------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// Aliases in this file provide neither TplInI1 nor IndirectClass declaration.
+
+class IndirectClass;
+
+template <typename>
+struct TplInI1;
+
+struct StructInD2 {
+  static TplInI1<IndirectClass> t;
+};
+
+typedef decltype(StructInD2::t) NonProvidingTypedef;
+
+namespace ns_in_d2 {
+using ::NonProvidingTypedef;
+}
+
+template <int>
+using NonProvidingAlias = ns_in_d2::NonProvidingTypedef;

--- a/tests/cxx/template_args-i1.h
+++ b/tests/cxx/template_args-i1.h
@@ -1,0 +1,13 @@
+//===--- template_args-i1.h - test input file for iwyu --------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+template <typename T>
+struct TplInI1 {
+  T t;
+};

--- a/tests/cxx/template_args.cc
+++ b/tests/cxx/template_args.cc
@@ -13,6 +13,8 @@
 // function-proto template arguments, for both classes and functions.
 
 #include "tests/cxx/direct.h"
+#include "tests/cxx/template_args-d1.h"
+#include "tests/cxx/template_args-d2.h"
 
 // ---------------------------------------------------------------
 
@@ -83,6 +85,8 @@ template<typename T> struct Inner { T t; };
 struct StaticTemplateFieldStruct {
   // IWYU: IndirectClass needs a declaration
   static Inner<IndirectClass> tpl;
+  static ProvidingAlias<5> aliasedProviding;
+  static NonProvidingAlias<5> aliasedNonProviding;
 };
 
 void NestedTemplateArguments() {
@@ -115,6 +119,37 @@ void NestedTemplateArguments() {
   Outer<decltype(StaticTemplateFieldStruct::tpl)>* opsi;
   // IWYU: IndirectClass is...*indirect.h
   (void)opsi->t;
+
+  // Test obtaining template argument through alias template, typedef and
+  // several other layers of sugar. Underlying type provision status of aliases
+  // should be accounted for.
+
+  // IWYU: IndirectClass is...*indirect.h
+  Outer<decltype(StaticTemplateFieldStruct::aliasedProviding)> oapi;
+  // IWYU: IndirectClass is...*indirect.h
+  (void)oapi.t;
+
+  Outer<decltype(StaticTemplateFieldStruct::aliasedProviding)*> oapip;
+  (void)oapip.t;
+
+  Outer<decltype(StaticTemplateFieldStruct::aliasedProviding)>* opapi;
+  // IWYU: IndirectClass is...*indirect.h
+  (void)opapi->t;
+
+  // IWYU: TplInI1 is...*-i1.h
+  // IWYU: IndirectClass is...*indirect.h
+  Outer<decltype(StaticTemplateFieldStruct::aliasedNonProviding)> oanpi;
+  // IWYU: TplInI1 is...*-i1.h
+  // IWYU: IndirectClass is...*indirect.h
+  (void)oanpi.t;
+
+  Outer<decltype(StaticTemplateFieldStruct::aliasedNonProviding)*> oanpip;
+  (void)oanpip.t;
+
+  Outer<decltype(StaticTemplateFieldStruct::aliasedNonProviding)>* opanpi;
+  // IWYU: TplInI1 is...*-i1.h
+  // IWYU: IndirectClass is...*indirect.h
+  (void)opanpi->t;
 }
 
 // ---------------------------------------------------------------
@@ -175,12 +210,16 @@ void TestResugaringOfTypedefs() {
 
 tests/cxx/template_args.cc should add these lines:
 #include "tests/cxx/indirect.h"
+#include "tests/cxx/template_args-i1.h"
 
 tests/cxx/template_args.cc should remove these lines:
 - #include "tests/cxx/direct.h"  // lines XX-XX
 
 The full include-list for tests/cxx/template_args.cc:
 #include "tests/cxx/indirect.h"  // for IndirectClass
+#include "tests/cxx/template_args-d1.h"  // for ProvidingAlias
+#include "tests/cxx/template_args-d2.h"  // for NonProvidingAlias
+#include "tests/cxx/template_args-i1.h"  // for TplInI1
 template <typename F> struct FunctionStruct;  // lines XX-XX
 
 ***** IWYU_SUMMARY */


### PR DESCRIPTION
Prior to this, if e.g. pointer type was sugared, the pointee type was absent in resugar_map. Sometimes this situation was correctly handled by means of excessive `CanIgnoreType` checks, sometimes was not, as in the added test case.

This should make #1179 able to be merged.