### PR TITLE
Share public include mappings for C++ iostream

### DIFF
--- a/gcc.stl.headers.imp
+++ b/gcc.stl.headers.imp
@@ -293,24 +293,6 @@
   { include: ["<hashtable.h>", private, "<hash_set>", public ] },
   # (This one should perhaps be found automatically somehow.)
   { include: ["<ext/sso_string_base.h>", private, "<string>", public ] },
-  # The iostream .h files are confusing.  Lots of private headers,
-  # which are handled above, but we also have public headers
-  # #including each other (eg <iostream> //includes <istream>).  We
-  # are pretty forgiving: if a user specifies any public header, we
-  # generally don't require the others.
-  # ( cd /usr/crosstool/v12/gcc-4.3.1-glibc-2.3.6-grte/x86_64-unknown-linux-gnu/x86_64-unknown-linux-gnu/include/c++/4.3.1 && egrep '^ *# *include <(istream|ostream|iostream|fstream|sstream|streambuf|ios|iosfwd)>' *stream* ios | perl -nle 'm/^([^:]+).*[<"]([^>"]+)[>"]/ and print qq@    { include: ["<$2>", public, "<$1>", public ] },@' | sort -u )
-  { include: ["<ios>", public, "<istream>", public ] },
-  { include: ["<ios>", public, "<ostream>", public ] },
-  { include: ["<iosfwd>", public, "<ios>", public ] },
-  { include: ["<iosfwd>", public, "<streambuf>", public ] },
-  { include: ["<istream>", public, "<fstream>", public ] },
-  { include: ["<istream>", public, "<iostream>", public ] },
-  { include: ["<istream>", public, "<sstream>", public ] },
-  { include: ["<ostream>", public, "<fstream>", public ] },
-  { include: ["<ostream>", public, "<iostream>", public ] },
-  { include: ["<ostream>", public, "<istream>", public ] },
-  { include: ["<ostream>", public, "<sstream>", public ] },
-  { include: ["<streambuf>", public, "<ios>", public ] },
   # The location of exception_defines.h varies by GCC version.  It should
   # never be included directly.
   { include: ["<exception_defines.h>", private, "<exception>", public ] },

--- a/stl.public.imp
+++ b/stl.public.imp
@@ -1,0 +1,24 @@
+# C++ Standard Library public include mappings
+# Used by all STL implementations
+[
+  # Note: make sure to sync this setting with iwyu_include_picker.cc
+
+  # The iostream .h files are confusing.  Lots of private headers,
+  # which are handled above, but we also have public headers
+  # #including each other (eg <iostream> //includes <istream>).  We
+  # are pretty forgiving: if a user specifies any public header, we
+  # generally don't require the others.
+  # ( cd /usr/crosstool/v12/gcc-4.3.1-glibc-2.3.6-grte/x86_64-unknown-linux-gnu/x86_64-unknown-linux-gnu/include/c++/4.3.1 && egrep '^ *# *include <(istream|ostream|iostream|fstream|sstream|streambuf|ios|iosfwd)>' *stream* ios | perl -nle 'm/^([^:]+).*[<"]([^>"]+)[>"]/ and print qq@    { include: ["<$2>", public, "<$1>", public ] },@' | sort -u )
+  { include: ["<ios>", public, "<istream>", public ] },
+  { include: ["<ios>", public, "<ostream>", public ] },
+  { include: ["<iosfwd>", public, "<ios>", public ] },
+  { include: ["<iosfwd>", public, "<streambuf>", public ] },
+  { include: ["<istream>", public, "<fstream>", public ] },
+  { include: ["<istream>", public, "<iostream>", public ] },
+  { include: ["<istream>", public, "<sstream>", public ] },
+  { include: ["<ostream>", public, "<fstream>", public ] },
+  { include: ["<ostream>", public, "<iostream>", public ] },
+  { include: ["<ostream>", public, "<istream>", public ] },
+  { include: ["<ostream>", public, "<sstream>", public ] },
+  { include: ["<streambuf>", public, "<ios>", public ] },
+]


### PR DESCRIPTION
Move the public->public include mappings specified for libstdcpp into a new array that we load whenever a C++ library is being used. This generally allows any of the iostream headers to stand in for each other.

This fixes the `cxx.test_no_char_traits` and `cxx.test_expl_inst_macro` tests on MacOS.