### PR TITLE
Avoid redundant reports on function declaration references

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -178,6 +178,7 @@ using clang::FriendTemplateDecl;
 using clang::FunctionDecl;
 using clang::FunctionProtoType;
 using clang::FunctionTemplateDecl;
+using clang::FunctionTemplateSpecializationInfo;
 using clang::FunctionType;
 using clang::LValueReferenceType;
 using clang::LinkageSpecDecl;
@@ -794,6 +795,13 @@ class BaseAstVisitor : public RecursiveASTVisitor<Derived> {
       return true;
 
     if (FunctionDecl* fn_decl = DynCastFrom(expr->getDecl())) {
+      const FunctionTemplateSpecializationInfo* tpl_spec_info =
+          fn_decl->getTemplateSpecializationInfo();
+      const bool is_def = fn_decl->isThisDeclarationADefinition();
+      if (!tpl_spec_info ||  // I. e. not a template specialization, or...
+          tpl_spec_info->isExplicitInstantiationOrSpecialization() || !is_def) {
+        return true;
+      }
       // If fn_decl has a class-name before it -- 'MyClass::method' --
       // it's a method pointer.
       const Type* parent_type = nullptr;

--- a/tests/cxx/funcptrs-i1.h
+++ b/tests/cxx/funcptrs-i1.h
@@ -44,10 +44,20 @@ Enum Function(Class*) {
   return E_one;
 }
 
+// Forward declaration means that FunctionReturningRecordType doesn't provide
+// its return type.
+class IndirectClass;
+IndirectClass FunctionReturningRecordType();
+
 template<typename T>
 int FunctionTemplate(Class*) {
   return T(10).Value();
 }
+
+template <typename T>
+IndirectClass FunctionTemplate2();
+
+extern template IndirectClass FunctionTemplate2<int>();
 
 template<typename T>
 class ClassTemplate {

--- a/tests/cxx/funcptrs.cc
+++ b/tests/cxx/funcptrs.cc
@@ -19,6 +19,7 @@
 // A 'function' can be a free function, a static member function, a member
 // function, or any template instantiation of the above.
 
+#include "tests/cxx/direct.h"
 #include "tests/cxx/funcptrs-d1.h"
 
 
@@ -79,6 +80,17 @@ void FreeFunctions() {
   // IWYU: Retval is...*funcptrs-i1.h
   // IWYU: FunctionTemplate is...*funcptrs-i1.h
   &FunctionTemplate<Retval>;
+
+  // Full return type info is needed neither for non-templated function...
+  // IWYU: FunctionReturningRecordType is...*funcptrs-i1.h
+  &FunctionReturningRecordType;
+  // ... nor for function template implicit instantiation without definition...
+  // IWYU: FunctionTemplate2 is...*funcptrs-i1.h
+  &FunctionTemplate2<char>;
+  // ... nor for function template explicit specialization or instantiation
+  // references.
+  // IWYU: FunctionTemplate2 is...*funcptrs-i1.h
+  &FunctionTemplate2<int>;
 }
 
 void ClassMembers() {
@@ -212,9 +224,10 @@ tests/cxx/funcptrs.cc should add these lines:
 #include "tests/cxx/funcptrs-i1.h"
 
 tests/cxx/funcptrs.cc should remove these lines:
+- #include "tests/cxx/direct.h"  // lines XX-XX
 - #include "tests/cxx/funcptrs-d1.h"  // lines XX-XX
 
 The full include-list for tests/cxx/funcptrs.cc:
-#include "tests/cxx/funcptrs-i1.h"  // for Class, ClassTemplate, Enum, Function, FunctionTemplate, Retval
+#include "tests/cxx/funcptrs-i1.h"  // for Class, ClassTemplate, Enum, Function, FunctionReturningRecordType, FunctionTemplate, FunctionTemplate2, Retval
 
 ***** IWYU_SUMMARY */


### PR DESCRIPTION
TraverseDeclRefExpr should work only with implicitly instantiated function template specialization references. Other types of function references don't require full return type info because they don't cause template instantiation.