### PR TITLE
Never forward-declare expressions used in typeid()

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -2549,6 +2549,23 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
     return true;
   }
 
+  // The C++ spec does not allow us to apply typeid to an incomplete type.
+  // Therefore, we must report the type to be included.
+  bool VisitCXXTypeidExpr(clang::CXXTypeidExpr* expr) {
+    if (CanIgnoreCurrentASTNode())
+      return true;
+
+    QualType type;
+    if (expr->isTypeOperand()) {
+      type = expr->getTypeOperandSourceInfo()->getType();
+    } else {
+      type = expr->getExprOperand()->getType();
+    }
+
+    ReportTypeUse(CurrentLoc(), type.getTypePtr());
+    return true;
+  }
+
   //------------------------------------------------------------
   // Visitors of types derived from clang::Type.
 

--- a/tests/cxx/typeid.cc
+++ b/tests/cxx/typeid.cc
@@ -1,0 +1,48 @@
+//===--- typeid.cc - test input file for iwyu -----------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_ARGS: -I .
+
+// Tests that IWYU suggests an include instead of a forward declaration for
+// expressions used as arguments to typeid(). This is necessary as calling
+// typeid() on an incomplete type causes the program to be ill-formed.
+// We need both typeid(expr) and typeid(type) calls to cause the necessary files
+// to be included, rather than forward declared.
+
+#include "tests/cxx/direct.h"
+#include <typeinfo>
+
+// Tests that typeid(expr) triggers an include, rather than a
+// forward declaration.
+// IWYU: IndirectClass needs a declaration
+void GetTypeInfoOfIndirectExpr(const IndirectClass &indirect) {
+  // IWYU: IndirectClass is...*indirect.h
+  const std::type_info &typeInfo = typeid(indirect);
+}
+
+// Tests that typeid(type) triggers an include, rather than a
+// forward declaration.
+void GetTypeInfoOfIndirectType() {
+  // IWYU: IndirectClass is...*indirect.h
+  const std::type_info &typeInfo = typeid(IndirectClass);
+}
+
+/**** IWYU_SUMMARY
+
+tests/cxx/typeid.cc should add these lines:
+#include "tests/cxx/indirect.h"
+
+tests/cxx/typeid.cc should remove these lines:
+- #include "tests/cxx/direct.h"  // lines XX-XX
+
+The full include-list for tests/cxx/typeid.cc:
+#include <typeinfo>  // for type_info
+#include "tests/cxx/indirect.h"  // for IndirectClass
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
The C++ spec requires expressions found in typeid() calls to be fully-formed. Therefore, any necessary classes should not be forward-declared.
This commit adds a new visitor that checks for typeid() calls, and reports the necessary types to be included.

I'm hoping the tests will pass. The changes passed the tests for me on the `clang_11` branch, but I had issues compiling clang on my under-powered laptop to run them against master!

Let me know if there's anything you think can be improved, it's a small patch but I wouldn't be surprised if I've made some rookie errors :)

Hopefully closes #1168 