### PR TITLE
Desugar UsingType among others

### DIFF
--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -1144,7 +1144,6 @@ const Type* Desugar(const Type* type) {
   while (true) {
     // Don't desugar types that (potentially) add a name.
     if (cur->getTypeClass() == Type::Typedef ||
-        cur->getTypeClass() == Type::Using ||
         cur->getTypeClass() == Type::TemplateSpecialization) {
       return cur;
     }


### PR DESCRIPTION
`clang::UsingType` denotes a sugar type which is introduced by a using-declaration (e.g., `using ns::SomeType;`). It has not such a special meaning in IWYU as `TypedefType` or `TemplateSpecializationType`.

No functional change is expected.