### PR TITLE
Add infrastructure to allow skipping tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,6 +223,7 @@ if (Python3_Interpreter_FOUND)
       -- $<TARGET_FILE:include-what-you-use>
       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     )
+    set_tests_properties(${name} PROPERTIES SKIP_RETURN_CODE 99)
   endfunction()
 
   execute_process(

--- a/docs/IWYUStyle.md
+++ b/docs/IWYUStyle.md
@@ -281,6 +281,23 @@ comment:
 The args are added to the `include-what-you-use` command as-written after line
 unwrapping, so IWYU flags must be explicitly prefixed with `-Xiwyu`.
 
+### Prerequisites ###
+
+If a test has prerequisites, annotate the `.cc` file itself using a
+directive comment:
+
+```
+// IWYU_REQUIRES: feature(value)
+// IWYU_UNSUPPORTED: feature(value)
+```
+
+`IWYU_REQUIRES` states that the following feature test must evaluate
+true for the test to be valid.
+
+`IWYU_UNSUPPORTED` states that the test is invalid when the feature
+test evaluates as false.
+
+If any prerequisite fails the test will be skipped.
 
 [1]: https://google.github.io/styleguide/cppguide.html
 [2]: https://llvm.org/docs/CodingStandards.html

--- a/run_iwyu_tests.py
+++ b/run_iwyu_tests.py
@@ -42,6 +42,7 @@ def Partition(l, delimiter):
 
 def TestIwyuOnRelevantFiles(filename):
   logging.info('Testing iwyu on %s', filename)
+
   # Split full/path/to/foo.cc into full/path/to/foo and .cc.
   (all_but_extension, extension) = os.path.splitext(filename)
   (dirname, basename) = os.path.split(all_but_extension)
@@ -124,7 +125,16 @@ if __name__ == '__main__':
   (runner_args, _) = parser.parse_known_args(unittest_args)
 
   if runner_args.run_test_file:
-    exit(TestIwyuOnRelevantFiles(runner_args.run_test_file))
+    try:
+      r = TestIwyuOnRelevantFiles(runner_args.run_test_file)
+    except unittest.SkipTest as e:
+      # Catch the skip test exception that unittest would normally
+      # handle. Instead set a return code that informs Ctest that the
+      # test is being skipped
+      print(f"Skipped {runner_args.run_test_file}: {e}")
+      exit(99)
+    else:
+      exit(r)
 
   @GenerateTests(rootdir='tests/c', pattern='*.c')
   class c(unittest.TestCase): pass

--- a/tests/cxx/ms_inline_asm.cc
+++ b/tests/cxx/ms_inline_asm.cc
@@ -7,7 +7,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// IWYU_ARGS: -fms-extensions
+// IWYU_ARGS: -fms-extensions --target=x86_64
+// IWYU_REQUIRES: iwyu_has_target_support_for(x86-64)
 
 // This file is not strictly an IWYU test, it just checks that the parser
 // doesn't choke on Microsoft inline assembly on any of our target platforms.


### PR DESCRIPTION
There may be reasons to skip a test. This infrastructure allows each test to define a condition under which it would skip. This is done by adding an '// IWYU_SKIP:' comment. The following text is evaluated as python code - if the result is true, the test is skipped.

I was looking at whether I could silence the `ms_inline_asm`, but saw the discussion on #1201. I'm not sure whether you'd prefer to set --target=x86_64, or mark the test for skipping with something like this. The infrastructure may come in handy to skip over tests that we can't get to work with libstdc++ or clang_mapping.