### PR TITLE
Fix CanForwardDeclareType for tpl instantiations

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -3072,34 +3072,6 @@ class InstantiatedTemplateVisitor
     return TraverseTemplateSpecializationTypeHelper(typeloc.getTypePtr());
   }
 
-  bool TraverseSubstTemplateTypeParmTypeHelper(
-      const clang::SubstTemplateTypeParmType* type) {
-    if (CanIgnoreCurrentASTNode() ||
-        CanIgnoreType(type, IgnoreKind::ForExpansion))
-      return true;
-
-    const Type* actual_type = ResugarType(type);
-    CHECK_(actual_type && "If !CanIgnoreType(), we should be resugar-able");
-    return TraverseType(QualType(actual_type, 0));
-  }
-
-  // When we see a template argument used inside an instantiated
-  // template, we want to explore the type recursively.  For instance
-  // if we see Inner<Outer<Foo>>(), we want to recurse onto Foo.
-  bool TraverseSubstTemplateTypeParmType(
-      clang::SubstTemplateTypeParmType* type) {
-    if (!Base::TraverseSubstTemplateTypeParmType(type))
-      return false;
-    return TraverseSubstTemplateTypeParmTypeHelper(type);
-  }
-
-  bool TraverseSubstTemplateTypeParmTypeLoc(
-      clang::SubstTemplateTypeParmTypeLoc typeloc) {
-    if (!Base::TraverseSubstTemplateTypeParmTypeLoc(typeloc))
-      return false;
-    return TraverseSubstTemplateTypeParmTypeHelper(typeloc.getTypePtr());
-  }
-
   // Check whether a use of a template parameter is a full use.
   bool IsTemplateTypeParmUseFullUse(const Type* type) {
     const ASTNode* node = MostElaboratedAncestor(current_ast_node());

--- a/tests/cxx/explicit_instantiation2.cc
+++ b/tests/cxx/explicit_instantiation2.cc
@@ -19,13 +19,13 @@
 //        definition (2), as it affects the semantics.
 // 2: Explicit instantiation definition.
 // 3: Full use in a template, provided as an explicit parameter.
-// 4: Fwd-decl use in a template, provided as an explicit parameter.
 // 5: Full use in a template, provided as an default parameter.
 // 7: Full use in a template, provided as a template template parameter.
 // 8: Fwd-decl use in a template, provided as a template template parameter.
 //
 // Negative scenarios, where the dependent template specialization is not
 // required, or it does not provide an explicit instantiation:
+// 4: Fwd-decl use in a template, provided as an explicit parameter.
 // 6: Fwd-decl use in a template, provided as a default parameter.
 // 9: Implicit instantiation of Template<int>
 // 10: Specialization of Template<T>
@@ -53,7 +53,6 @@ FullUseArg<
     // IWYU: Template is...*explicit_instantiation-template.h
     t3; // 3
 
-// IWYU: Template is...*template_short.h.*for explicit instantiation
 FwdDeclUseArg<
     // IWYU: Template needs a declaration...*
     Template<short>>

--- a/tests/cxx/template_args.cc
+++ b/tests/cxx/template_args.cc
@@ -124,16 +124,17 @@ void NestedTemplateArguments() {
   // several other layers of sugar. Underlying type provision status of aliases
   // should be accounted for.
 
+  // ProvidingAlias provides TplInI1 but doesn't provide IndirectClass.
   // IWYU: IndirectClass is...*indirect.h
   Outer<decltype(StaticTemplateFieldStruct::aliasedProviding)> oapi;
-  // IWYU: IndirectClass is...*indirect.h
+  // TODO(bolshakov): IWYU: IndirectClass is...*indirect.h
   (void)oapi.t;
 
   Outer<decltype(StaticTemplateFieldStruct::aliasedProviding)*> oapip;
   (void)oapip.t;
 
   Outer<decltype(StaticTemplateFieldStruct::aliasedProviding)>* opapi;
-  // IWYU: IndirectClass is...*indirect.h
+  // TODO(bolshakov): IWYU: IndirectClass is...*indirect.h
   (void)opapi->t;
 
   // IWYU: TplInI1 is...*-i1.h
@@ -205,6 +206,18 @@ void TestResugaringOfTypedefs() {
 
 // ---------------------------------------------------------------
 
+template <typename T>
+class TemplateWithFwdDeclUse {
+  T* t;
+};
+
+// IWYU should not suggest neither TplInI1 nor IndirectClass full info
+// for fwd-decl use in TemplateWithFwdDeclUse.
+// IWYU: TplInI1 needs a declaration
+// IWYU: IndirectClass needs a declaration
+TemplateWithFwdDeclUse<TplInI1<IndirectClass>> c;
+
+// ---------------------------------------------------------------
 
 /**** IWYU_SUMMARY
 


### PR DESCRIPTION
`InstantiatedTemplateVisitor` traverses `SubstTemplateTypeParmType` underlying type retaining `SubstTemplateTypeParmType` node in the node stack. Its presence broke analysis in some cases.

This is one more lead-up PR for #1179.