### PR TITLE
Support Canonical C/C++ mappings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,6 +173,8 @@ else()
     # [1] https://llvm.org/viewvc/llvm-project?view=revision&revision=348907
     # [2] https://llvm.org/viewvc/llvm-project?view=revision&revision=348915
     clangSerialization
+
+    clangToolingInclusionsStdlib
   )
 endif()
 

--- a/include-what-you-use.1
+++ b/include-what-you-use.1
@@ -77,6 +77,18 @@ Exit with error code
 (defaults to 1 if omitted) whether there are \(lqinclude-what-you-use\(rq
 violations or not (for use with \fBmake\fR(1)).
 .TP
+.BI \-\-experimental= flag[,flag...]
+Enable experimental feature. These feature may change or be removed
+without any notice. Current experimental features are:
+.RS
+.TP
+.B clang_mappings
+Use Clang libTooling standard library symbol mappings instead of
+built-in mappings. This potentially replaces the built-in mappings in
+the future, but is currently experimental while the issues are being
+evaluated.
+.RE
+.TP
 .BI \-\-keep= glob
 Always keep the includes matched by
 .IR glob .

--- a/iwyu_globals.h
+++ b/iwyu_globals.h
@@ -87,6 +87,7 @@ struct CommandlineFlags {
   CommandlineFlags();                     // sets flags to default values
   int ParseArgv(int argc, char** argv);   // parses flags from argv
   bool HasDebugFlag(const char* flag) const;
+  bool HasExperimentalFlag(const char* flag) const;
 
   set<string> check_also;  // -c: globs to report iwyu violations for
   set<string> keep;        // -k: globs to force-keep includes for
@@ -108,6 +109,7 @@ struct CommandlineFlags {
   int exit_code_error;   // Exit with this code for iwyu violations.
   int exit_code_always;  // Always exit with this exit code.
   set<string> dbg_flags; // Debug flags.
+  set<string> exp_flags;       // Experimental flags.
   RegexDialect regex_dialect;  // Dialect for regular expression processing.
 };
 

--- a/iwyu_include_picker.cc
+++ b/iwyu_include_picker.cc
@@ -37,6 +37,7 @@
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/YAMLParser.h"
 #include "clang/Basic/FileManager.h"
+#include "clang/Tooling/Inclusions/StandardLibrary.h"
 
 using std::find;
 using std::make_pair;
@@ -1297,9 +1298,23 @@ IncludePicker::IncludePicker(RegexDialect regex_dialect,
 
 void IncludePicker::AddDefaultMappings(CStdLib cstdlib,
                                        CXXStdLib cxxstdlib) {
+  using clang::tooling::stdlib::Header;
+  using clang::tooling::stdlib::Lang;
+  using clang::tooling::stdlib::Symbol;
+
   if (cstdlib == CStdLib::Glibc) {
     AddSymbolMappings(libc_symbol_map, IWYU_ARRAYSIZE(libc_symbol_map));
     AddIncludeMappings(libc_include_map, IWYU_ARRAYSIZE(libc_include_map));
+  } else if (cstdlib == CStdLib::ClangSymbols) {
+    // Get canonical C standard library mappings from clang tooling
+    for (const Symbol& sym : Symbol::all(Lang::C)) {
+      string name = sym.name().str();
+
+      // the canonical header is returned first
+      for (const Header& header : sym.headers()) {
+        AddSymbolMapping(name, MappedInclude(header.name().str()), kPublic);
+      }
+    }
   }
 
   if (cxxstdlib == CXXStdLib::Libstdcxx) {
@@ -1310,6 +1325,16 @@ void IncludePicker::AddDefaultMappings(CStdLib cstdlib,
   } else if (cxxstdlib == CXXStdLib::Libcxx) {
     AddSymbolMappings(libcxx_symbol_map, IWYU_ARRAYSIZE(libcxx_symbol_map));
     AddIncludeMappings(libcxx_include_map, IWYU_ARRAYSIZE(libcxx_include_map));
+  } else if (cxxstdlib == CXXStdLib::ClangSymbols) {
+    // Get canonical C++ standard library mappings from clang tooling
+    for (const Symbol& sym : Symbol::all(Lang::CXX)) {
+      string name = sym.qualifiedName().str();
+
+      // the canonical header is returned first
+      for (const Header& header : sym.headers()) {
+        AddSymbolMapping(name, MappedInclude(header.name().str()), kPublic);
+      }
+    }
   }
 
   if (cxxstdlib != CXXStdLib::None) {

--- a/iwyu_include_picker.h
+++ b/iwyu_include_picker.h
@@ -67,8 +67,8 @@ struct IncludeMapEntry;
 
 enum class RegexDialect;
 enum IncludeVisibility { kUnusedVisibility, kPublic, kPrivate };
-enum class CStdLib { None, Glibc };
-enum class CXXStdLib { None, Libstdcxx, Libcxx };
+enum class CStdLib { None, ClangSymbols, Glibc };
+enum class CXXStdLib { None, ClangSymbols, Libstdcxx, Libcxx };
 
 // When a symbol or file is mapped to an include, that include is represented
 // by this struct.  It always has a quoted_include and may also have a path


### PR DESCRIPTION
Clang Tooling has recently gained knowledge about the canonical symbol mappings specified by the standards (sourced from cppreference). Add an option to use these instead of the mappings based on particular implementations.

The benefit of this is that the mapping is independent of any particular implementation, and should be portable.

The main downside is that the mapping is done per symbol, so if the user overloads a symbol that the standard library provides, then IWYU will suggest the standard library header instead of the user header. As an example check tests/cxx/precomputed_tpl_args.cc declaration of std::less

By observation, it looks like IWYU is not mapping operators() correctly (or they may not be getting defined) so implementation detail is leaking through.