### PR TITLE
Require includes for namespace alias use

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -1581,7 +1581,7 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
     // using-decl.
     // TODO(csilvers): maybe just insert our own using declaration
     // instead?  We can call it "Use what you use". :-)
-    // TODO(csilvers): check for using statements and namespace aliases too.
+    // TODO(csilvers): check for using directives too.
     if (using_decl) {
       preprocessor_info().FileInfoFor(used_in)->ReportUsingDeclUse(
           used_loc, using_decl, use_flags, "(for using decl)");
@@ -2522,6 +2522,12 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
   // Visitors defined by BaseAstVisitor.
 
   bool VisitNestedNameSpecifier(NestedNameSpecifier* nns) {
+    // If this is a NamespaceAlias, then mark the alias as used,
+    // requiring whichever file(s) declare the alias.
+    if (nns->getKind() == NestedNameSpecifier::NamespaceAlias) {
+      ReportDeclUse(CurrentLoc(), nns->getAsNamespaceAlias());
+    }
+
     if (!Base::VisitNestedNameSpecifier(nns))
       return false;
     // If we're in an nns (e.g. the Foo in Foo::bar), we're never

--- a/tests/cxx/namespace_alias-d1.h
+++ b/tests/cxx/namespace_alias-d1.h
@@ -1,0 +1,19 @@
+//===--- namespace_alias-d1.h - test input file for IWYU ------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_NAMESPACE_ALIAS_D1_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_NAMESPACE_ALIAS_D1_H_
+
+// Nothing defined here, just including namespace_alias-i2.h and
+// namespace_alias-i3.h - IWYU should recommend dropping this header
+
+#include "tests/cxx/namespace_alias-i2.h"
+#include "tests/cxx/namespace_alias-i3.h"
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_NAMESPACE_ALIAS_D1_H_

--- a/tests/cxx/namespace_alias-i1.h
+++ b/tests/cxx/namespace_alias-i1.h
@@ -1,0 +1,20 @@
+//===--- namespace_alias-i1.h - test input file for IWYU ------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_NAMESPACE_ALIAS_I1_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_NAMESPACE_ALIAS_I1_H_
+
+// Just declare something in a namespace. Nested for good measure.
+namespace ns1 {
+namespace ns2 {
+void Function1();
+}
+}  // namespace ns1
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_NAMESPACE_ALIAS_I1_H_

--- a/tests/cxx/namespace_alias-i2.h
+++ b/tests/cxx/namespace_alias-i2.h
@@ -1,0 +1,18 @@
+//===--- namespace_alias-i2.h - test input file for IWYU ------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_NAMESPACE_ALIAS_I2_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_NAMESPACE_ALIAS_I2_H_
+
+#include "tests/cxx/namespace_alias-i1.h"
+
+// Alias a namespace defined in another file
+namespace ns_alias1 = ns1::ns2;
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_NAMESPACE_ALIAS_I2_H_

--- a/tests/cxx/namespace_alias-i3.h
+++ b/tests/cxx/namespace_alias-i3.h
@@ -1,0 +1,20 @@
+//===--- namespace_alias-i3.h - test input file for IWYU ------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_NAMESPACE_ALIAS_I3_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_NAMESPACE_ALIAS_I3_H_
+
+// Just declare something in a namespace. Nested for good measure.
+namespace ns3 {
+namespace ns4 {
+void Function1();
+}
+}  // namespace ns3
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_NAMESPACE_ALIAS_I3_H_

--- a/tests/cxx/namespace_alias.cc
+++ b/tests/cxx/namespace_alias.cc
@@ -1,0 +1,42 @@
+//===--- namespace_alias.cc - test input file for IWYU --------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_ARGS: -I .
+
+// Check that using a namespace alias requires an appropriate include
+
+#include "tests/cxx/namespace_alias-d1.h"
+
+// The referenced namespace must be declared. This file doesn't use symbols from
+// the namespace, so a header is explicitly suggested for it.
+// IWYU: ns3::ns4 is defined in...*namespace_alias-i3.h
+namespace ns_alias2 = ns3::ns4;
+
+void Func() {
+  // IWYU: ns1::ns2::Function1 is...*namespace_alias-i1.h
+  // IWYU: ns_alias1 is defined in...*namespace_alias-i2.h
+  ns_alias1::Function1();
+}
+
+/**** IWYU_SUMMARY
+
+tests/cxx/namespace_alias.cc should add these lines:
+#include "tests/cxx/namespace_alias-i1.h"
+#include "tests/cxx/namespace_alias-i2.h"
+#include "tests/cxx/namespace_alias-i3.h"
+
+tests/cxx/namespace_alias.cc should remove these lines:
+- #include "tests/cxx/namespace_alias-d1.h"  // lines XX-XX
+
+The full include-list for tests/cxx/namespace_alias.cc:
+#include "tests/cxx/namespace_alias-i1.h"  // for Function1
+#include "tests/cxx/namespace_alias-i2.h"  // for ns_alias1
+#include "tests/cxx/namespace_alias-i3.h"  // for ns4
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
Identify that the namespace alias is used from VisitNestedNameSpecifier().

This was part of the original submission for PR #1213.