### PR TITLE
Fix the incorrect include path of Triple.h

### DIFF
--- a/iwyu_driver.cc
+++ b/iwyu_driver.cc
@@ -21,7 +21,7 @@
 
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/STLExtras.h"
-#include "llvm/ADT/Triple.h"
+#include "llvm/TargetParser/Triple.h"
 #include "llvm/Option/ArgList.h"
 #include "llvm/Support/ErrorOr.h"
 #include "llvm/Support/Host.h"


### PR DESCRIPTION
The `Triple.h` header is moved from `llvm/ADT/Triple.h` to `llvm/TargetParser/Triple.h` in LLVM's master (commit: f09cf34d00625e57dea5317a3ac0412c07292148). This patch will fix the pass and unblock the CI.