### PR TITLE
Macos run_iwyu_test.py improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,6 +173,8 @@ else()
     # [1] https://llvm.org/viewvc/llvm-project?view=revision&revision=348907
     # [2] https://llvm.org/viewvc/llvm-project?view=revision&revision=348915
     clangSerialization
+
+    clangToolingInclusionsStdlib
   )
 endif()
 

--- a/iwyu_globals.cc
+++ b/iwyu_globals.cc
@@ -200,6 +200,7 @@ CommandlineFlags::CommandlineFlags()
       no_fwd_decls(false),
       quoted_includes_first(false),
       cxx17ns(false),
+      use_libcxx(false),
       exit_code_error(EXIT_SUCCESS),
       exit_code_always(EXIT_SUCCESS),
       regex_dialect(RegexDialect::LLVM) {
@@ -415,8 +416,9 @@ void InitGlobals(clang::SourceManager* sm, clang::HeaderSearch* header_search) {
   vector<HeaderSearchPath> search_paths =
       ComputeHeaderSearchPaths(header_search);
   SetHeaderSearchPaths(search_paths);
-  include_picker = new IncludePicker(GlobalFlags().no_default_mappings,
-                                     GlobalFlags().regex_dialect);
+  include_picker =
+      new IncludePicker(GlobalFlags().no_default_mappings,
+                        GlobalFlags().regex_dialect, GlobalFlags().use_libcxx);
   function_calls_full_use_cache = new FullUseCache;
   class_members_full_use_cache = new FullUseCache;
 
@@ -441,6 +443,16 @@ const CommandlineFlags& GlobalFlags() {
 CommandlineFlags* MutableGlobalFlagsForTesting() {
   CHECK_(commandline_flags && "Call ParseIwyuCommandlineFlags() before this");
   return commandline_flags;
+}
+
+void SelectCXXStdlibLibcxx() {
+  CHECK_(commandline_flags && "Call ParseIwyuCommandlineFlags() before this");
+  commandline_flags->use_libcxx = true;
+}
+
+void SelectCXXStdlibLibstdcpp() {
+  CHECK_(commandline_flags && "Call ParseIwyuCommandlineFlags() before this");
+  commandline_flags->use_libcxx = false;
 }
 
 clang::SourceManager* GlobalSourceManager() {
@@ -509,8 +521,9 @@ void InitGlobalsAndFlagsForTesting() {
   commandline_flags = new CommandlineFlags;
   source_manager = nullptr;
   data_getter = nullptr;
-  include_picker = new IncludePicker(GlobalFlags().no_default_mappings,
-                                     GlobalFlags().regex_dialect);
+  include_picker =
+      new IncludePicker(GlobalFlags().no_default_mappings,
+                        GlobalFlags().regex_dialect, GlobalFlags().use_libcxx);
   function_calls_full_use_cache = new FullUseCache;
   class_members_full_use_cache = new FullUseCache;
 

--- a/iwyu_globals.h
+++ b/iwyu_globals.h
@@ -100,6 +100,7 @@ struct CommandlineFlags {
   bool no_fwd_decls;  // Disable forward declarations.
   bool quoted_includes_first; // Place quoted includes first in sort order.
   bool cxx17ns; // -C: C++17 nested namespace syntax
+  bool use_libcxx;       // Use libc++ default mappings instead of libstdc++
   int exit_code_error;   // Exit with this code for iwyu violations.
   int exit_code_always;  // Always exit with this exit code.
   set<string> dbg_flags; // Debug flags.
@@ -114,6 +115,9 @@ clang::SourceManager* GlobalSourceManager();
 
 const IncludePicker& GlobalIncludePicker();
 IncludePicker* MutableGlobalIncludePicker();   // only use at great need!
+
+void SelectCXXStdlibLibcxx();
+void SelectCXXStdlibLibstdcpp();
 
 const clang::PrintingPolicy& DefaultPrintPolicy();
 

--- a/iwyu_globals.h
+++ b/iwyu_globals.h
@@ -101,6 +101,7 @@ struct CommandlineFlags {
   bool quoted_includes_first; // Place quoted includes first in sort order.
   bool cxx17ns; // -C: C++17 nested namespace syntax
   bool use_libcxx;       // Use libc++ default mappings instead of libstdc++
+  bool canonical_stdlib;  // Use canonical C/C++ mappings
   int exit_code_error;   // Exit with this code for iwyu violations.
   int exit_code_always;  // Always exit with this exit code.
   set<string> dbg_flags; // Debug flags.

--- a/iwyu_include_picker.cc
+++ b/iwyu_include_picker.cc
@@ -1049,13 +1049,32 @@ const IncludeMapEntry libstdcpp_include_map[] = {
 
 const IncludeMapEntry libcxx_symbol_map[] = {
   { "std::nullptr_t", kPrivate, "<cstddef>", kPublic },
+  { "std::filebuf", kPrivate, "<fstream>", kPublic },
+  { "std::fstream", kPrivate, "<fstream>", kPublic },
+  { "std::ifstream", kPrivate, "<fstream>", kPublic },
+  { "std::ofstream", kPrivate, "<fstream>", kPublic },
+  { "std::wfilebuf", kPrivate, "<fstream>", kPublic },
+  { "std::wfstream", kPrivate, "<fstream>", kPublic },
+  { "std::wifstream", kPrivate, "<fstream>", kPublic },
+  { "std::wofstream", kPrivate, "<fstream>", kPublic },
 
   // For older MacOS libc++ (13.0.0), on macOS Ventura (13.2.1)
   { "std::string", kPrivate, "<string>", kPublic },
+  { "std::wstring", kPrivate, "<string>", kPublic },
 };
 
 const IncludeMapEntry libcxx_include_map[] = {
     {"<__mutex_base>", kPrivate, "<mutex>", kPublic},
+
+    {"<__fwd/array.h>", kPrivate, "<array>", kPublic },
+    {"<__fwd/hash.h>", kPrivate, "<functional>", kPublic },
+    {"<__fwd/memory_resource.h>", kPrivate, "<memory_resource>", kPublic },
+    {"<__fwd/pair.h>", kPrivate, "<utility>", kPublic },
+    {"<__fwd/span.h>", kPrivate, "<span>", kPublic },
+    {"<__fwd/string.h>", kPrivate, "<string>", kPublic },
+    {"<__fwd/string_view.h>", kPrivate, "<string_view>", kPublic },
+    {"<__fwd/subrange.h>", kPrivate, "<range>", kPublic },
+    {"<__fwd/tuple.h>", kPrivate, "<tuple>", kPublic },
 
     // For the following entries:
     // cd llvm-project/libcxx/include ; find -type d -name "__*" | sort | sed -e "s#./__\(.*\)#  { \"@<__\1/.*>\", kPrivate, \"<\1>\", kPublic },#"

--- a/iwyu_include_picker.cc
+++ b/iwyu_include_picker.cc
@@ -1065,6 +1065,8 @@ const IncludeMapEntry libcxx_symbol_map[] = {
 
 const IncludeMapEntry libcxx_include_map[] = {
     {"<__mutex_base>", kPrivate, "<mutex>", kPublic},
+    {"<__tree>", kPrivate, "<map>", kPublic },
+    {"<__tree>", kPrivate, "<set>", kPublic },
 
     {"<__fwd/array.h>", kPrivate, "<array>", kPublic },
     {"<__fwd/hash.h>", kPrivate, "<functional>", kPublic },

--- a/iwyu_include_picker.cc
+++ b/iwyu_include_picker.cc
@@ -591,6 +591,9 @@ const IncludeMapEntry libc_include_map[] = {
   { "<sys/ucontext.h>", kPrivate, "<ucontext.h>", kPublic },
   // Exports guaranteed by the C standard
   { "<stdint.h>", kPublic, "<inttypes.h>", kPublic },
+  // macos
+  { "<sys/errno.h>", kPrivate, "<errno.h>", kPublic },
+  { "<_ctype.h>", kPrivate, "<ctype.h>", kPublic },
 };
 
 const IncludeMapEntry stdlib_c_include_map[] = {

--- a/iwyu_include_picker.h
+++ b/iwyu_include_picker.h
@@ -67,6 +67,8 @@ struct IncludeMapEntry;
 
 enum class RegexDialect;
 enum IncludeVisibility { kUnusedVisibility, kPublic, kPrivate };
+enum LibCImpl { kNoC, kCanonicalC, kGlibc };
+enum LibCXXImpl { kNoCXX, kCanonicalCXX, kLibstdcpp, kLibcxx };
 
 // When a symbol or file is mapped to an include, that include is represented
 // by this struct.  It always has a quoted_include and may also have a path
@@ -92,8 +94,8 @@ class IncludePicker {
   // visibility of the respective files.
   typedef map<string, IncludeVisibility> VisibilityMap;
 
-  IncludePicker(bool no_default_mappings, RegexDialect regex_dialect,
-                bool use_libcxx);
+  IncludePicker(RegexDialect regex_dialect, enum LibCImpl libc_impl,
+                enum LibCXXImpl libcxx_impl);
 
   // ----- Routines to dynamically modify the include-picker
 
@@ -191,7 +193,7 @@ class IncludePicker {
                            const vector<string>& search_path);
 
   // Adds all hard-coded default mappings.
-  void AddDefaultMappings(bool use_libcxx);
+  void AddDefaultMappings(enum LibCImpl libc_impl, enum LibCXXImpl libcxx_impl);
 
   // Adds a mapping from a one header to another, typically
   // from a private to a public quoted include.

--- a/iwyu_include_picker.h
+++ b/iwyu_include_picker.h
@@ -92,7 +92,8 @@ class IncludePicker {
   // visibility of the respective files.
   typedef map<string, IncludeVisibility> VisibilityMap;
 
-  IncludePicker(bool no_default_mappings, RegexDialect regex_dialect);
+  IncludePicker(bool no_default_mappings, RegexDialect regex_dialect,
+                bool use_libcxx);
 
   // ----- Routines to dynamically modify the include-picker
 
@@ -190,7 +191,7 @@ class IncludePicker {
                            const vector<string>& search_path);
 
   // Adds all hard-coded default mappings.
-  void AddDefaultMappings();
+  void AddDefaultMappings(bool use_libcxx);
 
   // Adds a mapping from a one header to another, typically
   // from a private to a public quoted include.

--- a/libcxx.imp
+++ b/libcxx.imp
@@ -1,6 +1,8 @@
 # libc++ headers
 [
   { include: ["<__mutex_base>", private, "<mutex>", public ] },
+  { include: ["<__tree>", private, "<map>", public ] },
+  { include: ["<__tree>", private, "<set>", public ] },
 
   { include: ["<__fwd/array.h>", private, "<array>", public ] },
   { include: ["<__fwd/hash.h>", private, "<functional>", public ] },

--- a/libcxx.imp
+++ b/libcxx.imp
@@ -2,6 +2,16 @@
 [
   { include: ["<__mutex_base>", private, "<mutex>", public ] },
 
+  { include: ["<__fwd/array.h>", private, "<array>", public ] },
+  { include: ["<__fwd/hash.h>", private, "<functional>", public ] },
+  { include: ["<__fwd/memory_resource.h>", private, "<memory_resource>", public ] },
+  { include: ["<__fwd/pair.h>", private, "<utility>", public ] },
+  { include: ["<__fwd/span.h>", private, "<span>", public ] },
+  { include: ["<__fwd/string.h>", private, "<string>", public ] },
+  { include: ["<__fwd/string_view.h>", private, "<string_view>", public ] },
+  { include: ["<__fwd/subrange.h>", private, "<range>", public ] },
+  { include: ["<__fwd/tuple.h>", private, "<tuple>", public ] },
+
   # For the following entries:
   # cd llvm-project/libcxx/include ; find -type d -name "__*" | sort | sed -e "s#./__\(.*\)#  { include: [\"@<__\1/.*>\", private, \"<\1>\", public ] },#"
   #
@@ -37,9 +47,18 @@
   { include: ["@<__variant/.*>", private, "<variant>", public ] },
 
   { symbol: [ "std::nullptr_t", private, "<cstddef>", public ] },
+  { symbol: [ "std::filebuf", private, "<fstream>", public ] },
+  { symbol: [ "std::fstream", private, "<fstream>", public ] },
+  { symbol: [ "std::ifstream", private, "<fstream>", public ] },
+  { symbol: [ "std::ofstream", private, "<fstream>", public ] },
+  { symbol: [ "std::wfilebuf", private, "<fstream>", public ] },
+  { symbol: [ "std::wfstream", private, "<fstream>", public ] },
+  { symbol: [ "std::wifstream", private, "<fstream>", public ] },
+  { symbol: [ "std::wofstream", private, "<fstream>", public ] },
 
   # For older MacOS libc++ (13.0.0), on macOS Ventura (13.2.1)
   { include: ["<__functional_base>", private, "<functional>", public ] },
 
   { symbol: [ "std::string", private, "<string>", public ] },
+  { symbol: [ "std::wstring", private, "<string>", public ] },
 ]

--- a/libcxx.imp
+++ b/libcxx.imp
@@ -1,10 +1,45 @@
 # libc++ headers
 [
-  { include: ["<__functional_base>", private, "<functional>", public ] },
   { include: ["<__mutex_base>", private, "<mutex>", public ] },
-  { symbol: [ "std::declval", private, "<utility>", public ] },
-  { symbol: [ "std::forward", private, "<utility>", public ] },
-  { symbol: [ "std::move", private, "<utility>", public ] },
+
+  # For the following entries:
+  # cd llvm-project/libcxx/include ; find -type d -name "__*" | sort | sed -e "s#./__\(.*\)#  { include: [\"@<__\1/.*>\", private, \"<\1>\", public ] },#"
+  #
+  # tweak tuple_dir entry, and comment out debug_utils, fwd, support
+  { include: ["@<__algorithm/.*>", private, "<algorithm>", public ] },
+  { include: ["@<__atomic/.*>", private, "<atomic>", public] },
+  { include: ["@<__algorithm/.*>", private, "<algorithm>", public ] },
+  { include: ["@<__bit/.*>", private, "<bit>", public ] },
+  { include: ["@<__charconv/.*>", private, "<charconv>", public ] },
+  { include: ["@<__chrono/.*>", private, "<chrono>", public ] },
+  { include: ["@<__compare/.*>", private, "<compare>", public ] },
+  { include: ["@<__concepts/.*>", private, "<concepts>", public ] },
+  { include: ["@<__coroutine/.*>", private, "<coroutine>", public ] },
+  #{ include: ["@<__debug_utils/.*>", private, "<>", public ] },
+  { include: ["@<__expected/.*>", private, "<expected>", public ] },
+  { include: ["@<__filesystem/.*>", private, "<filesystem>", public ] },
+  { include: ["@<__format/.*>", private, "<format>", public ] },
+  { include: ["@<__functional/.*>", private, "<functional>", public ] },
+  #{ include: ["@<__fwd/.*>", private, "<>", public ] },
+  { include: ["@<__ios/.*>", private, "<ios>", public ] },
+  { include: ["@<__iterator/.*>", private, "<iterator>", public ] },
+  { include: ["@<__memory/.*>", private, "<memory>", public ] },
+  { include: ["@<__memory_resource/.*>", private, "<memory_resource>", public ] },
+  { include: ["@<__numeric/.*>", private, "<numeric>", public ] },
+  { include: ["@<__random/.*>", private, "<random>", public ] },
+  { include: ["@<__ranges/.*>", private, "<ranges>", public ] },
+  { include: ["@<__string/.*>", private, "<string>", public ] },
+  #{ include: ["@<__support/.*>", private, "<>", public ] },
+  { include: ["@<__thread/.*>", private, "<thread>", public ] },
+  { include: ["@<__tuple_dir/.*>", private, "<tuple>", public ] },
+  { include: ["@<__type_traits/.*>", private, "<type_traits>", public ] },
+  { include: ["@<__utility/.*>", private, "<utility>", public ] },
+  { include: ["@<__variant/.*>", private, "<variant>", public ] },
+
   { symbol: [ "std::nullptr_t", private, "<cstddef>", public ] },
+
+  # For older MacOS libc++ (13.0.0), on macOS Ventura (13.2.1)
+  { include: ["<__functional_base>", private, "<functional>", public ] },
+
   { symbol: [ "std::string", private, "<string>", public ] },
 ]


### PR DESCRIPTION
I've been working on MacOS for the namespace series that I raised. I've got 10 `run_iwyu_test.py` failures, so this series is an attempt to clean some of them up. The main problems stems from using `libstdcpp` mappings instead of `libcxx`.

The primary resolution is to add an internal mapping for `libcxx`, and to determine the selected C++ standard library at runtime. I've also updated the `libcxx.imp` mappings for what's in `libc++` 17, with some backwards compatibility for MacOS's `libc++` 13 (which is actually what I'm testing against - IWYU isn't happy when pointed at the standalone libc++ includes).

A secondary resolution is to allow the user to select canonical mappings using clang's newish `Tooling/Inclusion` library. See that commit for details. This seems to work pretty well, and is handy for double checking against the libcxx behaviour.

The final commit in the series adds a couple of tweaks to play nicer with MacOS `libc`, but we may want to drop this commit to do this 'properly' (I'm not sure how we'd want to do this)

After this series, the number of test failures is down to 5. I've also run the resulting IWYU on its source code, and have satisified myself that the suggestions in both `libcxx` and canonical mode are sensible. The one outlier is that IWYU suggests removing `<algorithm>` from `iwyu_stl_util.h` (as it doesn't get any full uses of `std::find`), which seems wrong but I'm not familiar enough with the template corner cases :)