### PR TITLE
iwyu_test_util: add support for EXTRA_IWYU_ARGS env variable

### DIFF
--- a/iwyu_test_util.py
+++ b/iwyu_test_util.py
@@ -438,6 +438,9 @@ def TestIwyuOnRelativeFile(cc_file, cpp_files_to_check, verbose=False):
   env_verbose_level = os.getenv('IWYU_VERBOSE')
   if env_verbose_level:
     cmd += ['-Xiwyu', '--verbose=' + env_verbose_level]
+  env_iwyu_extra_args = os.getenv('IWYU_EXTRA_ARGS')
+  if env_iwyu_extra_args:
+      cmd += shlex.split(env_iwyu_extra_args)
   cmd += [cc_file]
 
   if verbose:


### PR DESCRIPTION
When running the tests as part of Gentoo's emerge process (in src_test()) the tests fail due clang's include directory missing.

The emerge phase that runs the tests is performed with the application under test still in the build directory. And this is what breaks the IWYU tests there.

The include-what-you-use binary seems to have, amongst other, the following default include path (as per
`include-what-you-use-0.19_build/bin/include-what-you-use -E -x c++ - -v < /dev/null`):

```
ignoring nonexistent directory
"/var/tmp/portage/dev-util/include-what-you-use-0.19/work/include-what-you-use-0.19_build/bin/../../../../lib/clang/15.0.7/include"
```

Here,
/var/tmp/portage/dev-util/include-what-you-use-0.19/work/include-what-you-use-0.19_build/ is the build directory. Unfortunately, the whole path to the clang include is invalid (non-existent). It will become correct once IWYU is merged into the live filesystem.

As workaround I added `EXTRA_IWYU_ARGS` to the run_`iwyu_tests.py` script, to be able to provide the correct include path by invoking run_`iwyu_test.py` basically like:

```
EXTRA_IWYU_ARGS="-I /usr/lib/clang/15.0.7/include" \
    run_iwyu_tests.py \
	-- ${BUILD_DIR}/bin/include-what-you-use
```

Related Gentoo bug: https://bugs.gentoo.org/905214