### PR TITLE
Ignore redecls without location for explicit instantiation

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -3268,8 +3268,7 @@ class InstantiatedTemplateVisitor
     std::vector<const CXXRecordDecl*> explicit_inst_decls;
     for (const NamedDecl* redecl : decl->redecls()) {
       if (IsExplicitInstantiation(redecl) &&
-          GlobalSourceManager()->isBeforeInTranslationUnit(
-            redecl->getLocation(), caller_loc())) {
+          IsBeforeInTranslationUnit(redecl->getLocation(), caller_loc())) {
         // Earlier checks imply that this is a CXXRecordDecl.
         explicit_inst_decls.push_back(cast<CXXRecordDecl>(redecl));
       }

--- a/tests/cxx/expl_inst_macro.cc
+++ b/tests/cxx/expl_inst_macro.cc
@@ -1,0 +1,30 @@
+//===--- expl_inst_macro.cc - test input file for iwyu --------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/expl_inst_macro.h"
+
+// 'macro' expands to a use of 'std::cout'. Under gcc/libstd++ this triggers use
+// of the explicit instantiation basic_ostream<char>.
+// IWYU's explicit instantiation processing attempts to use source locations to
+// find all redecls before in the translation unit. The fact that we're in a
+// macro sometimes causes IWYU to fail to compute valid source locations, so the
+// location arithmetic would cause an assertion failure.
+// This opaque test case checks that we no longer do, in this specific case.
+
+// IWYU_ARGS: -I .
+
+void test() {
+  macro;
+}
+
+/**** IWYU_SUMMARY
+
+(tests/cxx/expl_inst_macro.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/expl_inst_macro.h
+++ b/tests/cxx/expl_inst_macro.h
@@ -1,0 +1,20 @@
+//===--- expl_inst_macro.h - test input file for iwyu ---*- C++ -*---------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include <iostream>
+
+// This triggers use of an explicit instantiation basic_ostream<char> from
+// <iostream> (with gcc/libstdc++), which in turn is processed by IWYU.
+#define macro std::cout << " "
+
+/**** IWYU_SUMMARY
+
+(tests/cxx/expl_inst_macro.h has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
Issue #1275 describes how an IWYU covering libstdc++ v9 basic_ostream crashes with an LLVM_ENABLE_ASSERTIONS build.

The reason appears to be that Clang does not maintain a valid location for all redeclarations of a template. The reporter does not use precompiled headers, so this could be a Clang bug.

Detect the problem and skip over any redecls without location with a warning at log level 6.