### PR TITLE
[clang compat] Remove unused llvm::Optional

### DIFF
--- a/iwyu_preprocessor.cc
+++ b/iwyu_preprocessor.cc
@@ -44,7 +44,6 @@ using clang::SourceLocation;
 using clang::SourceRange;
 using clang::Token;
 using llvm::errs;
-using llvm::Optional;
 using llvm::StringRef;
 using std::make_pair;
 using std::string;


### PR DESCRIPTION
Clang [125f4457a54a550846732763ee36b1447ec8d66e](https://github.com/llvm/llvm-project/commit/125f4457a54a550846732763ee36b1447ec8d66e) changed.
The LLVM project is migrating from llvm::Optional to std::optional.

We would previously see llvm::Optional via an indirect include:
```
    iwyu_preprocessor.h
      iwyu_output.h
        clang/AST/Decl.h
          clang/AST/APValue.h
            clang/Basic/LLVM.h
```

Since we don't use it, remove the using-declaration.