### PR TITLE
Add new IWYU pragma: always_keep

### DIFF
--- a/docs/IWYUPragmas.md
+++ b/docs/IWYUPragmas.md
@@ -181,6 +181,21 @@ You can explicitly mark an arbitrary `#include` directive as denoting the associ
 
 You can mark multiple `#include` directives as associated and they will all be considered as such.
 
+## IWYU pragma: always_keep ##
+
+This pragma applies to the current header file. It says that any include of this file will be preserved by all includers.
+
+    header.h:
+      // IWYU pragma: always_keep
+      struct Unused {};
+
+    main.cc:
+      #include "header.h"
+
+Even if no symbols from `header.h` are used in `main.cc`, it will not be suggested for removal.
+
+This is useful for headers that provide additional type traits that aren't possible for IWYU to track (e.g. hash functions for a type, to be used by STL containers).
+
 ## Which pragma should I use? ##
 
 Ideally, IWYU should be smart enough to understand your intentions (and intentions of the authors of libraries you use), so the first answer should always be: none.
@@ -190,6 +205,7 @@ In practice, intentions are not so clear -- it might be ambiguous whether an `#i
 IWYU pragmas have some overlap, so it can sometimes be hard to choose one over the other. Here's a guide based on how I understand them at the moment:
 
 * Use `IWYU pragma: keep` to force IWYU to keep any `#include` directive that would be discarded under its normal policies.
+* Use `IWYU pragma: always_keep` to force IWYU to keep a header in all includers, whether they contribute any used symbols or not.
 * Use `IWYU pragma: export` to tell IWYU that one header serves as the provider for all symbols in another, included header (e.g. facade headers). Use `IWYU pragma: begin_exports/end_exports` for a whole group of included headers.
 * Use `IWYU pragma: no_include` to tell IWYU that the file in which the pragma is defined should never `#include` a specific header (the header may already be included via some other `#include`.)
 * Use `IWYU pragma: no_forward_declare` to tell IWYU that the file in which the pragma is defined should never forward-declare a specific symbol (a forward declaration may already be available via some other `#include`.)
@@ -200,7 +216,7 @@ IWYU pragmas have some overlap, so it can sometimes be hard to choose one over t
 The pragmas come in three different classes;
 
   1. Ones that apply to a single `#include` directive (`keep`, `export`)
-  2. Ones that apply to a file being included (`private`, `friend`)
+  2. Ones that apply to a file being included (`private`, `friend`, `always_keep`)
   3. Ones that apply to a file including other headers (`no_include`, `no_forward_declare`)
 
 Some files are both included and include others, so it can make sense to mix and match.

--- a/include-what-you-use.1
+++ b/include-what-you-use.1
@@ -287,6 +287,10 @@ Used in a source file after an
 directive, this marks the header as associated to the source file.
 This is required if source and header filename differ in more than their ending.
 Includes from an associated header are assumed in the source file.
+.TP
+.B // IWYU pragma: always_keep
+Indicates that includes of the current file should never be removed from
+includers.
 .SH FILES
 .I /usr/share/include-what-you-use
 .RS

--- a/iwyu_preprocessor.cc
+++ b/iwyu_preprocessor.cc
@@ -473,11 +473,9 @@ void IwyuPreprocessorInfo::MaybeProtectInclude(
   } else if (FileInfoFor(includee)->is_pch_in_code()) {
     protect_reason = "pch in code";
 
-  // There's one more place we keep the #include: if our file re-exports it.
-  // (A decision to re-export an #include counts as a "use" of it.)
-  // But we need to finalize all #includes before we can test that,
-  // so we do it in a separate function, ProtectReexportIncludes, below.
-
+    // There's a few more places where we want to keep the #include, but we need
+    // to finalize all #includes before we can test them, so we do it in a
+    // separate function, FinalizeProtectedIncludes, below.
   }
 
   if (!protect_reason.empty()) {
@@ -490,20 +488,22 @@ void IwyuPreprocessorInfo::MaybeProtectInclude(
   }
 }
 
-static void ProtectReexportIncludes(
-    map<const FileEntry*, IwyuFileInfo>* file_info_map) {
-  for (map<const FileEntry*, IwyuFileInfo>::iterator
-           it = file_info_map->begin(); it != file_info_map->end(); ++it) {
-    IwyuFileInfo& includer = it->second;
-    set<const FileEntry*> incs = includer.direct_includes_as_fileentries();
-    const string includer_path = GetFilePath(it->first);
-    for (const FileEntry* include : incs) {
+void IwyuPreprocessorInfo::FinalizeProtectedIncludes() {
+  for (auto& entry : iwyu_file_info_map_) {
+    const FileEntry* includer_file = entry.first;
+    IwyuFileInfo& includer = entry.second;
+    const string includer_path = GetFilePath(includer_file);
+
+    for (const FileEntry* include : includer.direct_includes_as_fileentries()) {
       const string includee_path = GetFilePath(include);
       if (GlobalIncludePicker().HasMapping(includee_path, includer_path)) {
+        // If includer re-exports includee, that counts as a "use" of it, so
+        // protect the include.
         includer.ReportIncludeFileUse(include,
                                       ConvertToQuotedInclude(includee_path));
-        ERRSYM(it->first) << "Marked dep: " << includer_path << " needs to keep"
-                          << " " << includee_path << " (reason: re-exports)\n";
+        ERRSYM(includer_file)
+            << "Marked dep: " << includer_path << " needs to keep "
+            << includee_path << " (reason: re-exports)\n";
       }
     }
   }
@@ -1023,7 +1023,7 @@ void IwyuPreprocessorInfo::HandlePreprocessingDone() {
     file_info_map_entry.second.HandlePreprocessingDone();
   }
   MutableGlobalIncludePicker()->FinalizeAddedIncludes();
-  ProtectReexportIncludes(&iwyu_file_info_map_);
+  FinalizeProtectedIncludes();
   PopulateIntendsToProvideMap();
   PopulateTransitiveIncludeMap();
 }

--- a/iwyu_preprocessor.h
+++ b/iwyu_preprocessor.h
@@ -286,6 +286,7 @@ class IwyuPreprocessorInfo : public clang::PPCallbacks,
                                    set<const clang::FileEntry*>* retval) const;
   void PopulateIntendsToProvideMap();
   void PopulateTransitiveIncludeMap();
+  void FinalizeProtectedIncludes();
 
   // Return true if at the current point in the parse of the given file,
   // there is a pending "begin_exports" pragma.

--- a/iwyu_preprocessor.h
+++ b/iwyu_preprocessor.h
@@ -383,6 +383,10 @@ class IwyuPreprocessorInfo : public clang::PPCallbacks,
   // other places because it is unclear which inclusion directive filename
   // location corresponds to.
   clang::SourceLocation include_filename_loc_;
+
+  // Keeps track of which files have the "always_keep" pragma, so they can be
+  // marked as such for all includers.
+  std::set<const clang::FileEntry*> always_keep_files_;
 };
 
 }  // namespace include_what_you_use

--- a/tests/cxx/pragma_always_keep-d1.h
+++ b/tests/cxx/pragma_always_keep-d1.h
@@ -1,0 +1,12 @@
+//===--- pragma_always_keep-d1.h - test input file for iwyu ---------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU pragma: always_keep
+
+struct Unused {};

--- a/tests/cxx/pragma_always_keep.cc
+++ b/tests/cxx/pragma_always_keep.cc
@@ -1,0 +1,29 @@
+//===--- pragma_always_keep.cc - test input file for iwyu -----------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// This test demonstrates that the "always_keep" pragma forces an includer to
+// use a nominally unused file.
+
+// IWYU_ARGS: -I .
+
+#include "tests/cxx/pragma_always_keep-d1.h"
+
+// direct.h does not have an "always_keep" pragma, and should be removed.
+#include "tests/cxx/direct.h"
+
+/**** IWYU_SUMMARY
+tests/cxx/pragma_always_keep.cc should add these lines:
+
+tests/cxx/pragma_always_keep.cc should remove these lines:
+- #include "tests/cxx/direct.h"  // lines XX-XX
+
+The full include-list for tests/cxx/pragma_always_keep.cc:
+#include "tests/cxx/pragma_always_keep-d1.h"
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
This was proposed by the clangd/clang-include-fixer developers, who
already implement many of IWYU's pragma comments.

The pragma makes sense for us too, so implement it and add documentation
to describe the semantics.

Semantics and rationale suggested by @kadircet, as well as a
documentation draft from which I've borrowed some words.

Fixes issue #1235.
