### PR TITLE
Test reporting types hidden in template arguments

### DIFF
--- a/tests/cxx/member_expr.cc
+++ b/tests/cxx/member_expr.cc
@@ -120,6 +120,27 @@ void ViaMacro(const IndirectTemplate<IndirectClass>& ic) {
   IC_CALL_METHOD;
 }
 
+// Test type use with member expression inside a template.
+
+template <typename T>
+void MemberExprInside() {
+  T* t = nullptr;
+  (*t)->Method();
+}
+
+class IndirectClass;  // IndirectClassPtr doesn't provide IndirectClass.
+typedef IndirectClass* IndirectClassPtr;
+
+namespace ns {
+using ::IndirectClassPtr;
+}
+
+void Fn() {
+  // IndirectClass is hidden by a pointer and (at least) two levels of sugar.
+  // IWYU: IndirectClass is...*indirect.h
+  MemberExprInside<ns::IndirectClassPtr>();
+}
+
 /**** IWYU_SUMMARY
 
 tests/cxx/member_expr.cc should add these lines:
@@ -127,6 +148,7 @@ tests/cxx/member_expr.cc should add these lines:
 
 tests/cxx/member_expr.cc should remove these lines:
 - #include "tests/cxx/direct.h"  // lines XX-XX
+- class IndirectClass;  // lines XX-XX
 
 The full include-list for tests/cxx/member_expr.cc:
 #include "tests/cxx/indirect.h"  // for IndirectClass, IndirectTemplate

--- a/tests/cxx/operator_new.cc
+++ b/tests/cxx/operator_new.cc
@@ -43,6 +43,12 @@ void ExpressionsBuiltinTypes() {
 }
 
 // New- and delete-expressions with user-defined types.
+
+template <typename T>
+void TplFnWithDelete(T p) {
+  delete p;
+}
+
 void ExpressionsUserTypes() {
   // IWYU: IndirectClass needs a declaration
   // IWYU: IndirectClass is...*indirect.h
@@ -55,6 +61,11 @@ void ExpressionsUserTypes() {
   IndirectClass* arr = new IndirectClass[4];
   // IWYU: IndirectClass is...*indirect.h
   delete[] arr;
+
+  // Hide the pointer type behind "decltype" sugar.
+  decltype(elem) elem2 = nullptr;
+  // IWYU: IndirectClass is...*indirect.h
+  TplFnWithDelete(elem2);
 }
 
 // Aligned allocation uses operator new(size_t, std::align_val_t) under the

--- a/tests/cxx/sizeof_reference.cc
+++ b/tests/cxx/sizeof_reference.cc
@@ -103,6 +103,22 @@ SizeofTakingStructTplRef2<IndirectClass> sizeof_taking_struct5;
 // IWYU: IndirectClass needs a declaration
 SizeofTakingStructTplRef2<IndirectClass&> sizeof_taking_struct6;
 
+// The same with some sugar.
+
+// IWYU: IndirectClass is...*indirect.h
+SizeofTakingStruct<decltype(ref)> sizeof_taking_struct7;
+
+// IWYU: IndirectClass is...*indirect.h
+SizeofTakingStructRef<decltype(dummy)> sizeof_taking_struct8;
+
+SizeofTakingStructTpl<decltype(ref)> sizeof_taking_struct9;
+
+SizeofTakingStructTplRef<decltype(dummy)> sizeof_taking_struct10;
+
+// IWYU: IndirectClass is...*indirect.h
+SizeofTakingStructTplRef2<decltype(dummy)> sizeof_taking_struct11;
+
+SizeofTakingStructTplRef2<decltype(ref)> sizeof_taking_struct12;
 
 /**** IWYU_SUMMARY
 

--- a/tests/cxx/sizeof_reference.cc
+++ b/tests/cxx/sizeof_reference.cc
@@ -11,6 +11,10 @@
 
 // Tests that sizeof(reference) is treated the same as
 // sizeof(underlying_object), like it's supposed to be.
+//
+// C++ [expr.sizeof]p2:
+//   When applied to a reference or a reference type,
+//   the result is the size of the referenced type.
 
 #include <stddef.h>
 #include "tests/cxx/direct.h"
@@ -76,11 +80,17 @@ SizeofTakingStruct<IndirectClass&> sizeof_taking_struct1;
 // IWYU: IndirectClass needs a declaration
 SizeofTakingStructRef<IndirectClass> sizeof_taking_struct2;
 
-// Not sure why, but C++ doesn't require full type of IndirectClass here.
+// sizeof(IndirectTemplateStruct<IndirectClass&>) doesn't require IndirectClass
+// full type because IndirectTemplateStruct<IndirectClass&> stores just
+// a pointer, in fact. Hence, its size doesn't depend on IndirectClass size.
+// C++ [expr.sizeof]p2:
+//   When applied to a class, the result is the number of bytes in an object of
+//   that class...
 // IWYU: IndirectClass needs a declaration
 SizeofTakingStructTpl<IndirectClass&> sizeof_taking_struct3;
 
-// Not sure why, but C++ doesn't require full type of IndirectClass here.
+// sizeof(IndirectTemplateStruct<IndirectClass&>) doesn't require IndirectClass
+// full type.
 // IWYU: IndirectClass needs a declaration
 SizeofTakingStructTplRef<IndirectClass> sizeof_taking_struct4;
 
@@ -88,7 +98,8 @@ SizeofTakingStructTplRef<IndirectClass> sizeof_taking_struct4;
 // IWYU: IndirectClass needs a declaration
 SizeofTakingStructTplRef2<IndirectClass> sizeof_taking_struct5;
 
-// Not sure why, but C++ doesn't require full type of IndirectClass here.
+// sizeof(IndirectTemplateStruct<IndirectClass&>) doesn't require IndirectClass
+// full type.
 // IWYU: IndirectClass needs a declaration
 SizeofTakingStructTplRef2<IndirectClass&> sizeof_taking_struct6;
 


### PR DESCRIPTION
The full type use reporting in the three covered cases is ensured with excessive `CanIgnoreType` calls which check not only the type to be reported but also the type before dereferencing (which occurs to be in the resugaring map). This approach should be refactored.