### PR TITLE
Simplify quoted_includes_first testcase

### DIFF
--- a/tests/cxx/quoted_includes_first.cc
+++ b/tests/cxx/quoted_includes_first.cc
@@ -19,8 +19,12 @@
 #include "subdir/indirect_subdir.h"
 #include "quoted_includes_first.h"
 
-std::unique_ptr<IndirectSubDirClass> CreateIndirectSubDirClass() {
-  return std::unique_ptr<IndirectSubDirClass>(new IndirectSubDirClass);
+std::unique_ptr<int> CreateInt() {
+  return std::unique_ptr<int>(new int(20));
+}
+
+static IndirectSubDirClass GetIndirectSubDirClass() {
+  return global;
 }
 
 /**** IWYU_SUMMARY

--- a/tests/cxx/quoted_includes_first.h
+++ b/tests/cxx/quoted_includes_first.h
@@ -13,21 +13,21 @@
 #include <memory>
 #include "subdir/indirect_subdir.h"
 
-std::unique_ptr<IndirectSubDirClass> CreateIndirectSubDirClass();
+std::unique_ptr<int> CreateInt();
+
+inline const IndirectSubDirClass global;
 
 /**** IWYU_SUMMARY
 
 tests/cxx/quoted_includes_first.h should add these lines:
-class IndirectSubDirClass;
 
 tests/cxx/quoted_includes_first.h should remove these lines:
-- #include "subdir/indirect_subdir.h"  // lines XX-XX
 - #include <iostream>  // lines XX-XX
 - #include <list>  // lines XX-XX
 - #include <map>  // lines XX-XX
 
 The full include-list for tests/cxx/quoted_includes_first.h:
+#include "subdir/indirect_subdir.h"  // for IndirectSubDirClass
 #include <memory>  // for unique_ptr
-class IndirectSubDirClass;
 
 ***** IWYU_SUMMARY */


### PR DESCRIPTION
Instantiating `unique_ptr<T>` of a user-defined type T in a function return type is one of the more complex IWYU scenarios you can imagine and this testcase is really only intended to cover the sorting policy of include directives.

We still need both system angle-quoted headers and user quoted headers, so keep `unique_ptr<>`, but use a plain int instead. Add full uses of IndirectSubDirClass in both .h and .cc test files to see that includes are sorted properly.