### PR TITLE
Use the correct decl location for use logging

### DIFF
--- a/iwyu_output.cc
+++ b/iwyu_output.cc
@@ -618,7 +618,7 @@ static void LogSymbolUse(const string& prefix, const OneUse& use) {
   string decl_loc;
   string printable_ptr;
   if (use.decl()) {
-    decl_loc = PrintableLoc(GetLocation(use.decl()));
+    decl_loc = PrintableLoc(use.decl_loc());
     printable_ptr = internal::PrintablePtr(use.decl());
   } else {
     decl_loc = use.decl_filepath();
@@ -1279,7 +1279,7 @@ void ProcessFullUse(OneUse* use,
       if (DeclIsVisibleToUseInSameFile(redecl, *use)) {
         VERRS(6) << "Ignoring use of " << use->symbol_name() << " ("
                  << use->PrintableUseLoc() << "): definition is present: "
-                 << PrintableLoc(GetLocation(use->decl())) << "\n";
+                 << PrintableLoc(use->decl_loc()) << "\n";
         use->set_ignore_use();
         return;
       }


### PR DESCRIPTION
Back in 27da44e009660d8efc9726b1a4d80d8f9f063539 (Oct, 2018), the location of the decl was precomputed and stored separately in the data structure for uses.

Unfortunately it was only used for analysis then, not logging. Update logging to use OneUse::decl_loc() consistently.

This clarifies log output particularly for uses with custom flags for function definitions and explicit template instantiations, which are the only ones where decl_loc() is different from GetLocation(decl()).