### PR TITLE
More consistent work with resugaring map

### DIFF
--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -1145,6 +1145,8 @@ const Type* GetTypeOf(const TypeDecl* decl) {
 }
 
 const Type* GetCanonicalType(const Type* type) {
+  if (!type)
+    return type;
   QualType canonical_type = type->getCanonicalTypeUnqualified();
   return canonical_type.getTypePtr();
 }


### PR DESCRIPTION
Keys of `resugar_map` are canonical types, but `Desugar` doesn't give canonical type if template specialization or alias is present in the sugar chain. It may become important if `ReportTypeUse` starts to call `CanIgnoreType` check for types stored in the cache because the cache stores sugared types, e.g. `TemplateSpecializationType`s.

After this change, `IwyuBaseAstVisitor::VisitTemplateSpecializationType` starts to work from `InstantiatedTemplateVisitor` in some cases (at least, on traversal original template specialization type, e.g. `Tpl1<Tpl2<int>>`). Hence, an empty implementation of `ReportDeclForwardDeclareUse` is needed in `InstantiatedTemplateVisitor`, because it should not report forward declarations.

No functional change is expected.

This is one more preparatory PR for #1179.