### PR TITLE
Improve placement-new detection in templates

### DIFF
--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -115,6 +115,7 @@ using clang::TypeLoc;
 using clang::TypedefNameDecl;
 using clang::TypedefType;
 using clang::UnaryOperator;
+using clang::UnresolvedLookupExpr;
 using clang::UsingDirectiveDecl;
 using clang::ValueDecl;
 using clang::VarDecl;
@@ -1409,6 +1410,13 @@ bool IsAddressOf(const Expr* expr) {
   if (const UnaryOperator* unary = DynCastFrom(expr->IgnoreParens()))
     return unary->getOpcode() == clang::UO_AddrOf;
   return false;
+}
+
+bool IsDependentNameCall(const Expr* expr) {
+  const CallExpr* call_expr = dyn_cast<CallExpr>(expr);
+  if (!call_expr)
+    return false;
+  return isa<UnresolvedLookupExpr>(call_expr->getCallee());
 }
 
 const Type* TypeOfParentIfMethod(const CallExpr* expr) {

--- a/iwyu_ast_util.h
+++ b/iwyu_ast_util.h
@@ -798,6 +798,10 @@ bool CanBeOpaqueDeclared(const clang::EnumType* type);
 // Returns true if the given expr is '&<something>'.
 bool IsAddressOf(const clang::Expr* expr);
 
+// Returns true if the given expr is a call-expression targeting an
+// unresolved/dependent name.
+bool IsDependentNameCall(const clang::Expr* expr);
+
 // If this function call comes from a class method -- either a normal
 // one or a static one -- returns the type of the class.  Otherwise,
 // returns nullptr.  Note that static class methods do *not* have a

--- a/tests/cxx/placement_new-d1.h
+++ b/tests/cxx/placement_new-d1.h
@@ -11,5 +11,6 @@
 #define INCLUDE_WHAT_YOU_USE_TESTS_CXX_PLACEMENT_NEW_D1_H_
 
 #include "tests/cxx/placement_new-i1.h"
+#include "tests/cxx/placement_new-i2.h"
 
 #endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_PLACEMENT_NEW_D1_H_

--- a/tests/cxx/placement_new-i2.h
+++ b/tests/cxx/placement_new-i2.h
@@ -1,0 +1,19 @@
+//===--- placement_new-i2.h - test input file for iwyu ----*- C++ -*-------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_PLACEMENT_NEW_I2_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_PLACEMENT_NEW_I2_H_
+
+// Naive implementation of std::addressof for test.
+template<class T>
+T* AddressOf(T& t) {
+  return &t;
+}
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_PLACEMENT_NEW_I2_H_


### PR DESCRIPTION
When placement-new is used in a template, and the buffer/target argument is provided by a call to a dependent name, the placement-new expression would not be recognized as such. This is commonplace now that std::addressof exists:

    template<class T, typename...Args>
    void construct(T& buf, Args&&... args) {
      // definitive placement-new below
      new(std::addressof(buf)) T(args)
    }

Prior to this fix, `<new>` would be suggested at the instantiation location rather than the definition location. If the template was defined in a file covered by IWYU analysis, IWYU would suggest to remove `<new>` there, breaking the template.

Add a few more testcases for placement syntax in templates.

Fixes #1229.