### PR TITLE
Report overloaded function return type

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -2424,12 +2424,6 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
       return false;
     if (!callee || CanIgnoreCurrentASTNode() || CanIgnoreDecl(callee))
       return true;
-    // We may have already been checked in a previous
-    // VisitOverloadExpr() call.  Don't check again in that case.
-    if (IsProcessedOverloadLoc(CurrentLoc()))
-      return true;
-
-    ReportDeclUse(CurrentLoc(), callee);
 
     // Usually the function-author is responsible for providing the
     // full type information for the return type of the function, but
@@ -2440,6 +2434,13 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
                     return_type)) {
       ReportTypeUse(CurrentLoc(), return_type);
     }
+
+    // We may have already been checked in a previous
+    // VisitOverloadExpr() call.  Don't check again in that case.
+    if (IsProcessedOverloadLoc(CurrentLoc()))
+      return true;
+
+    ReportDeclUse(CurrentLoc(), callee);
 
     return true;
   }

--- a/tests/cxx/overloaded_fn_return.cc
+++ b/tests/cxx/overloaded_fn_return.cc
@@ -1,0 +1,44 @@
+//===--- overloaded_fn_return.cc - test input file for iwyu ---------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_ARGS: -I .
+
+// Tests reporting full use of function return type in instantiated template
+// when the function call is unresolved at template definition point.
+
+#include "tests/cxx/direct.h"
+
+class IndirectClass;
+
+IndirectClass OverloadedFn(IndirectClass*);
+void OverloadedFn(float*);
+
+template <typename T>
+void TplFn() {
+  OverloadedFn((T*)nullptr);
+}
+
+void Fn() {
+  // IWYU: IndirectClass is...*indirect.h
+  TplFn<IndirectClass>();
+}
+
+/**** IWYU_SUMMARY
+
+tests/cxx/overloaded_fn_return.cc should add these lines:
+#include "tests/cxx/indirect.h"
+
+tests/cxx/overloaded_fn_return.cc should remove these lines:
+- #include "tests/cxx/direct.h"  // lines XX-XX
+- class IndirectClass;  // lines XX-XX
+
+The full include-list for tests/cxx/overloaded_fn_return.cc:
+#include "tests/cxx/indirect.h"  // for IndirectClass
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
Function return type should be analyzed regardless from whether the overload set was reported or not, because overload set processing doesn't deal with return types. It is reasonable because different functions in an overload set may have different return types.