### PR TITLE
Add functions to derive standard libs from compilation

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -4299,8 +4299,7 @@ class IwyuAction : public ASTFrontendAction {
       CompilerInstance& compiler,  // NOLINT
       llvm::StringRef /* dummy */) override {
     // Do this first thing after getting our hands on a CompilerInstance.
-    InitGlobals(&compiler.getSourceManager(),
-                &compiler.getPreprocessor().getHeaderSearchInfo());
+    InitGlobals(compiler);
 
     auto* const preprocessor_consumer = new IwyuPreprocessorInfo();
     compiler.getPreprocessor().addPPCallbacks(

--- a/iwyu_globals.h
+++ b/iwyu_globals.h
@@ -16,6 +16,7 @@
 #include <vector>                       // for vector
 
 namespace clang {
+class CompilerInstance;
 class FileEntry;
 class HeaderSearch;
 class SourceManager;
@@ -56,6 +57,7 @@ class OptionsParser {
 };
 
 void InitGlobals(clang::SourceManager* sm, clang::HeaderSearch* header_search);
+void InitGlobals(clang::CompilerInstance& compiler);
 
 // Can be called by tests -- doesn't need a SourceManager or
 // argc/argv.  Note that GlobalSourceManager() and DefaultDataGetter()


### PR DESCRIPTION
Pass CompilerInstance directly to InitGlobals to give it access to the entire compilation state.

No functional change.