### PR TITLE
Traversal logging

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -948,11 +948,11 @@ class AstFlattenerVisitor : public BaseAstVisitor<AstFlattenerVisitor> {
   }
 
   bool ShouldPrintSymbolFromCurrentFile() const override {
-    return false;
+    return ShouldPrint(7);
   }
 
   string GetSymbolAnnotation() const override {
-    return "[Uninstantiated template AST-node] ";
+    return " in uninstantiated tpl";
   }
 
   //------------------------------------------------------------
@@ -974,7 +974,6 @@ class AstFlattenerVisitor : public BaseAstVisitor<AstFlattenerVisitor> {
   }
 
   bool VisitTypeLoc(TypeLoc typeloc) {
-    VERRS(7) << GetSymbolAnnotation() << PrintableTypeLoc(typeloc) << "\n";
     seen_nodes_.Add(typeloc);
     return true;
   }
@@ -985,31 +984,22 @@ class AstFlattenerVisitor : public BaseAstVisitor<AstFlattenerVisitor> {
   }
 
   bool VisitTemplateName(TemplateName tpl_name) {
-    VERRS(7) << GetSymbolAnnotation()
-             << PrintableTemplateName(tpl_name) << "\n";
     seen_nodes_.Add(tpl_name);
     return true;
   }
 
   bool VisitTemplateArgument(const TemplateArgument& tpl_arg) {
-    VERRS(7) << GetSymbolAnnotation()
-             << PrintableTemplateArgument(tpl_arg) << "\n";
     seen_nodes_.Add(tpl_arg);
     return true;
   }
 
   bool VisitTemplateArgumentLoc(const TemplateArgumentLoc& tpl_argloc) {
-    VERRS(7) << GetSymbolAnnotation()
-             << PrintableTemplateArgumentLoc(tpl_argloc) << "\n";
     seen_nodes_.Add(tpl_argloc);
     return true;
   }
 
   bool TraverseImplicitDestructorCall(clang::CXXDestructorDecl* decl,
                                       const Type* type) {
-    VERRS(7) << GetSymbolAnnotation() << "[implicit dtor] "
-             << static_cast<void*>(decl) << " "
-             << PrintableDecl(decl) << "\n";
     AddAstNodeAsPointer(decl);
     return Base::TraverseImplicitDestructorCall(decl, type);
   }
@@ -1017,9 +1007,6 @@ class AstFlattenerVisitor : public BaseAstVisitor<AstFlattenerVisitor> {
   bool HandleFunctionCall(clang::FunctionDecl* callee,
                           const clang::Type* parent_type,
                           const clang::Expr* calling_expr) {
-    VERRS(7) << GetSymbolAnnotation() << "[function call] "
-             << static_cast<void*>(callee) << " "
-             << PrintableDecl(callee) << "\n";
     AddAstNodeAsPointer(callee);
     return Base::HandleFunctionCall(callee, parent_type, calling_expr);
   }
@@ -1032,10 +1019,6 @@ class AstFlattenerVisitor : public BaseAstVisitor<AstFlattenerVisitor> {
   }
 
   void AddCurrentAstNodeAsPointer() {
-    if (ShouldPrint(7)) {
-      errs() << GetSymbolAnnotation() << current_ast_node()->GetAs<void>()
-             << " " << PrintableASTNode(current_ast_node()) << "\n";
-    }
     AddAstNodeAsPointer(current_ast_node()->GetAs<void>());
   }
 


### PR DESCRIPTION
While analyzing #1203, I started wondering why I didn't see any types logged under `SubstTemplateTypeParmType`. Turns out I brought it on myself [against better judgment](https://github.com/include-what-you-use/include-what-you-use/pull/1086#issuecomment-1193387628).

It's always bugged me that logging happens in `Visit`, so fix this, and make things more consistent, by moving logging to `Traverse` methods instead.

Before
```
...
tests/1181/reduced.hpp:5:33: (3) [ TemplateSpecializationTypeLoc ] enum_data<E>
Adding a template-class type of interest: E -> E
Adding a type-components of interest: E
[Uninstantiated template AST-node] 0x561179f88ff0 [CXXRecordDecl] struct enum_data {}
[Uninstantiated template AST-node] 0x561179f892d0 [CXXRecordDecl] struct enum_data
[Uninstantiated template AST-node] 0x561179f89378 [VarDecl] static const int staticVar
...
tests/1181/reduced.hpp:5:47: (1) [ VarDecl ] 0x55b9852f42f8 const int staticVar
tests/1181/reduced.hpp:5:33: (2) [ NestedNameSpecifier ] 0x55b9852f6ba0 enum_data<enum color>::
tests/1181/reduced.hpp:5:33: (3) [ TemplateSpecializationTypeLoc ] enum_data<enum color>
Adding a template-class type of interest: enum color -> enum color
tests/1181/reduced.hpp:5:33: (4 in tpl) [ TemplateName ] enum_data
tests/1181/reduced.hpp:5:33: (4 in tpl) [ TemplateArgument ] 0x55b9852f4398 <enum color>
AnalyzeTemplateTypeParmUse: type = enum color, actual_type = enum color
(Replaying full-use information from the cache for enum_data)
Marked full-info use of decl 0x55b9852c7ff0 enum_data (from tests/1181/reduced.hpp:1:28) at tests/1181/reduced.hpp:5:33
tests/1181/reduced.hpp:5:33: (4) [ TemplateName ] enum_data
tests/1181/reduced.hpp:5:43: (4) [ TemplateArgumentLoc ] 0x7fffe67ee210 <enum color>
tests/1181/reduced.hpp:5:43: (5, fwd decl) [ SubstTemplateTypeParmTypeLoc ] enum color
Marked fwd-decl use of decl 0x55b9852c8b58 color (from tests/1181/enum.hpp:2:12) at tests/1181/reduced.hpp:5:43
```

After:
```
...
tests/1181/reduced.hpp:5:33: (3) [ TemplateSpecializationTypeLoc ] enum_data<E>
Adding a template-class type of interest: E -> E
Adding a type-components of interest: E
tests/1181/reduced.hpp:1:28: (0 in uninstantiated tpl) [ CXXRecordDecl ] 0x557f8fabeff0 struct enum_data {}
tests/1181/reduced.hpp:1:28: (1 in uninstantiated tpl) [ CXXRecordDecl ] 0x557f8fabf2d0 struct enum_data
tests/1181/reduced.hpp:2:20: (1 in uninstantiated tpl) [ VarDecl ] 0x557f8fabf378 static const int staticVar
...
tests/1181/reduced.hpp:5:47: (1) [ VarDecl ] 0x55adfca912f8 const int staticVar
tests/1181/reduced.hpp:5:33: (2) [ NestedNameSpecifier ] 0x55adfca93ba0 enum_data<enum color>::
tests/1181/reduced.hpp:5:33: (3) [ TemplateSpecializationTypeLoc ] enum_data<enum color>
Adding a template-class type of interest: enum color -> enum color
tests/1181/reduced.hpp:5:33: (4 in tpl) [ TemplateName ] enum_data
tests/1181/reduced.hpp:5:33: (4 in tpl) [ TemplateArgument ] 0x55adfca91398 <enum color>
tests/1181/reduced.hpp:5:33: (5 in tpl, fwd decl) [ SubstTemplateTypeParmType ] 0x55adfca911e0 enum color
AnalyzeTemplateTypeParmUse: type = enum color, actual_type = enum color
tests/1181/reduced.hpp:5:33: (6 in tpl, fwd decl) [ EnumType ] 0x55adfca65c00 enum color
(Replaying full-use information from the cache for enum_data)
Marked full-info use of decl 0x55adfca64ff0 enum_data (from tests/1181/reduced.hpp:1:28) at tests/1181/reduced.hpp:5:33
tests/1181/reduced.hpp:5:33: (4) [ TemplateName ] enum_data
tests/1181/reduced.hpp:5:43: (4) [ TemplateArgumentLoc ] 0x7ffe94218dd0 <enum color>
tests/1181/reduced.hpp:5:43: (5, fwd decl) [ SubstTemplateTypeParmTypeLoc ] enum color
tests/1181/reduced.hpp:5:43: (6, fwd decl) [ EnumType ] 0x55adfca65c00 enum color
Marked fwd-decl use of decl 0x55adfca65b58 color (from tests/1181/enum.hpp:2:12) at tests/1181/reduced.hpp:5:43
```