### PR TITLE
Provide default values for class members

### DIFF
--- a/iwyu_output.cc
+++ b/iwyu_output.cc
@@ -492,13 +492,7 @@ string MungedForwardDeclareLine(const NamedDecl* decl) {
 
 OneIncludeOrForwardDeclareLine::OneIncludeOrForwardDeclareLine(
     const NamedDecl* fwd_decl)
-    : line_(internal::MungedForwardDeclareLine(fwd_decl)),
-      start_linenum_(-1),   // set 'for real' below
-      end_linenum_(-1),     // set 'for real' below
-      is_desired_(false),
-      is_present_(false),
-      included_file_(nullptr),
-      fwd_decl_(fwd_decl) {
+    : line_(internal::MungedForwardDeclareLine(fwd_decl)), fwd_decl_(fwd_decl) {
   const SourceRange decl_lines = GetSourceRangeOfClassDecl(fwd_decl);
   // We always want to use the instantiation line numbers: for code like
   //     FORWARD_DECLARE_CLASS(MyClass);
@@ -512,11 +506,8 @@ OneIncludeOrForwardDeclareLine::OneIncludeOrForwardDeclareLine(
     : line_("#include " + quoted_include),
       start_linenum_(linenum),
       end_linenum_(linenum),
-      is_desired_(false),
-      is_present_(false),
       quoted_include_(quoted_include),
-      included_file_(included_file),
-      fwd_decl_(nullptr) {
+      included_file_(included_file) {
 }
 
 bool OneIncludeOrForwardDeclareLine::HasSymbolUse(const string& symbol_name)

--- a/iwyu_output.h
+++ b/iwyu_output.h
@@ -203,17 +203,17 @@ class OneIncludeOrForwardDeclareLine {
   }
 
  private:
-  string line_;                     // '#include XXX' or 'class YYY;'
-  int start_linenum_;
-  int end_linenum_;
-  bool is_desired_;                 // IWYU will recommend this line
-  bool is_present_;                 // line was present before the IWYU run
+  string line_;  // '#include XXX' or 'class YYY;'
+  int start_linenum_ = -1;
+  int end_linenum_ = -1;
+  bool is_desired_ = false;         // IWYU will recommend this line
+  bool is_present_ = false;         // line was present before the IWYU run
   map<string, int> symbol_counts_;  // how many times we referenced each symbol
   // Only either two following members are set for includes
-  string quoted_include_;           // quoted file name we're including
-  const clang::FileEntry* included_file_;  // the file we're including
+  string quoted_include_;  // quoted file name we're including
+  const clang::FileEntry* included_file_ = nullptr;  // the file we're including
   // ...or this member is set for the fwd-decl we're emitting.
-  const clang::NamedDecl* fwd_decl_;
+  const clang::NamedDecl* fwd_decl_ = nullptr;
 };
 
 // This class holds IWYU information about a single file (FileEntry)


### PR DESCRIPTION
Otherwise, one could get an undefined behavior when forgetting to set them in a constructor.

No functional change.