### PR TITLE
Abandon python2 for scripts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,25 +16,25 @@ If fixing a bug in IWYU, please add a test to the test suite!  You can create a 
 
 To run the IWYU tests, run
 
-    python run_iwyu_tests.py
+    python3 run_iwyu_tests.py
 
 It runs one test for each `.cc` file in the `tests/` directory.  (We have additional tests in `more_tests/`, but have not yet gotten the testing framework set up for those tests.) The test runner searches for IWYU in the system `PATH` by default.
 
 The output can be a bit hard to read, but if a test fails, the reason why will be listed after the `ERROR:root:Test failed for xxx` line.
 
-You can select individual tests by listing them as arguments. Test names are derived from the file path and name, e.g. `tests/cxx/array.cc` will be named `cxx.test_array`. You can use `python run_iwyu_tests.py --list` to list all available test names.
+You can select individual tests by listing them as arguments. Test names are derived from the file path and name, e.g. `tests/cxx/array.cc` will be named `cxx.test_array`. You can use `python3 run_iwyu_tests.py --list` to list all available test names.
 
-    python run_iwyu_tests.py cxx.test_array cxx.test_macro_location c.test_enum
+    python3 run_iwyu_tests.py cxx.test_array cxx.test_macro_location c.test_enum
 
 If you don't want to modify your `PATH` you can specify which IWYU executable to use for testing
 
-    python run_iwyu_tests.py -- ./include-what-you-use
+    python3 run_iwyu_tests.py -- ./include-what-you-use
 
 (put any test names before '--' and the IWYU path after.)
 
 When fixing `fix_includes.py`, add a test case to `fix_includes_test.py` and run
 
-    python fix_includes_test.py
+    python3 fix_includes_test.py
 
 ## Debugging ##
 

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ or, on Windows systems:
 
       mkdir build && cd build
       cmake -DCMAKE_CXX_COMPILER="%VCINSTALLDIR%/bin/cl.exe" -DCMAKE_C_COMPILER="%VCINSTALLDIR%/VC/bin/cl.exe" -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -G Ninja ...
-      python iwyu_tool.py -p .
+      python3 iwyu_tool.py -p .
 
 Unless a source filename is provided, all files in the project will be analyzed.
 
@@ -183,10 +183,10 @@ See `iwyu_tool.py --help` for more options.
 
 #### Applying fixes ####
 
-We also include a tool that automatically fixes up your source files based on the IWYU recommendations.  This is also alpha-quality software!  Here's how to use it (requires python):
+We also include a tool that automatically fixes up your source files based on the IWYU recommendations.  This is also alpha-quality software!  Here's how to use it (requires python3):
 
       make -k CXX=include-what-you-use CXXFLAGS="-Xiwyu --error_always" 2> /tmp/iwyu.out
-      python fix_includes.py < /tmp/iwyu.out
+      python3 fix_includes.py < /tmp/iwyu.out
 
 If you don't like the way `fix_includes.py` munges your `#include` lines, you can control its behavior via flags. `fix_includes.py --help` will give a full list, but these are some common ones:
 

--- a/iwyu_test_util.py
+++ b/iwyu_test_util.py
@@ -10,16 +10,6 @@
 ##===----------------------------------------------------------------------===##
 
 """Utilities for writing tests for IWYU.
-
-This script has been tested with python 2.7, 3.1.3 and 3.2.
-In order to support all of these platforms there are a few unusual constructs:
- * print statements require parentheses
- * standard output must be decoded as utf-8
- * range() must be used in place of xrange()
- * _PortableNext() is used to obtain next iterator value
-
-There is more detail on some of these issues at:
-http://diveintopython3.org/porting-code-to-python-3-with-2to3.html
 """
 
 __author__ = 'wan@google.com (Zhanyong Wan)'
@@ -53,13 +43,6 @@ _NODIFFS_RE = re.compile(r'^\((.*?) has correct #includes/fwd-decls\)$')
 # source file. Example:
 # // IWYU_ARGS: -Xiwyu --mapping_file=... -I .
 _IWYU_TEST_RUN_ARGS_RE = re.compile(r'^//\sIWYU_ARGS:\s(.*)$')
-
-
-def _PortableNext(iterator):
-  if hasattr(iterator, 'next'):
-    iterator.next()  # Python 2.4-2.6
-  else:
-    next(iterator)   # Python 3
 
 
 def _Which(program, paths):
@@ -406,7 +389,7 @@ def _CompareExpectedAndActualSummaries(expected_summaries, actual_summaries):
     this_failure = difflib.unified_diff(expected_summaries.get(loc, []),
                                         actual_summaries.get(loc, []))
     try:
-      _PortableNext(this_failure)     # read past the 'what files are this' header
+      next(this_failure)     # read past the 'what files are this' header
       failures.append('\n')
       failures.append('Unexpected summary diffs for %s:\n' % loc)
       failures.extend(this_failure)

--- a/iwyu_tool.py
+++ b/iwyu_tool.py
@@ -24,7 +24,7 @@ Example usage with CMake:
     -DCMAKE_C_COMPILER="%VCINSTALLDIR%/VC/bin/cl.exe" \
     -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
     -G Ninja ...
-  $ python iwyu_tool.py -p .
+  $ python3 iwyu_tool.py -p .
 
 See iwyu_tool.py -h for more details on command-line arguments.
 """


### PR DESCRIPTION
* Update documentation to explicitly use python3
* Remove a few particularly ugly compatibility hacks

There are probably a lot more things we could do to use more idiomatic python3, but that can happen as necessary.

This patch primarily wants to make explicit that python3 is assumed, and python2 is no longer supported.