### PR TITLE
Avoid redundant namespace reporting

### DIFF
--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -1034,6 +1034,18 @@ bool IsInInlineNamespace(const Decl* decl) {
   return false;
 }
 
+bool IsInNamespace(const clang::NamedDecl* decl,
+                   const clang::NamespaceDecl* ns_decl) {
+  const DeclContext* primary_ns_context = ns_decl->getPrimaryContext();
+  for (const DeclContext* dc = decl->getDeclContext(); dc;
+       dc = dc->getParent()) {
+    if (dc->getPrimaryContext() == primary_ns_context)
+      return true;
+  }
+
+  return false;
+}
+
 bool IsForwardDecl(const NamedDecl* decl) {
   if (const auto* tag_decl = dyn_cast<TagDecl>(decl)) {
     // clang-format off

--- a/iwyu_ast_util.h
+++ b/iwyu_ast_util.h
@@ -40,6 +40,7 @@ class ClassTemplateDecl;
 class Expr;
 class FunctionDecl;
 class NamedDecl;
+class NamespaceDecl;
 class TagDecl;
 class TemplateDecl;
 class TemplateName;
@@ -610,6 +611,8 @@ bool IsExplicitInstantiation(const clang::Decl* decl);
 
 // Returns true if this decl is nested inside an inline namespace.
 bool IsInInlineNamespace(const clang::Decl* decl);
+
+bool IsInNamespace(const clang::NamedDecl*, const clang::NamespaceDecl*);
 
 // Returns true if a named decl looks like a forward-declaration of a
 // class (rather than a definition, a friend declaration, or an 'in

--- a/tests/cxx/badinc.cc
+++ b/tests/cxx/badinc.cc
@@ -133,15 +133,8 @@ int i1_macro_symbol_with_value_and_value2_var2;
 #endif
 
 // Using declarations and statements.
-// TODO(csilvers): I don't see a consistent way to say whether
-// "i1_ns2" is an iwyu violation or not, since namespaces can be
-// re-opened in many different files.  So let this go, even though all
-// uses of this namespace are in badinc-i1.h; we'll get the iwyu
-// violation later when we try to use symbols from i1_ns2.
-// IWYU: i1_ns2 is defined in...*which isn't directly #included.
 using namespace i1_ns2;
 using i1_ns3::i1_int_global3;
-// IWYU: i1_ns4 is...*badinc-i1.h
 namespace cc_ns_alias = i1_ns4;
 using i1_ns::I1_NamespaceStruct;
 // IWYU: i1_ns::I1_NamespaceTemplateFn is...*badinc-i1.h
@@ -1845,7 +1838,7 @@ The full include-list for tests/cxx/badinc.cc:
 #include <typeinfo>  // for type_info
 #include "tests/cxx/badinc-d1.h"  // for D1CopyClassFn, D1Function, D1_Class, D1_CopyClass, D1_Enum, D1_I1_Typedef, D1_StructPtr, D1_Subclass, D1_TemplateClass, D1_TemplateStructWithDefaultParam, MACRO_CALLING_I4_FUNCTION
 #include "tests/cxx/badinc-d4.h"  // for D4_ClassForOperator, operator<<
-#include "tests/cxx/badinc-i1.h"  // for EmptyDestructorClass, H_Class::H_Class_DefinedInI1, I1_And_I2_OverloadedFunction, I1_Base, I1_Class, I1_ClassPtr, I1_Enum, I1_Function, I1_FunctionPtr, I1_I2_Class_Typedef, I1_MACRO_LOGGING_CLASS, I1_MACRO_SYMBOL_WITHOUT_VALUE, I1_MACRO_SYMBOL_WITH_VALUE, I1_MACRO_SYMBOL_WITH_VALUE0, I1_MACRO_SYMBOL_WITH_VALUE2, I1_ManyPtrStruct (ptr only), I1_MemberPtr, I1_NamespaceClass, I1_NamespaceStruct, I1_NamespaceTemplateFn, I1_OverloadedFunction, I1_PtrAndUseOnSameLine, I1_PtrDereferenceClass, I1_PtrDereferenceStatic, I1_PtrDereferenceStruct, I1_SiblingClass, I1_StaticMethod, I1_Struct, I1_Subclass, I1_SubclassesI2Class, I1_TemplateClass, I1_TemplateClassFwdDeclaredInD2 (ptr only), I1_TemplateFunction, I1_TemplateMethodOnlyClass, I1_TemplateSubclass, I1_Typedef, I1_TypedefOnly_Class, I1_Union, I1_UnnamedStruct, I1_UnusedNamespaceStruct (ptr only), I1_const_ptr, I2_OperatorDefinedInI1Class::operator<<, MACRO_CALLING_I6_FUNCTION, OperateOn, i1_GlobalFunction, i1_int, i1_int_global, i1_int_global2, i1_int_global2sub, i1_int_global3, i1_int_global3sub, i1_int_global4, i1_int_global4sub, i1_int_globalsub, i1_ns2, i1_ns4, i1_ns5, kI1ConstInt, operator==
+#include "tests/cxx/badinc-i1.h"  // for EmptyDestructorClass, H_Class::H_Class_DefinedInI1, I1_And_I2_OverloadedFunction, I1_Base, I1_Class, I1_ClassPtr, I1_Enum, I1_Function, I1_FunctionPtr, I1_I2_Class_Typedef, I1_MACRO_LOGGING_CLASS, I1_MACRO_SYMBOL_WITHOUT_VALUE, I1_MACRO_SYMBOL_WITH_VALUE, I1_MACRO_SYMBOL_WITH_VALUE0, I1_MACRO_SYMBOL_WITH_VALUE2, I1_ManyPtrStruct (ptr only), I1_MemberPtr, I1_NamespaceClass, I1_NamespaceStruct, I1_NamespaceTemplateFn, I1_OverloadedFunction, I1_PtrAndUseOnSameLine, I1_PtrDereferenceClass, I1_PtrDereferenceStatic, I1_PtrDereferenceStruct, I1_SiblingClass, I1_StaticMethod, I1_Struct, I1_Subclass, I1_SubclassesI2Class, I1_TemplateClass, I1_TemplateClassFwdDeclaredInD2 (ptr only), I1_TemplateFunction, I1_TemplateMethodOnlyClass, I1_TemplateSubclass, I1_Typedef, I1_TypedefOnly_Class, I1_Union, I1_UnnamedStruct, I1_UnusedNamespaceStruct (ptr only), I1_const_ptr, I2_OperatorDefinedInI1Class::operator<<, MACRO_CALLING_I6_FUNCTION, OperateOn, i1_GlobalFunction, i1_int, i1_int_global, i1_int_global2, i1_int_global2sub, i1_int_global3, i1_int_global3sub, i1_int_global4, i1_int_global4sub, i1_int_globalsub, i1_ns5, kI1ConstInt, operator==
 #include "tests/cxx/badinc2.c"
 class D2_Class;
 class D2_ForwardDeclareClass;

--- a/tests/cxx/namespace_use-d1.h
+++ b/tests/cxx/namespace_use-d1.h
@@ -1,0 +1,21 @@
+//===--- namespace_use-d1.h - test input file for iwyu --------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "namespace_use-i1.h"
+#include "namespace_use-i2.h"
+
+namespace i1_ns {
+
+// Declare something extra in i1_ns to see if d1 or i1 is suggested
+enum X {
+  X1,
+  X2,
+};
+
+}  // namespace i1_ns

--- a/tests/cxx/namespace_use-i1.h
+++ b/tests/cxx/namespace_use-i1.h
@@ -1,0 +1,12 @@
+//===--- namespace_use-i1.h - test input file for iwyu --------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+namespace i1_ns {
+void Action();
+}

--- a/tests/cxx/namespace_use-i2.h
+++ b/tests/cxx/namespace_use-i2.h
@@ -1,0 +1,12 @@
+//===--- namespace_use-i2.h - test input file for iwyu --------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+namespace i2_ns {
+int GetValue();
+}

--- a/tests/cxx/namespace_use.cc
+++ b/tests/cxx/namespace_use.cc
@@ -1,0 +1,45 @@
+//===--- namespace_use.cc - test input file for iwyu ----------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_ARGS: -I .
+
+// Tests that using-directives i.e. using namespace, get appropriate include
+// suggestions.
+
+#include "tests/cxx/namespace_use-d1.h"
+
+// Purely using the namespace, not any symbols.
+// This could be unused, or being used transitively in namespace lookup.
+// The include suggestion will be the first header that declares the namespace.
+// IWYU: i1_ns is defined in ...*
+using namespace i1_ns;
+
+// This namespace gets used for symbols within it.
+// Suggestions for includes will come via the symbol usage rather than here.
+using namespace i2_ns;
+
+int main(int, const char**) {
+  // IWYU: i2_ns::GetValue is defined in ...*namespace_use-i2.h
+  return GetValue();
+}
+
+/**** IWYU_SUMMARY
+
+tests/cxx/namespace_use.cc should add these lines:
+#include "tests/cxx/namespace_use-i1.h"
+#include "tests/cxx/namespace_use-i2.h"
+
+tests/cxx/namespace_use.cc should remove these lines:
+- #include "tests/cxx/namespace_use-d1.h"  // lines XX-XX
+
+The full include-list for tests/cxx/namespace_use.cc:
+#include "tests/cxx/namespace_use-i1.h"  // for i1_ns
+#include "tests/cxx/namespace_use-i2.h"  // for GetValue
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
When referencing a symbol, `ns::sym`, the declaration of `sym` will also have a sufficient declaration for the associated namespace `ns`.

A using directive or namespace alias wants a declaration for the namespace. If there are uses of symbols in that namespace, then rely on IWYU for those symbols to satisfy the namespace use.

If there is no symbol use from the namespace, then the first header where the namespace is seen will still be recommended (existing behavior). This is expected to be uncommon.

This ameliorates the impact of #828, but does not fix it.