### PR TITLE
libcxx: map <__tree> to <map> and <set>

### DIFF
--- a/libcxx.imp
+++ b/libcxx.imp
@@ -1,6 +1,8 @@
 # libc++ headers
 [
   { include: ["<__mutex_base>", private, "<mutex>", public ] },
+  { include: ["<__tree>", private, "<set>", public ] },
+  { include: ["<__tree>", private, "<map>", public ] },
 
   # For the following entries:
   # cd llvm-project/libcxx/include ; find -type d -name "__*" | sort | sed -e "s#./__\(.*\)#  { include: [\"@<__\1/.*>\", private, \"<\1>\", public ] },#"


### PR DESCRIPTION
The <__tree> header defines red-black tree class used by both map and set implementations.

When using a const set iterator, IWYU sees this being defined in <__tree>. This doesn't happen for the map iterator (or other map functionality that I could spot).

For consistency, map the header to both <map> and <set> so including either header is accepted by IWYU.