### PR TITLE
libstdcxx std::declval source

### DIFF
--- a/gcc.symbols.imp
+++ b/gcc.symbols.imp
@@ -259,6 +259,9 @@
   { symbol: [ "NULL", private, "<unistd.h>", public ] },
   { symbol: [ "NULL", private, "<wchar.h>", public ] },
 
+  # GCC defines std::declval in <type_traits>, but the canonical location is <utility>
+  { symbol: [ "std::declval", private, "<utility>", public ] },
+
   # Kludge time: almost all STL types take an allocator, but they
   # almost always use the default value.  Usually we detect that
   # and don't try to do IWYU, but sometimes it passes through.

--- a/iwyu_include_picker.cc
+++ b/iwyu_include_picker.cc
@@ -375,7 +375,10 @@ const IncludeMapEntry stdlib_cxx_symbol_map[] = {
 };
 
 // Symbol -> include mappings for GNU libstdc++
-const IncludeMapEntry libstdcpp_symbol_map[] = {};
+const IncludeMapEntry libstdcpp_symbol_map[] = {
+  // GCC defines std::declval in <type_traits>, but the canonical location is <utility>
+  { "std::declval", kPrivate, "<utility>", kPublic },
+};
 
 const IncludeMapEntry libc_include_map[] = {
   // Private -> public include mappings for GNU libc


### PR DESCRIPTION
`std::declval` is defined in `<utility>`. Currently `libstdcxx` actually defines it in `<type_traits>`, so add a mapping so we suggest the canonical include.

This also fixes a problem with MSVC builds, which don't like empty arrays. Highlighted in #1231.