### PR TITLE
Handle alias components separately

### DIFF
--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -590,7 +590,6 @@ class SugaredTypeEnumerator
     // TODO(bolshakov): it doesn't always work properly. For example, both A and
     // TypedefForA would be inserted in seen_types_ for Tpl<A, TypedefForA>,
     // leading to indeterminate resugar_map construction.
-    // TODO(bolshakov): check whether typedef components are "provided".
     return Base::TraverseType(QualType(desugared, 0));
   }
 

--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -523,9 +523,9 @@ static const Type* GetTemplateArgAsType(const TemplateArgument& tpl_arg) {
   return nullptr;
 }
 
-// These utilities figure out the template arguments that are
-// specified in various contexts: TemplateSpecializationType (for
-// template classes) and FunctionDecl (for template functions).
+// These utilities figure out the template arguments and other type components
+// that are specified in various contexts: TemplateSpecializationType (for
+// template classes), FunctionDecl (for template functions), and type aliases.
 //
 // For classes, we care only about explicitly specified template args,
 // not implicit, default args.  For functions, we care about all
@@ -541,10 +541,10 @@ static const Type* GetTemplateArgAsType(const TemplateArgument& tpl_arg) {
 // int(const MyClass&), int, const MyClass&, MyClass).  Note that
 // this function only returns types-as-written, so it does *not* return
 // alloc<int(*)(const MyClass&)>, even though it's part of vector.
-class TypeEnumerator : public RecursiveASTVisitor<TypeEnumerator> {
- public:
-  typedef RecursiveASTVisitor<TypeEnumerator> Base;
 
+class SugaredTypeEnumerator
+    : public RecursiveASTVisitor<SugaredTypeEnumerator> {
+ public:
   // --- Public interface
   // We can add more entry points as needed.
   set<const Type*> Enumerate(const Type* type) {
@@ -575,6 +575,8 @@ class TypeEnumerator : public RecursiveASTVisitor<TypeEnumerator> {
   }
 
  private:
+  typedef RecursiveASTVisitor<SugaredTypeEnumerator> Base;
+
   bool TraverseTypeHelper(QualType qual_type) {
     CHECK_(!qual_type.isNull());
 
@@ -595,11 +597,58 @@ class TypeEnumerator : public RecursiveASTVisitor<TypeEnumerator> {
   set<const Type*> seen_types_;
 };
 
+class TypeEnumeratorWithoutSubstituted
+    : public RecursiveASTVisitor<TypeEnumeratorWithoutSubstituted> {
+ public:
+  // --- Public interface
+  set<const Type*> Enumerate(const Type* type) {
+    seen_types_.clear();
+    if (!type)
+      return seen_types_;
+    TraverseType(QualType(type, 0));
+    return seen_types_;
+  }
+
+  // --- Methods on RecursiveASTVisitor
+  bool TraverseType(QualType type) {
+    if (type.isNull())
+      return Base::TraverseType(type);
+    return TraverseTypeHelper(type);
+  }
+
+  bool TraverseTypeLoc(TypeLoc type_loc) {
+    if (!type_loc)
+      return Base::TraverseTypeLoc(type_loc);
+    return TraverseTypeHelper(type_loc.getType());
+  }
+
+ private:
+  typedef RecursiveASTVisitor<TypeEnumeratorWithoutSubstituted> Base;
+
+  bool TraverseTypeHelper(QualType qual_type) {
+    CHECK_(!qual_type.isNull());
+    const Type* type = qual_type.getTypePtr();
+    if (type->getAs<SubstTemplateTypeParmType>())
+      return true;
+
+    seen_types_.insert(GetCanonicalType(type));
+
+    return Base::TraverseType(qual_type);
+  }
+
+  set<const Type*> seen_types_;
+};
+
 // A 'component' of a type is a type beneath it in the AST tree.
 // So 'Foo*' has component 'Foo', as does 'vector<Foo>', while
 // vector<pair<Foo, Bar>> has components pair<Foo,Bar>, Foo, and Bar.
 set<const Type*> GetComponentsOfType(const Type* type) {
-  TypeEnumerator type_enumerator;
+  SugaredTypeEnumerator type_enumerator;
+  return type_enumerator.Enumerate(type);
+}
+
+set<const Type*> GetComponentsOfTypeWithoutSubstituted(const Type* type) {
+  TypeEnumeratorWithoutSubstituted type_enumerator;
   return type_enumerator.Enumerate(type);
 }
 
@@ -1357,7 +1406,7 @@ GetTplTypeResugarMapForClassNoComponentTypes(const clang::Type* type) {
   // explicitly specified type may fulfill multiple template args:
   //   template <typename R, typename A1> struct Foo<R(A1)> { ... }
   set<unsigned> explicit_args;   // indices into tpl_args we've filled
-  TypeEnumerator type_enumerator;
+  SugaredTypeEnumerator type_enumerator;
   for (unsigned i = 0; i < tpl_spec_type->template_arguments().size(); ++i) {
     set<const Type*> arg_components =
         type_enumerator.Enumerate(tpl_spec_type->template_arguments()[i]);

--- a/iwyu_ast_util.h
+++ b/iwyu_ast_util.h
@@ -702,6 +702,16 @@ const clang::Type* Desugar(const clang::Type* type);
 // 'B' but not 'Tpl1<A, B>'.
 set<const clang::Type*> GetComponentsOfType(const clang::Type* type);
 
+// Returns types for determination of their "provision" status. They are
+// canonicalized because intermediate sugar should be always provided already
+// according to language rules. Substituted template parameter types (and their
+// underlying types) cannot be provided. E. g., given such a template
+// template <class T> struct Tpl1 { typedef Tpl2<T, A> Alias; };
+// the returned set for the type 'Tpl1<B>::Alias' contains 'A' but not 'B'
+// or any sugar for 'B'.
+set<const clang::Type*> GetComponentsOfTypeWithoutSubstituted(
+    const clang::Type*);
+
 // Returns true if the type has any template arguments.
 bool IsTemplatizedType(const clang::Type* type);
 

--- a/tests/cxx/badinc.cc
+++ b/tests/cxx/badinc.cc
@@ -194,8 +194,6 @@ typedef I1_Class Cc_typedef_array[kI1ConstInt];
 // definition even of I2_Class, since we don't know if clients will be
 // using the no-arg Cc_tpl_typedef ctor, which requires the full
 // definition of I2_Class.
-// IWYU: I1_Class needs a declaration
-// IWYU: I2_Class needs a declaration
 // IWYU: I1_TemplateClass is...*badinc-i1.h.*#included\.
 // IWYU: I1_TemplateClass is...*badinc-i1.h.*for autocast
 // IWYU: I1_TemplateClass is...*badinc-i1.h.*for fn return type
@@ -213,7 +211,10 @@ Cc_tpl_typedef cc_tpl_typedef;
 // IWYU: I2_Class::InlFileTemplateFn is...*badinc-i2-inl.h
 // IWYU: I2_Class::InlFileStaticFn is...*badinc-i2-inl.h
 typedef I2_Class Cc_I2_Class_Typedef;
-// IWYU: I1_Struct needs a declaration
+// I1_Struct isn't really used by any possible operation with H_TemplateStruct,
+// but '#include' is required as a common rule, as long as I1_Struct
+// isn't forward-declared.
+// IWYU: I1_Struct is...*badinc-i1.h
 // IWYU: OperateOn is...*badinc-i1.h
 typedef H_TemplateStruct<I1_Struct> Cc_H_TemplateStruct_I1Class_Typedef;
 
@@ -1838,7 +1839,7 @@ The full include-list for tests/cxx/badinc.cc:
 #include <setjmp.h>
 #include <stddef.h>  // for offsetof
 #include <algorithm>  // for find
-#include <fstream>  // for fstream
+#include <fstream>  // for basic_fstream, fstream
 #include <list>  // for list
 #include <string>  // for basic_string, operator+, string
 #include <typeinfo>  // for type_info

--- a/tests/cxx/badinc.h
+++ b/tests/cxx/badinc.h
@@ -287,7 +287,6 @@ typedef std::set<I2_Enum> H_I2Enum_Set;
 // re-exporting the vector<I2_Class> type, so it must be fully defined.
 // TODO(csilvers): IWYU: I2_Class::~I2_Class is...*badinc-i2-inl.h
 // IWYU: std::vector is...*<vector>
-// IWYU: I2_Class needs a declaration
 // IWYU: I2_Class is...*badinc-i2.h
 typedef std::vector<I2_Class> H_I2Class_Vector_Unused;
 // IWYU: I2_TemplateClass is...*badinc-i2.h
@@ -297,10 +296,12 @@ typedef std::vector<I2_Class> H_I2Class_Vector_Unused;
 // IWYU: I2_Enum is...*badinc-i2.h
 typedef I2_TemplateClass<I2_Enum> H_TemplateTypedef;
 
-// IWYU: I2_Struct needs a declaration
+// IWYU: I2_Struct is...*badinc-i2.h
 typedef I2_Struct* H_StructPtr;
 
-// IWYU: I2_Class needs a declaration
+// Forward-declaration suggestion may be better here,
+// but the warning can easily be suppressed by means of fwd-declaring.
+// IWYU: I2_Class is...*badinc-i2.h
 typedef int (*H_FunctionPtr)(int, I2_Class*);
 
 H_Enum H_Function(H_Class* c) {
@@ -394,7 +395,7 @@ The full include-list for tests/cxx/badinc.h:
 #include <stdio.h>  // for NULL, printf
 #include <queue>  // for queue
 #include <set>  // for set
-#include <string>  // for string
+#include <string>  // for basic_string, string
 #include <vector>  // for vector
 #include "tests/cxx/badinc-d3.h"  // for D3_Enum
 #include "tests/cxx/badinc-i2-inl.h"  // for I2_Class::I2_Class, I2_Class::InlFileFn, I2_Class::InlFileStaticFn, I2_Class::InlFileTemplateFn, I2_Class::~I2_Class, I2_TemplateClass::I2_TemplateClass<FOO>, I2_TemplateClass::InlFileTemplateClassFn, I2_TemplateClass::~I2_TemplateClass<FOO>

--- a/tests/cxx/iwyu_stricter_than_cpp-d4.h
+++ b/tests/cxx/iwyu_stricter_than_cpp-d4.h
@@ -1,0 +1,21 @@
+//===--- iwyu_stricter_than_cpp-d4.h - test input file for iwyu -----------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef IWYU_STRICTER_THAN_CPP_D4_H_
+#define IWYU_STRICTER_THAN_CPP_D4_H_
+
+#include "tests/cxx/iwyu_stricter_than_cpp-i5.h"
+
+template <typename T1, typename T2>
+struct TplDirectStruct7 {
+  static constexpr auto s = sizeof(T1);
+  T2* t2;
+};
+
+#endif

--- a/tests/cxx/iwyu_stricter_than_cpp-i5.h
+++ b/tests/cxx/iwyu_stricter_than_cpp-i5.h
@@ -1,0 +1,14 @@
+//===--- iwyu_stricter_than_cpp-i5.h - test input file for iwyu -----------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+template <typename T1, typename T2>
+struct TplIndirectStruct3 {
+  static constexpr auto s = sizeof(T1);
+  T2* t2;
+};

--- a/tests/cxx/iwyu_stricter_than_cpp-type_alias.h
+++ b/tests/cxx/iwyu_stricter_than_cpp-type_alias.h
@@ -14,6 +14,7 @@
 // (2) do not directly #include the definition of the relevant type.
 
 #include "tests/cxx/iwyu_stricter_than_cpp-d1.h"
+#include "tests/cxx/iwyu_stricter_than_cpp-d4.h"
 
 // --- Type aliases.
 
@@ -60,6 +61,26 @@ using TplDoesEverythingRightAl = TplIndirectStruct2<int>;
 template <> struct TplIndirectStruct2<float>;
 using TplDoesEverythingRightAgainAl = TplIndirectStruct2<float>;
 
+// --- With user-defined types as template parameters.
+
+// struct IndirectStruct2; (fwd-declared above)
+template <typename TFullTypeUsed, typename TForwardDeclarable>
+struct TplIndirectStruct3;
+
+using TplOnlyArgumentTypeProvidedAl =
+    // IWYU: IndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h
+    TplIndirectStruct3<IndirectStruct1, IndirectStruct2>;
+
+using TplAllForwardDeclaredAl =
+    TplIndirectStruct3<IndirectStruct2, IndirectStruct2>;
+
+using TplAllNeededTypesProvidedAl =
+    // IWYU: IndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h
+    TplDirectStruct7<IndirectStruct1, IndirectStruct2>;
+
+using TplOnlyTemplateProvidedAl =
+    TplDirectStruct7<IndirectStruct2, IndirectStruct2>;
+
 // --- Special aliases, for nested name testing
 
 struct IndirectStruct3;
@@ -80,10 +101,12 @@ tests/cxx/iwyu_stricter_than_cpp-type_alias.h should remove these lines:
 
 The full include-list for tests/cxx/iwyu_stricter_than_cpp-type_alias.h:
 #include "tests/cxx/iwyu_stricter_than_cpp-d1.h"  // for DirectStruct1, DirectStruct2, DirectStruct3, TplDirectStruct1, TplDirectStruct2
+#include "tests/cxx/iwyu_stricter_than_cpp-d4.h"  // for TplDirectStruct7
 #include "tests/cxx/iwyu_stricter_than_cpp-i1.h"  // for IndirectStruct1, IndirectStructForwardDeclaredInD1, TplIndirectStruct1, TplIndirectStructForwardDeclaredInD1
 struct IndirectStruct2;  // lines XX-XX
 struct IndirectStruct3;  // lines XX-XX
 struct IndirectStruct4;  // lines XX-XX
 template <typename T> struct TplIndirectStruct2;  // lines XX-XX
+template <typename TFullTypeUsed, typename TForwardDeclarable> struct TplIndirectStruct3;  // lines XX-XX+1
 
 ***** IWYU_SUMMARY */

--- a/tests/cxx/iwyu_stricter_than_cpp-typedefs.h
+++ b/tests/cxx/iwyu_stricter_than_cpp-typedefs.h
@@ -14,6 +14,7 @@
 // (2) do not directly #include the definition of the relevant type.
 
 #include "tests/cxx/iwyu_stricter_than_cpp-d1.h"
+#include "tests/cxx/iwyu_stricter_than_cpp-d4.h"
 
 // --- Typedefs.
 
@@ -60,6 +61,26 @@ typedef TplIndirectStruct2<int> TplDoesEverythingRight;
 template <> struct TplIndirectStruct2<float>;
 typedef TplIndirectStruct2<float> TplDoesEverythingRightAgain;
 
+// --- With user-defined types as template parameters.
+
+// struct IndirectStruct2; (fwd-declared above)
+template <typename TFullTypeUsed, typename TForwardDeclarable>
+struct TplIndirectStruct3;
+
+// IWYU: IndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h
+typedef TplIndirectStruct3<IndirectStruct1, IndirectStruct2>
+    TplOnlyArgumentTypeProvided;
+
+typedef TplIndirectStruct3<IndirectStruct2, IndirectStruct2>
+    TplAllForwardDeclared;
+
+// IWYU: IndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h
+typedef TplDirectStruct7<IndirectStruct1, IndirectStruct2>
+    TplAllNeededTypesProvided;
+
+typedef TplDirectStruct7<IndirectStruct2, IndirectStruct2>
+    TplOnlyTemplateProvided;
+
 // --- Special typedefs, for nested name testing
 
 struct IndirectStruct3;
@@ -80,10 +101,12 @@ tests/cxx/iwyu_stricter_than_cpp-typedefs.h should remove these lines:
 
 The full include-list for tests/cxx/iwyu_stricter_than_cpp-typedefs.h:
 #include "tests/cxx/iwyu_stricter_than_cpp-d1.h"  // for DirectStruct1, DirectStruct2, DirectStruct3, TplDirectStruct1, TplDirectStruct2
+#include "tests/cxx/iwyu_stricter_than_cpp-d4.h"  // for TplDirectStruct7
 #include "tests/cxx/iwyu_stricter_than_cpp-i1.h"  // for IndirectStruct1, IndirectStructForwardDeclaredInD1, TplIndirectStruct1, TplIndirectStructForwardDeclaredInD1
 struct IndirectStruct2;  // lines XX-XX
 struct IndirectStruct3;  // lines XX-XX
 struct IndirectStruct4;  // lines XX-XX
 template <typename T> struct TplIndirectStruct2;  // lines XX-XX
+template <typename TFullTypeUsed, typename TForwardDeclarable> struct TplIndirectStruct3;  // lines XX-XX+1
 
 ***** IWYU_SUMMARY */

--- a/tests/cxx/iwyu_stricter_than_cpp.cc
+++ b/tests/cxx/iwyu_stricter_than_cpp.cc
@@ -47,6 +47,27 @@
 #include "tests/cxx/iwyu_stricter_than_cpp-d2.h"
 #include "tests/cxx/iwyu_stricter_than_cpp-d3.h"
 
+template <typename T>
+void UsingFn() {
+  T t;
+}
+
+template <typename T>
+void NonUsingFn() {
+  T* t = nullptr;
+}
+
+template <typename T>
+struct UsingType {
+  T t;
+};
+
+template <typename T>
+struct NonUsingType {
+  T* t = nullptr;
+};
+
+
 typedef DoesEverythingRight DoubleTypedef;
 
 // If the typedef in -typedefs.h requires the full type, then users of
@@ -90,6 +111,37 @@ void TestTypedefs() {
   TplAllNeededTypesProvided tantp;
   // IWYU: IndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
   TplOnlyTemplateProvided totp;
+
+  // IWYU: TplIndirectStruct3 is...*iwyu_stricter_than_cpp-i5.h
+  UsingFn<TplOnlyArgumentTypeProvided>();
+  // IWYU: TplIndirectStruct3 is...*iwyu_stricter_than_cpp-i5.h
+  // IWYU: IndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
+  UsingFn<TplAllForwardDeclared>();
+  UsingFn<TplAllNeededTypesProvided>();
+  // IWYU: IndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
+  UsingFn<TplOnlyTemplateProvided>();
+
+  NonUsingFn<TplAllForwardDeclared>();
+
+  // IWYU: TplIndirectStruct3 is...*iwyu_stricter_than_cpp-i5.h
+  UsingType<TplOnlyArgumentTypeProvided> only_argument_provided;
+  // IWYU: TplIndirectStruct3 is...*iwyu_stricter_than_cpp-i5.h
+  // IWYU: IndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
+  UsingType<TplAllForwardDeclared> all_fwd_declared;
+  UsingType<TplAllNeededTypesProvided> all_provided;
+  // IWYU: IndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
+  UsingType<TplOnlyTemplateProvided> only_template_provided;
+
+  NonUsingType<TplAllForwardDeclared> no_type_needed;
+
+  // IWYU: TplIndirectStruct3 is...*iwyu_stricter_than_cpp-i5.h
+  (void)sizeof(only_argument_provided);
+  // IWYU: TplIndirectStruct3 is...*iwyu_stricter_than_cpp-i5.h
+  // IWYU: IndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
+  (void)sizeof(all_fwd_declared);
+  (void)sizeof(all_provided);
+  // IWYU: IndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
+  (void)sizeof(only_template_provided);
 
   // Nested name testing
   IndirectStruct3ProvidingTypedef::IndirectClassProvidingTypedef pp;
@@ -143,6 +195,37 @@ void TestTypeAliases() {
   TplAllNeededTypesProvidedAl tantp;
   // IWYU: IndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
   TplOnlyTemplateProvidedAl totp;
+
+  // IWYU: TplIndirectStruct3 is...*iwyu_stricter_than_cpp-i5.h
+  UsingFn<TplOnlyArgumentTypeProvidedAl>();
+  // IWYU: TplIndirectStruct3 is...*iwyu_stricter_than_cpp-i5.h
+  // IWYU: IndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
+  UsingFn<TplAllForwardDeclaredAl>();
+  UsingFn<TplAllNeededTypesProvidedAl>();
+  // IWYU: IndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
+  UsingFn<TplOnlyTemplateProvidedAl>();
+
+  NonUsingFn<TplAllForwardDeclaredAl>();
+
+  // IWYU: TplIndirectStruct3 is...*iwyu_stricter_than_cpp-i5.h
+  UsingType<TplOnlyArgumentTypeProvidedAl> only_argument_provided;
+  // IWYU: TplIndirectStruct3 is...*iwyu_stricter_than_cpp-i5.h
+  // IWYU: IndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
+  UsingType<TplAllForwardDeclaredAl> all_fwd_declared;
+  UsingType<TplAllNeededTypesProvidedAl> all_provided;
+  // IWYU: IndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
+  UsingType<TplOnlyTemplateProvidedAl> only_template_provided;
+
+  NonUsingType<TplAllForwardDeclaredAl> no_type_needed;
+
+  // IWYU: TplIndirectStruct3 is...*iwyu_stricter_than_cpp-i5.h
+  (void)sizeof(only_argument_provided);
+  // IWYU: TplIndirectStruct3 is...*iwyu_stricter_than_cpp-i5.h
+  // IWYU: IndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
+  (void)sizeof(all_fwd_declared);
+  (void)sizeof(all_provided);
+  // IWYU: IndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
+  (void)sizeof(only_template_provided);
 
   // Nested name testing
   IndirectStruct3ProvidingAl::IndirectClassProvidingAl pp;

--- a/tests/cxx/iwyu_stricter_than_cpp.cc
+++ b/tests/cxx/iwyu_stricter_than_cpp.cc
@@ -82,6 +82,15 @@ void TestTypedefs() {
   // IWYU: IndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
   (void)dor_ptr->a;
 
+  // IWYU: TplIndirectStruct3 is...*iwyu_stricter_than_cpp-i5.h
+  TplOnlyArgumentTypeProvided toatp;
+  // IWYU: TplIndirectStruct3 is...*iwyu_stricter_than_cpp-i5.h
+  // IWYU: IndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
+  TplAllForwardDeclared tafd;
+  TplAllNeededTypesProvided tantp;
+  // IWYU: IndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
+  TplOnlyTemplateProvided totp;
+
   // Nested name testing
   IndirectStruct3ProvidingTypedef::IndirectClassProvidingTypedef pp;
   // IWYU: IndirectClass is...*indirect.h
@@ -91,9 +100,6 @@ void TestTypedefs() {
   // IWYU: IndirectStruct4 is...*iwyu_stricter_than_cpp-i4.h
   // IWYU: IndirectClass is...*indirect.h
   IndirectStruct4NonProvidingTypedef::IndirectClassNonProvidingTypedef nn;
-
-  // TODO(csilvers): test template types where we need some (but not
-  // all) of the template args as well.
 }
 
 using DoubleTypedefAl = DoesEverythingRightAl;
@@ -128,6 +134,15 @@ void TestTypeAliases() {
   // ...at least until we dereference the pointer
   // IWYU: IndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
   (void)dor_ptr->a;
+
+  // IWYU: TplIndirectStruct3 is...*iwyu_stricter_than_cpp-i5.h
+  TplOnlyArgumentTypeProvidedAl toatp;
+  // IWYU: TplIndirectStruct3 is...*iwyu_stricter_than_cpp-i5.h
+  // IWYU: IndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
+  TplAllForwardDeclaredAl tafd;
+  TplAllNeededTypesProvidedAl tantp;
+  // IWYU: IndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
+  TplOnlyTemplateProvidedAl totp;
 
   // Nested name testing
   IndirectStruct3ProvidingAl::IndirectClassProvidingAl pp;
@@ -220,6 +235,7 @@ tests/cxx/iwyu_stricter_than_cpp.cc should add these lines:
 #include "tests/cxx/iwyu_stricter_than_cpp-i2.h"
 #include "tests/cxx/iwyu_stricter_than_cpp-i3.h"
 #include "tests/cxx/iwyu_stricter_than_cpp-i4.h"
+#include "tests/cxx/iwyu_stricter_than_cpp-i5.h"
 struct DirectStruct1;
 struct DirectStruct2;
 struct IndirectStruct1;
@@ -242,8 +258,9 @@ The full include-list for tests/cxx/iwyu_stricter_than_cpp.cc:
 #include "tests/cxx/iwyu_stricter_than_cpp-i2.h"  // for IndirectStruct2, TplIndirectStruct2
 #include "tests/cxx/iwyu_stricter_than_cpp-i3.h"  // for IndirectStruct3
 #include "tests/cxx/iwyu_stricter_than_cpp-i4.h"  // for IndirectStruct4
-#include "tests/cxx/iwyu_stricter_than_cpp-type_alias.h"  // for DoesEverythingRightAl, DoesNotForwardDeclareAl, DoesNotForwardDeclareAndIncludesAl, DoesNotForwardDeclareProperlyAl, IncludesAl, IncludesElaboratedAl, IndirectStruct3NonProvidingAl, IndirectStruct4NonProvidingAl, TplDoesEverythingRightAgainAl, TplDoesEverythingRightAl, TplDoesNotForwardDeclareAl, TplDoesNotForwardDeclareAndIncludesAl, TplDoesNotForwardDeclareProperlyAl, TplIncludesAl
-#include "tests/cxx/iwyu_stricter_than_cpp-typedefs.h"  // for DoesEverythingRight, DoesNotForwardDeclare, DoesNotForwardDeclareAndIncludes, DoesNotForwardDeclareProperly, Includes, IncludesElaborated, IndirectStruct3NonProvidingTypedef, IndirectStruct4NonProvidingTypedef, TplDoesEverythingRight, TplDoesEverythingRightAgain, TplDoesNotForwardDeclare, TplDoesNotForwardDeclareAndIncludes, TplDoesNotForwardDeclareProperly, TplIncludes
+#include "tests/cxx/iwyu_stricter_than_cpp-i5.h"  // for TplIndirectStruct3
+#include "tests/cxx/iwyu_stricter_than_cpp-type_alias.h"  // for DoesEverythingRightAl, DoesNotForwardDeclareAl, DoesNotForwardDeclareAndIncludesAl, DoesNotForwardDeclareProperlyAl, IncludesAl, IncludesElaboratedAl, IndirectStruct3NonProvidingAl, IndirectStruct4NonProvidingAl, TplAllForwardDeclaredAl, TplAllNeededTypesProvidedAl, TplDoesEverythingRightAgainAl, TplDoesEverythingRightAl, TplDoesNotForwardDeclareAl, TplDoesNotForwardDeclareAndIncludesAl, TplDoesNotForwardDeclareProperlyAl, TplIncludesAl, TplOnlyArgumentTypeProvidedAl, TplOnlyTemplateProvidedAl
+#include "tests/cxx/iwyu_stricter_than_cpp-typedefs.h"  // for DoesEverythingRight, DoesNotForwardDeclare, DoesNotForwardDeclareAndIncludes, DoesNotForwardDeclareProperly, Includes, IncludesElaborated, IndirectStruct3NonProvidingTypedef, IndirectStruct4NonProvidingTypedef, TplAllForwardDeclared, TplAllNeededTypesProvided, TplDoesEverythingRight, TplDoesEverythingRightAgain, TplDoesNotForwardDeclare, TplDoesNotForwardDeclareAndIncludes, TplDoesNotForwardDeclareProperly, TplIncludes, TplOnlyArgumentTypeProvided, TplOnlyTemplateProvided
 struct DirectStruct1;
 struct DirectStruct2;
 struct IndirectStruct1;

--- a/tests/cxx/template_args.cc
+++ b/tests/cxx/template_args.cc
@@ -127,14 +127,14 @@ void NestedTemplateArguments() {
   // ProvidingAlias provides TplInI1 but doesn't provide IndirectClass.
   // IWYU: IndirectClass is...*indirect.h
   Outer<decltype(StaticTemplateFieldStruct::aliasedProviding)> oapi;
-  // TODO(bolshakov): IWYU: IndirectClass is...*indirect.h
+  // IWYU: IndirectClass is...*indirect.h
   (void)oapi.t;
 
   Outer<decltype(StaticTemplateFieldStruct::aliasedProviding)*> oapip;
   (void)oapip.t;
 
   Outer<decltype(StaticTemplateFieldStruct::aliasedProviding)>* opapi;
-  // TODO(bolshakov): IWYU: IndirectClass is...*indirect.h
+  // IWYU: IndirectClass is...*indirect.h
   (void)opapi->t;
 
   // IWYU: TplInI1 is...*-i1.h

--- a/tests/cxx/typedef_in_template.cc
+++ b/tests/cxx/typedef_in_template.cc
@@ -31,21 +31,15 @@ void Declarations() {
   // Just using Container does not need the full types because there are only
   // aliases made, which do not require full-uses.
 
-  // TODO: But currently this is counted as a full-use because Class2 is used
-  // inside a template specialization (of Pair) within the definition of
-  // Container.
   // IWYU: Class1 needs a declaration
-  // IWYU: Class2 is...*typedef_in_template-i2.h
   // IWYU: Class2 needs a declaration
   Container<Class1, Class2> c;
 
   // Full-using any of those aliases *should* require a full use
   // of corresponding template argument type.
 
-  // TODO: full Class2 type info isn't needed here
   // IWYU: Class1 is...*typedef_in_template-i1.h
   // IWYU: Class1 needs a declaration
-  // IWYU: Class2 is...*typedef_in_template-i2.h
   // IWYU: Class2 needs a declaration
   Container<Class1, Class2>::value_type vt;
 
@@ -54,10 +48,8 @@ void Declarations() {
   // IWYU: Class2 needs a declaration
   Container<Class1, Class2>::pair_type pt;
 
-  // TODO: full Class2 type info isn't needed here
   // IWYU: Class1 is...*typedef_in_template-i1.h
   // IWYU: Class1 needs a declaration
-  // IWYU: Class2 is...*typedef_in_template-i2.h
   // IWYU: Class2 needs a declaration
   Container<Class1, Class2>::alias_type at;
 }


### PR DESCRIPTION
Separate determination of "provision" status for typedef or type alias underlying type components. It allows for e. g. some template arguments being provided and some not (alias user is responsible to `#include` them if they are required).

On alias declaration site, it is achieved with setting defaulted fwd-decl context flag and with reporting types if they are descendants of `TypedefNameDecl` and are "provided". On alias use site, underlying type components are enumerated and provided ones are blocked for report.

New test cases added, existing tests fixed (`basic_fstream` and `basic_string` in `badinc` test are reported due to their explicit instantiations).

I intend to make similar PRs for "autocast" and function return type handling later. (Or it should be incorporated into this one?)

Btw, it is the same PR which I mentioned in #1057, if I remember correctly...