### PR TITLE
Libcxx.imp updates for clang 16

### DIFF
--- a/libcxx.imp
+++ b/libcxx.imp
@@ -1,10 +1,45 @@
 # libc++ headers
 [
-  { include: ["<__functional_base>", private, "<functional>", public ] },
   { include: ["<__mutex_base>", private, "<mutex>", public ] },
-  { symbol: [ "std::declval", private, "<utility>", public ] },
-  { symbol: [ "std::forward", private, "<utility>", public ] },
-  { symbol: [ "std::move", private, "<utility>", public ] },
+
+  # For the following entries:
+  # cd llvm-project/libcxx/include ; find -type d -name "__*" | sort | sed -e "s#./__\(.*\)#  { include: [\"@<__\1/.*>\", private, \"<\1>\", public ] },#"
+  #
+  # tweak tuple_dir entry, and comment out debug_utils, fwd, support
+  { include: ["@<__algorithm/.*>", private, "<algorithm>", public ] },
+  { include: ["@<__atomic/.*>", private, "<atomic>", public] },
+  { include: ["@<__algorithm/.*>", private, "<algorithm>", public ] },
+  { include: ["@<__bit/.*>", private, "<bit>", public ] },
+  { include: ["@<__charconv/.*>", private, "<charconv>", public ] },
+  { include: ["@<__chrono/.*>", private, "<chrono>", public ] },
+  { include: ["@<__compare/.*>", private, "<compare>", public ] },
+  { include: ["@<__concepts/.*>", private, "<concepts>", public ] },
+  { include: ["@<__coroutine/.*>", private, "<coroutine>", public ] },
+  #{ include: ["@<__debug_utils/.*>", private, "<debug_utils>", public ] },
+  { include: ["@<__expected/.*>", private, "<expected>", public ] },
+  { include: ["@<__filesystem/.*>", private, "<filesystem>", public ] },
+  { include: ["@<__format/.*>", private, "<format>", public ] },
+  { include: ["@<__functional/.*>", private, "<functional>", public ] },
+  #{ include: ["@<__fwd/.*>", private, "<fwd>", public ] },
+  { include: ["@<__ios/.*>", private, "<ios>", public ] },
+  { include: ["@<__iterator/.*>", private, "<iterator>", public ] },
+  { include: ["@<__memory/.*>", private, "<memory>", public ] },
+  { include: ["@<__memory_resource/.*>", private, "<memory_resource>", public ] },
+  { include: ["@<__numeric/.*>", private, "<numeric>", public ] },
+  { include: ["@<__random/.*>", private, "<random>", public ] },
+  { include: ["@<__ranges/.*>", private, "<ranges>", public ] },
+  { include: ["@<__string/.*>", private, "<string>", public ] },
+  #{ include: ["@<__support/.*>", private, "<support>", public ] },
+  { include: ["@<__thread/.*>", private, "<thread>", public ] },
+  { include: ["@<__tuple_dir/.*>", private, "<tuple>", public ] },
+  { include: ["@<__type_traits/.*>", private, "<type_traits>", public ] },
+  { include: ["@<__utility/.*>", private, "<utility>", public ] },
+  { include: ["@<__variant/.*>", private, "<variant>", public ] },
+
   { symbol: [ "std::nullptr_t", private, "<cstddef>", public ] },
+
+  # For older MacOS libc++ (13.0.0), on macOS Ventura (13.2.1)
+  { include: ["<__functional_base>", private, "<functional>", public ] },
+
   { symbol: [ "std::string", private, "<string>", public ] },
 ]


### PR DESCRIPTION
Update the `libcxx` import mapping file with useful directory and symbol mappings. This is a step to improving `run_iwyu_tests.py` output on MacOS.

Sanity tested by running on IWYU source against `libcxx` 16, and MacOs's `libcxx` (13).

Added some test cases - I think it is useful to be able to verify that we aren't breaking standard library mappings, even if we can only do this on the current platform. Eventually, maybe CI can check a few different platforms. I don't expect that we'll have exhaustive tests - but we can at least add tests for issues that are identified.

I had a few further changes that I thought we'd need (spotted by browsing the source) - however I haven't actually seen IWYU complain about these.

I'm aware the IWYU branch for clang 16 is imminent - I've no expectation that these changes make that branch (although it might be nice).