### PR TITLE
RFC: Improved suggestions for namespace use

### DIFF
--- a/tests/cxx/multiple_decl_namespace-d1.h
+++ b/tests/cxx/multiple_decl_namespace-d1.h
@@ -1,0 +1,44 @@
+//===--- multiple_decl_namespace-d1.h - test input file for IWYU ----------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_MULTIPLE_DECL_NAMESPACE_D1_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_MULTIPLE_DECL_NAMESPACE_D1_H_
+
+// This header forward declares a bunch of stuff from other
+// namespaces.  None of these namespace declarations should be used as
+// the 'source' of any of these namespaces.  For the purposes of
+// testing, this header should be included first (so these are the
+// first namespace declarations for each namespace).
+
+// Forward declarations
+namespace test::single_header_ns {
+class Class3;
+}
+namespace test::multiple_header_ns {
+class Class4;
+}
+namespace test::multiple_header_with_using_ns {
+class Class5;
+}
+
+namespace test::ns1 {
+
+// To be representative, this header needs to contains something that
+// another namespace wants to use. Declare some flags.
+typedef unsigned Flags;
+const Flags F_None = 0;
+const Flags F_All = 1;
+
+// This is not referenced by the test but requires the forward declarations.
+void Function1(const test::single_header_ns::Class3&,
+               const test::multiple_header_ns::Class4&,
+               const test::multiple_header_with_using_ns::Class5&, Flags f);
+}  // namespace test::ns1
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_MULTIPLE_DECL_NAMESPACE_D1_H_

--- a/tests/cxx/multiple_decl_namespace-d2.h
+++ b/tests/cxx/multiple_decl_namespace-d2.h
@@ -1,0 +1,22 @@
+//===--- multiple_decl_namespace-d2.h - test input file for IWYU ----------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_MULTIPLE_DECL_NAMESPACE_D2_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_MULTIPLE_DECL_NAMESPACE_D2_H_
+
+#include "tests/cxx/multiple_decl_namespace-d1.h"  // for Flags
+
+// Simple namespace that users don't need to forward declare anything from.
+// However it uses a type from another namespace...
+namespace test::simple_ns {
+void Function2a(test::ns1::Flags f);
+void Function2b();
+}  // namespace test::simple_ns
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_MULTIPLE_DECL_NAMESPACE_D2_H_

--- a/tests/cxx/multiple_decl_namespace-d3.h
+++ b/tests/cxx/multiple_decl_namespace-d3.h
@@ -1,0 +1,33 @@
+//===--- multiple_decl_namespace-d3.h - test input file for IWYU ----------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_MULTIPLE_DECL_NAMESPACE_D3_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_MULTIPLE_DECL_NAMESPACE_D3_H_
+
+// Namespace where all full declarations are in a single file. It
+// contains interfaces where some types will need to be forward
+// declared by users.
+//
+// Split the namespace up into a few declarations for test coverage.
+namespace test::single_header_ns {
+class Class3 {
+  int i1;
+  int i2;
+};
+}  // namespace test::single_header_ns
+
+namespace test::single_header_ns {
+Class3* Function3a();
+}  // namespace test::single_header_ns
+
+namespace test::single_header_ns {
+void Function3b();
+}  // namespace test::single_header_ns
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_MULTIPLE_DECL_NAMESPACE_D3_H_

--- a/tests/cxx/multiple_decl_namespace-d4.h
+++ b/tests/cxx/multiple_decl_namespace-d4.h
@@ -1,0 +1,27 @@
+//===--- multiple_decl_namespace-d4.h - test input file for IWYU ----------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_MULTIPLE_DECL_NAMESPACE_D4_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_MULTIPLE_DECL_NAMESPACE_D4_H_
+
+// Namespace where all full declarations are spread across files. It
+// contains interfaces where some types will need to be forward
+// declared by users.
+namespace test::multiple_header_ns {
+
+class Class4 {
+  int i1;
+  int i2;
+};
+
+Class4* Function4a();
+void Function4b();
+}  // namespace test::multiple_header_ns
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_MULTIPLE_DECL_NAMESPACE_D4_H_

--- a/tests/cxx/multiple_decl_namespace-d5.h
+++ b/tests/cxx/multiple_decl_namespace-d5.h
@@ -1,0 +1,37 @@
+//===--- multiple_decl_namespace-d5.h - test input file for IWYU ----------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_MULTIPLE_DECL_NAMESPACE_D5_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_MULTIPLE_DECL_NAMESPACE_D5_H_
+
+// Dummy namespace to be referenced by using directive
+namespace other::consts {
+typedef unsigned Consts;
+const Consts C_PI = 314;
+}  // namespace other::consts
+
+// This namespace has a using-directive. This is a pretty clear sign
+// that this namespace block is not a bunch of forward declarations,
+// and need to be explicitly included by users.
+namespace test::multiple_header_with_using_ns {
+class Class5 {
+  int i1;
+  int i2;
+};
+
+// A using directive makes the target ns available in the nearest common parent
+// ns. This makes the content of consts available in the global namespace.
+using namespace other::consts;
+
+Class5* Function5a();
+void Function5b();
+void Function5c(Consts c);
+}  // namespace test::multiple_header_with_using_ns
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_MULTIPLE_DECL_NAMESPACE_D5_H_

--- a/tests/cxx/multiple_decl_namespace-d6.h
+++ b/tests/cxx/multiple_decl_namespace-d6.h
@@ -1,0 +1,24 @@
+//===--- multiple_decl_namespace-d6.h - test input file for IWYU ----------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_MULTIPLE_DECL_NAMESPACE_D6_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_MULTIPLE_DECL_NAMESPACE_D6_H_
+
+// This file contains further declarations for our multiple_header_*
+// namespaces.
+namespace test::multiple_header_ns {
+void Function6a();
+void Function6b();
+}  // namespace test::multiple_header_ns
+
+namespace test::multiple_header_with_using_ns {
+void Function6c();
+void Function6d();
+}  // namespace test::multiple_header_with_using_ns
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_MULTIPLE_DECL_NAMESPACE_D6_H_

--- a/tests/cxx/multiple_decl_namespace-i1.h
+++ b/tests/cxx/multiple_decl_namespace-i1.h
@@ -1,0 +1,20 @@
+//===--- multiple_decl_namespace-i1.h - test input file for IWYU ----------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_MULTIPLE_DECL_NAMESPACE_I1_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_MULTIPLE_DECL_NAMESPACE_I1_H_
+
+// Indirect includes of headers to force IWYU to complain
+#include "tests/cxx/multiple_decl_namespace-d2.h"
+#include "tests/cxx/multiple_decl_namespace-d3.h"
+#include "tests/cxx/multiple_decl_namespace-d4.h"
+#include "tests/cxx/multiple_decl_namespace-d5.h"
+#include "tests/cxx/multiple_decl_namespace-d6.h"
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_MULTIPLE_DECL_NAMESPACE_I1_H_

--- a/tests/cxx/multiple_decl_namespace.cc
+++ b/tests/cxx/multiple_decl_namespace.cc
@@ -1,0 +1,83 @@
+//===--- multiple_decl_namespace.cc - test input file for IWYU ------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_ARGS: -I .
+
+// Tests that we handle multiply declared namespaces correctly.
+//
+// Where declarations of a namespace occur in multiple headers (either
+// because forward declarations were needed or otherwise), IWYU should
+// avoid recommending to include a header which is otherwise unused
+// when it sees a using directive.
+//
+// A namespaces' declarations can be scattered around multiple files,
+// so there may not be a canonical file to include to satisfy a using
+// directive. IWYU should already identify a relevant header to
+// include for the namespaced identifier(s) that are being used from
+// the namespace.
+//
+// Where a single file provides all used declarations, IWYU can add
+// the namespace to the list of identifiers being provided by the file
+// (to be added to the include comment).
+//
+// Where multiple files provide used declarations, avoid adding the
+// namespace to any file.
+
+#include "tests/cxx/multiple_decl_namespace-d2.h"
+#include "tests/cxx/multiple_decl_namespace-i1.h"
+
+using namespace test::simple_ns;
+// IWYU: test::single_header_ns is...*multiple_decl_namespace-d3.h
+using namespace test::single_header_ns;
+using namespace test::multiple_header_ns;
+// IWYU: test::multiple_header_with_using_ns is...*multiple_decl_namespace-d5.h
+using namespace test::multiple_header_with_using_ns;
+
+void uses() {
+  // Use an identifier from single_header_ns, declared in d3.h
+  // IWYU: single_header_ns::Function3b is...*multiple_decl_namespace-d3.h
+  Function3b();
+
+  // Use an identifier whose header will pull in forward declarations
+  // in other namespaces. This is declared in d2.h. d2.h includes d1.h
+  // that forward declares single_header_ns.
+  Function2b();
+
+  // The first declaration of single_header_ns is seen in d1.h, but the
+  // declaration that we are using is in d3.h. We should _not_
+  // recommend including d1.h for single_header_ns.
+
+  // Use an identifier from multiple_header_ns, declared in d4.h+d6.h.
+  // No suggestion for the namespace, rely on symbols used instead.
+  // IWYU: multiple_header_ns::Function4b is...*multiple_decl_namespace-d4.h
+  Function4b();
+
+  // Use an identifier from multiple_header_with_using_ns, declared in d5.h+d6.h
+  // d5.h has a using-directive.
+  // IWYU: multiple_header_with_using_ns::Function5b is...*multiple_decl_namespace-d5.h
+  Function5b();
+}
+
+/**** IWYU_SUMMARY
+
+tests/cxx/multiple_decl_namespace.cc should add these lines:
+#include "tests/cxx/multiple_decl_namespace-d3.h"
+#include "tests/cxx/multiple_decl_namespace-d4.h"
+#include "tests/cxx/multiple_decl_namespace-d5.h"
+
+tests/cxx/multiple_decl_namespace.cc should remove these lines:
+- #include "tests/cxx/multiple_decl_namespace-i1.h"  // lines XX-XX
+
+The full include-list for tests/cxx/multiple_decl_namespace.cc:
+#include "tests/cxx/multiple_decl_namespace-d2.h"  // for Function2b, simple_ns
+#include "tests/cxx/multiple_decl_namespace-d3.h"  // for Function3b, single_header_ns
+#include "tests/cxx/multiple_decl_namespace-d4.h"  // for Function4b
+#include "tests/cxx/multiple_decl_namespace-d5.h"  // for Function5b, multiple_header_with_using_ns
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
This series is looking to address #828, where IWYU just suggests the first header that declares a namespace to satisfy a using directive.

The first couple commits play with namespace aliases, which were easier to get a handle on. The first commit adds reporting for when namespace aliases use a namespace, and the second adds a warning when the alias is unused. Although useful, I suspect we want to drop the second commmit (because IWYU generally doesn't warn on unused declarations). I believe the first commit is technically correct, but I've not seen a codebase with aliases in headers so hopefully this won't be disruptive.

The third commit finally attempts to improve the suggestion for the inculde to use. The logic is mostly in a new file, iwyu_namespace.cc, as I was trying a bunch of different things. I ended up caching the ReportDeclUse() to call during ResolvePendingAnalysis(), so we can pick the prefered NamespaceDecl to report. This works for the simple test case.

Any feedback appreciated!