### PR TITLE
Handle elaborated keywords as fwd-decls

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -2667,12 +2667,6 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
 
         parent_type = GetTypeOf(decl);
       } else if (const auto *decl = ast_node->GetParentAs<TypeDecl>()) {
-        // Elaborated types in type decls are always forward-declarable
-        // (and usually count as forward declarations themselves).
-        if (IsElaboratedTypeSpecifier(ast_node)) {
-          return true;
-        }
-
         // If we ourselves are a forward-decl -- that is, we're the type
         // component of a forward-declaration (which would be our parent
         // AST node) -- then we're forward-declarable by definition.

--- a/iwyu.cc
+++ b/iwyu.cc
@@ -167,6 +167,7 @@ using clang::Decl;
 using clang::DeclContext;
 using clang::DeclRefExpr;
 using clang::DeducedTemplateSpecializationType;
+using clang::ElaboratedTypeLoc;
 using clang::EnumConstantDecl;
 using clang::EnumDecl;
 using clang::EnumType;
@@ -4205,6 +4206,15 @@ class IwyuAstConsumer
     }
 
     return Base::VisitTemplateSpecializationType(type);
+  }
+
+  bool VisitElaboratedTypeLoc(ElaboratedTypeLoc type_loc) {
+    if (type_loc.getTypePtr()->getKeyword() != clang::ETK_None) {
+      preprocessor_info()
+          .FileInfoFor(CurrentFileEntry())
+          ->AddElaboratedType(type_loc);
+    }
+    return Base::VisitElaboratedTypeLoc(type_loc);
   }
 
   // --- Visitors defined by BaseASTVisitor (not RecursiveASTVisitor).

--- a/iwyu_output.h
+++ b/iwyu_output.h
@@ -30,6 +30,7 @@
 namespace clang {
 class FileEntry;
 class UsingDecl;
+class ElaboratedTypeLoc;
 }  // namespace clang
 
 namespace include_what_you_use {
@@ -144,6 +145,7 @@ class OneUse {
 class OneIncludeOrForwardDeclareLine {
  public:
   explicit OneIncludeOrForwardDeclareLine(const clang::NamedDecl* fwd_decl);
+  explicit OneIncludeOrForwardDeclareLine(clang::ElaboratedTypeLoc);
   OneIncludeOrForwardDeclareLine(const clang::FileEntry* included_file,
                                  const string& quoted_include, int linenum);
 
@@ -157,6 +159,9 @@ class OneIncludeOrForwardDeclareLine {
   }
   bool is_present() const {
     return is_present_;
+  }
+  bool is_elaborated_type() const {
+    return is_elaborated_type_;
   }
   const map<string, int>& symbol_counts() const {
     return symbol_counts_;
@@ -206,9 +211,10 @@ class OneIncludeOrForwardDeclareLine {
   string line_;  // '#include XXX' or 'class YYY;'
   int start_linenum_ = -1;
   int end_linenum_ = -1;
-  bool is_desired_ = false;         // IWYU will recommend this line
-  bool is_present_ = false;         // line was present before the IWYU run
-  map<string, int> symbol_counts_;  // how many times we referenced each symbol
+  bool is_desired_ = false;          // IWYU will recommend this line
+  bool is_present_ = false;          // line was present before the IWYU run
+  bool is_elaborated_type_ = false;  // Fwd-decl introduced by elaborated type
+  map<string, int> symbol_counts_;   // how many times we referenced each symbol
   // Only either two following members are set for includes
   string quoted_include_;  // quoted file name we're including
   const clang::FileEntry* included_file_ = nullptr;  // the file we're including
@@ -258,6 +264,7 @@ class IwyuFileInfo {
   // the fwd-decl be removed, even if we don't see any uses of it.
   void AddForwardDeclare(const clang::NamedDecl* fwd_decl,
                          bool definitely_keep_fwd_decl);
+  void AddElaboratedType(clang::ElaboratedTypeLoc);
 
   void AddUsingDecl(const clang::UsingDecl* using_decl);
 

--- a/tests/cxx/elaborated_type.cc
+++ b/tests/cxx/elaborated_type.cc
@@ -60,6 +60,21 @@ void global_qualified_elab(class ::GlobalClass* c);
 // they must also be forward-declared.
 Elaboration::Template<int, float>* namespace_qualified_template;
 
+// Elaborated types can be treated as forward-declarations, hence no fwd-decl is
+// needed if a declaration is introduced by elaborated type. Implicit
+// declaration introduction occurs at least when there isn't any previous
+// declaration of the type in a translation unit.
+void elaborated_first_elaborated(class FirstElaborated*);
+void bare_first_elaborated(FirstElaborated*);
+class FirstElaborated;
+void previously_introduced(FirstElaborated*);
+
+// But if an elaborated type appears after the first fwd-decl use of the type, a
+// true forward declaration is still needed.
+class FirstForwardDeclared;
+void bare_first_forward_declared(FirstForwardDeclared*);
+void elaborated_first_forward_declared(class FirstForwardDeclared*);
+
 /**** IWYU_SUMMARY
 
 tests/cxx/elaborated_type.cc should add these lines:
@@ -74,11 +89,13 @@ tests/cxx/elaborated_type.cc should remove these lines:
 - #include "tests/cxx/elaborated_type_namespace.h"  // lines XX-XX
 - #include "tests/cxx/elaborated_type_struct.h"  // lines XX-XX
 - #include "tests/cxx/elaborated_type_union.h"  // lines XX-XX
+- class FirstElaborated;  // lines XX-XX
 
 The full include-list for tests/cxx/elaborated_type.cc:
 #include "tests/cxx/elaborated_type_enum1.h"  // for ElaborationEnum1
 #include "tests/cxx/elaborated_type_enum2.h"  // for ElaborationEnum2
 class ElaborationClass;
+class FirstForwardDeclared;  // lines XX-XX
 class GlobalClass;  // lines XX-XX
 namespace Elaboration { class Class; }
 namespace Elaboration { template <typename T, typename U> struct Template; }

--- a/tests/cxx/iwyu_stricter_than_cpp-type_alias.h
+++ b/tests/cxx/iwyu_stricter_than_cpp-type_alias.h
@@ -29,6 +29,9 @@ using DoesNotForwardDeclareProperlyAl = IndirectStructForwardDeclaredInD1;
 struct DirectStruct1;
 using IncludesAl = DirectStruct1;
 
+// Essentially the same; should require corresponding header inclusion here.
+using IncludesElaboratedAl = struct DirectStruct3;
+
 // Requires the full type because it does not obey rules (1) *or* (2)
 using DoesNotForwardDeclareAndIncludesAl = DirectStruct2;
 
@@ -76,7 +79,7 @@ tests/cxx/iwyu_stricter_than_cpp-type_alias.h should remove these lines:
 - template <typename T> struct TplDirectStruct1;  // lines XX-XX
 
 The full include-list for tests/cxx/iwyu_stricter_than_cpp-type_alias.h:
-#include "tests/cxx/iwyu_stricter_than_cpp-d1.h"  // for DirectStruct1, DirectStruct2, TplDirectStruct1, TplDirectStruct2
+#include "tests/cxx/iwyu_stricter_than_cpp-d1.h"  // for DirectStruct1, DirectStruct2, DirectStruct3, TplDirectStruct1, TplDirectStruct2
 #include "tests/cxx/iwyu_stricter_than_cpp-i1.h"  // for IndirectStruct1, IndirectStructForwardDeclaredInD1, TplIndirectStruct1, TplIndirectStructForwardDeclaredInD1
 struct IndirectStruct2;  // lines XX-XX
 struct IndirectStruct3;  // lines XX-XX

--- a/tests/cxx/iwyu_stricter_than_cpp-typedefs.h
+++ b/tests/cxx/iwyu_stricter_than_cpp-typedefs.h
@@ -29,6 +29,9 @@ typedef IndirectStructForwardDeclaredInD1 DoesNotForwardDeclareProperly;
 struct DirectStruct1;
 typedef DirectStruct1 Includes;
 
+// Essentially the same; should require corresponding header inclusion here.
+typedef struct DirectStruct3 IncludesElaborated;
+
 // Requires the full type because it does not obey rules (1) *or* (2)
 typedef DirectStruct2 DoesNotForwardDeclareAndIncludes;
 
@@ -76,7 +79,7 @@ tests/cxx/iwyu_stricter_than_cpp-typedefs.h should remove these lines:
 - template <typename T> struct TplDirectStruct1;  // lines XX-XX
 
 The full include-list for tests/cxx/iwyu_stricter_than_cpp-typedefs.h:
-#include "tests/cxx/iwyu_stricter_than_cpp-d1.h"  // for DirectStruct1, DirectStruct2, TplDirectStruct1, TplDirectStruct2
+#include "tests/cxx/iwyu_stricter_than_cpp-d1.h"  // for DirectStruct1, DirectStruct2, DirectStruct3, TplDirectStruct1, TplDirectStruct2
 #include "tests/cxx/iwyu_stricter_than_cpp-i1.h"  // for IndirectStruct1, IndirectStructForwardDeclaredInD1, TplIndirectStruct1, TplIndirectStructForwardDeclaredInD1
 struct IndirectStruct2;  // lines XX-XX
 struct IndirectStruct3;  // lines XX-XX

--- a/tests/cxx/iwyu_stricter_than_cpp.cc
+++ b/tests/cxx/iwyu_stricter_than_cpp.cc
@@ -55,6 +55,7 @@ void TestTypedefs() {
   DoesNotForwardDeclare dnfd(1);
   DoesNotForwardDeclareProperly dnfdp(2);
   Includes i(3);
+  IncludesElaborated ie(3);
   DoesNotForwardDeclareAndIncludes dnfdai(4);
   // IWYU: IndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
   DoesEverythingRight dor(5);
@@ -101,6 +102,7 @@ void TestTypeAliases() {
   DoesNotForwardDeclareAl dnfd(1);
   DoesNotForwardDeclareProperlyAl dnfdp(2);
   IncludesAl i(3);
+  IncludesElaboratedAl ie(3);
   DoesNotForwardDeclareAndIncludesAl dnfdai(4);
   // IWYU: IndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
   DoesEverythingRightAl dor(5);
@@ -240,8 +242,8 @@ The full include-list for tests/cxx/iwyu_stricter_than_cpp.cc:
 #include "tests/cxx/iwyu_stricter_than_cpp-i2.h"  // for IndirectStruct2, TplIndirectStruct2
 #include "tests/cxx/iwyu_stricter_than_cpp-i3.h"  // for IndirectStruct3
 #include "tests/cxx/iwyu_stricter_than_cpp-i4.h"  // for IndirectStruct4
-#include "tests/cxx/iwyu_stricter_than_cpp-type_alias.h"  // for DoesEverythingRightAl, DoesNotForwardDeclareAl, DoesNotForwardDeclareAndIncludesAl, DoesNotForwardDeclareProperlyAl, IncludesAl, IndirectStruct3NonProvidingAl, IndirectStruct4NonProvidingAl, TplDoesEverythingRightAgainAl, TplDoesEverythingRightAl, TplDoesNotForwardDeclareAl, TplDoesNotForwardDeclareAndIncludesAl, TplDoesNotForwardDeclareProperlyAl, TplIncludesAl
-#include "tests/cxx/iwyu_stricter_than_cpp-typedefs.h"  // for DoesEverythingRight, DoesNotForwardDeclare, DoesNotForwardDeclareAndIncludes, DoesNotForwardDeclareProperly, Includes, IndirectStruct3NonProvidingTypedef, IndirectStruct4NonProvidingTypedef, TplDoesEverythingRight, TplDoesEverythingRightAgain, TplDoesNotForwardDeclare, TplDoesNotForwardDeclareAndIncludes, TplDoesNotForwardDeclareProperly, TplIncludes
+#include "tests/cxx/iwyu_stricter_than_cpp-type_alias.h"  // for DoesEverythingRightAl, DoesNotForwardDeclareAl, DoesNotForwardDeclareAndIncludesAl, DoesNotForwardDeclareProperlyAl, IncludesAl, IncludesElaboratedAl, IndirectStruct3NonProvidingAl, IndirectStruct4NonProvidingAl, TplDoesEverythingRightAgainAl, TplDoesEverythingRightAl, TplDoesNotForwardDeclareAl, TplDoesNotForwardDeclareAndIncludesAl, TplDoesNotForwardDeclareProperlyAl, TplIncludesAl
+#include "tests/cxx/iwyu_stricter_than_cpp-typedefs.h"  // for DoesEverythingRight, DoesNotForwardDeclare, DoesNotForwardDeclareAndIncludes, DoesNotForwardDeclareProperly, Includes, IncludesElaborated, IndirectStruct3NonProvidingTypedef, IndirectStruct4NonProvidingTypedef, TplDoesEverythingRight, TplDoesEverythingRightAgain, TplDoesNotForwardDeclare, TplDoesNotForwardDeclareAndIncludes, TplDoesNotForwardDeclareProperly, TplIncludes
 struct DirectStruct1;
 struct DirectStruct2;
 struct IndirectStruct1;


### PR DESCRIPTION
C++ doesn't require any forward-declaration after the declaration name occured in an elaborated type with corresponding tag (`class`/`struct`/`union`).

Initial support. Only those elaborated types are treated as fwd-declarations which occur before any other declaration of the underlying type ("owning" elaborated types).

"TypeLoc" is intercepted and handled instead of just the type because only explicitly written elaborated types matter. Moreover, location information could be used in the future for full support of treating elaborated types as fwd-declarations, even in the "non-owning" case.

Besides, it is the more correct fix of #1065.

Provision of underlying elaborated type in typedef or type alias declaration has been fixed. Otherwise, there was a bug when IWYU required a full type neither on alias declaration side nor on using side.
