### PR TITLE
Avoid visiting substituted template parameter types

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -197,6 +197,7 @@ using clang::Sema;
 using clang::SourceLocation;
 using clang::Stmt;
 using clang::SubstTemplateTypeParmType;
+using clang::SubstTemplateTypeParmTypeLoc;
 using clang::TagDecl;
 using clang::TagType;
 using clang::TemplateArgument;
@@ -4226,6 +4227,19 @@ class IwyuAstConsumer
     }
 
     return Base::VisitTemplateSpecializationType(type);
+  }
+
+  // RecursiveASTVisitor by default traverses the SubstTemplateTypeParmType
+  // replacement type, which means in some cases we'll see substituted types
+  // when instantiating out-of-line template members. Recording and attribution
+  // of template argument uses should be handled by InstantiatedTemplateVisitor,
+  // so short-circuit the traversal here.
+  bool TraverseSubstTemplateTypeParmType(SubstTemplateTypeParmType* type) {
+    return getDerived().WalkUpFromSubstTemplateTypeParmType(type);
+  }
+
+  bool TraverseSubstTemplateTypeParmTypeLoc(SubstTemplateTypeParmTypeLoc loc) {
+    return getDerived().WalkUpFromSubstTemplateTypeParmTypeLoc(loc);
   }
 
   // --- Visitors defined by BaseASTVisitor (not RecursiveASTVisitor).

--- a/tests/cxx/template_args_assoc.cc
+++ b/tests/cxx/template_args_assoc.cc
@@ -1,0 +1,37 @@
+//===--- template_args_assoc.cc - test input file for iwyu ----------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/template_args_assoc.h"
+#include "tests/cxx/direct.h"
+
+// Test a template declared in the associated header and instantiated here.
+// Issue #1181 describes a scenario where this led to the substituted template
+// param being reported in the template declaration rather than the
+// instantiation.
+
+// IWYU_ARGS: -I .
+
+void Test() {
+  // IWYU: IndirectClass needs a declaration...*
+  Template<IndirectClass> x;
+}
+
+/**** IWYU_SUMMARY
+
+tests/cxx/template_args_assoc.cc should add these lines:
+class IndirectClass;
+
+tests/cxx/template_args_assoc.cc should remove these lines:
+- #include "tests/cxx/direct.h"  // lines XX-XX
+
+The full include-list for tests/cxx/template_args_assoc.cc:
+#include "tests/cxx/template_args_assoc.h"
+class IndirectClass;
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/template_args_assoc.h
+++ b/tests/cxx/template_args_assoc.h
@@ -1,0 +1,28 @@
+//===--- template_args_assoc.h - test input file for iwyu -----------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+template <typename>
+struct Template {
+  static const int static_var;
+  virtual void var() const;
+};
+
+template <typename E>
+const int Template<E>::static_var = 0;
+
+template <typename E>
+void Template<E>::var() const {
+  (void)static_var;
+}
+
+/**** IWYU_SUMMARY
+
+(tests/cxx/template_args_assoc.h has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
For a template where definition and instantiation are in different files, but the same component (associated header/source files), IWYU could get confused about attribution of types visited via SubstTemplateTypeParmType.

Template instantiation and the policy around which types are reported where is handled by InstantiatedTemplateVisitor with a lot of precision.

Stub out the traversal of SubstTemplateTypeParmType in IwyuAstConsumer (the top-level visitor for source files) on the assumption that instantiation/substitution should be handled exclusively by InstantiatedTemplateVisitor.

Fixes issue #1181.