### PR TITLE
Log "Extra tokens" warning at higher verbosity level

### DIFF
--- a/iwyu_preprocessor.cc
+++ b/iwyu_preprocessor.cc
@@ -127,7 +127,7 @@ bool MatchOneToken(const vector<string>& tokens,
   if (tokens.size() > num_expected_tokens &&
       !StartsWith(tokens[num_expected_tokens], "//") &&
       !StartsWith(tokens[num_expected_tokens], "*/")) {
-    Warn(loc, "Extra tokens on pragma line");
+    VERRS(4) << PrintableLoc(loc) << ": warning: Extra tokens on pragma line\n";
   }
   return true;
 }
@@ -158,7 +158,7 @@ bool MatchTwoTokens(const vector<string>& tokens,
       !StartsWith(tokens[num_expected_tokens], "//") &&
       !StartsWith(tokens[num_expected_tokens], "*/")) {
     // Accept but warn.
-    Warn(loc, "Extra tokens on pragma line");
+    VERRS(4) << PrintableLoc(loc) << ": warning: Extra tokens on pragma line\n";
   }
   return true;
 }


### PR DESCRIPTION
While it might be nice to have this diagnostic for troubleshooting, it doesn't really matter if there are extra tokens; they are ignored.

Up the verbosity level to silently accept them by default.

Fixes issue #1207.