### PR TITLE
Handle "autocast" type components separately

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -1600,11 +1600,8 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
 
   // Called when the given type is fully used at used_loc, regardless
   // of the type being explicitly written in the source code or not.
-  // The comment, if not nullptr, is extra text that is included along
-  // with the warning message that iwyu emits.
-  virtual void ReportTypeUse(SourceLocation used_loc, const Type* type,
-                             const char* comment = nullptr) {
-    ReportTypeUseInternal(used_loc, type, comment, blocked_types_);
+  virtual void ReportTypeUse(SourceLocation used_loc, const Type* type) {
+    ReportTypeUseInternal(used_loc, type, blocked_types_);
   }
 
   void ReportTypesUse(SourceLocation used_loc, const set<const Type*>& types) {
@@ -2610,7 +2607,6 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
   }
 
   void ReportTypeUseInternal(SourceLocation used_loc, const Type* type,
-                             const char* comment,
                              const set<const Type*>& blocked_types) {
     if (CanIgnoreType(type))
       return;
@@ -2655,7 +2651,7 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
         const Type* type = RemovePointersAndReferencesAsWritten(
             typedef_decl->getUnderlyingType().getTypePtr());
         IwyuBaseAstVisitor<Derived>::ReportTypeUseInternal(
-            used_loc, type, nullptr, provided_with_typedef);
+            used_loc, type, provided_with_typedef);
       }
       return;
     }
@@ -2677,7 +2673,7 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
     if (const NamedDecl* decl = TypeToDeclAsWritten(type)) {
       decl = GetDefinitionAsWritten(decl);
       VERRS(6) << "(For type " << PrintableType(type) << "):\n";
-      IwyuBaseAstVisitor<Derived>::ReportDeclUse(used_loc, decl, comment);
+      IwyuBaseAstVisitor<Derived>::ReportDeclUse(used_loc, decl);
     }
   }
 
@@ -2957,8 +2953,7 @@ class InstantiatedTemplateVisitor
     // implicit stuff, it should not suggest forward declarations.
   }
 
-  void ReportTypeUse(SourceLocation used_loc, const Type* type,
-                     const char* comment = nullptr) override {
+  void ReportTypeUse(SourceLocation used_loc, const Type* type) override {
     // clang desugars template types, so Foo<MyTypedef>() gets turned
     // into Foo<UnderlyingType>().  Try to convert back.
     type = ResugarType(type);
@@ -2969,7 +2964,7 @@ class InstantiatedTemplateVisitor
       for (CacheStoringScope* storer : cache_storers_)
         storer->NoteReportedType(type);
     }
-    Base::ReportTypeUse(caller_loc(), type, comment);
+    Base::ReportTypeUse(caller_loc(), type);
   }
 
   //------------------------------------------------------------

--- a/iwyu.cc
+++ b/iwyu.cc
@@ -125,7 +125,6 @@
 #include "clang/AST/NestedNameSpecifier.h"
 #include "clang/AST/OperationKinds.h"
 #include "clang/AST/RecursiveASTVisitor.h"
-#include "clang/AST/Stmt.h"
 #include "clang/AST/TemplateBase.h"
 #include "clang/AST/Type.h"
 #include "clang/AST/TypeLoc.h"
@@ -1458,8 +1457,7 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
 
   // ast_node is the node for the autocast CastExpr.  We use it to get
   // the parent CallExpr to figure out what function is being called.
-  set<const Type*> GetCallerResponsibleTypesForAutocast(
-      const ASTNode* ast_node) const {
+  set<const Type*> GetProvidedTypesForAutocast(const ASTNode* ast_node) const {
     while (ast_node && !ast_node->IsA<CallExpr>())
       ast_node = ast_node->parent();
     CHECK_(ast_node && "Should only check Autocast if under a CallExpr");
@@ -1481,11 +1479,9 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
     }
 
     // Now look at all the function decls that are visible from the
-    // call-location.  We keep only the autocast params that *all*
-    // the function decl authors want the caller to be responsible
-    // for.  We do this by elimination: start with all types, and
-    // remove them as we see authors providing the full type.
-    set<const Type*> retval = autocast_types;
+    // call-location.  A type component is considered as provided if *any*
+    // of the function decls provides it.
+    set<const Type*> retval;
     for (FunctionDecl::redecl_iterator fn_redecl = fn_decl->redecls_begin();
          fn_redecl != fn_decl->redecls_end(); ++fn_redecl) {
       // Ignore function-decls that we can't see from the use-location.
@@ -1495,19 +1491,12 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
       }
       if (fn_redecl->isThisDeclarationADefinition() && !IsInHeader(*fn_redecl))
         continue;
-      for (set<const Type*>::iterator it = retval.begin();
-           it != retval.end(); ) {
-        if (!CodeAuthorWantsJustAForwardDeclare(*it, GetLocation(*fn_redecl))) {
-          // set<> has nice property that erasing doesn't invalidate iterators.
-
-          retval.erase(it++);
-        } else {
-          ++it;
-        }
+      for (const Type* type : autocast_types) {
+        const set<const Type*> components =
+            GetProvidedTypes(type, GetLocation(*fn_redecl));
+        retval.insert(components.begin(), components.end());
       }
     }
-
-    // TODO(csilvers): include template type-args of each entry of retval.
 
     return retval;
   }
@@ -1718,52 +1707,8 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
         return true;
       }
     } else {
-      // Make all our types forward-declarable...
+      // Make all our types forward-declarable.
       current_ast_node()->set_in_forward_declare_context(true);
-    }
-
-    // (The exceptions below don't apply to friend declarations; we
-    // never need full types for them.)
-    if (IsFriendDecl(decl))
-      return true;
-
-    // ...except the return value (handled in CanBeProvidedTypeComponent)
-
-    // ...and non-explicit, one-arg ('autocast') constructor types.
-    for (FunctionDecl::param_iterator param = decl->param_begin();
-         param != decl->param_end(); ++param) {
-      const Type* param_type = GetTypeOf(*param);
-      if (!HasImplicitConversionConstructor(param_type))
-        continue;
-      const Type* deref_param_type =
-          RemovePointersAndReferencesAsWritten(param_type);
-      if (CanIgnoreType(deref_param_type))
-        continue;
-
-      // TODO(csilvers): remove this 'if' check when we've resolved the
-      // clang bug where getTypeSourceInfo() can return nullptr.
-      if ((*param)->getTypeSourceInfo()) {
-        const TypeLoc param_tl = (*param)->getTypeSourceInfo()->getTypeLoc();
-        // While iwyu requires the full type of autocast parameters,
-        // c++ does not.  Function-writers can force iwyu to follow
-        // the language by explicitly forward-declaring the type.
-        // Check for that now, and don't require the full type.
-        if (CodeAuthorWantsJustAForwardDeclare(deref_param_type,
-                                               GetLocation(&param_tl)))
-          continue;
-        // This is a 'full type required' check, to 'turn off' fwd decl.
-        // But don't bother to report in situations where we need the
-        // full type for other reasons; that's just double-reporting.
-        if (current_ast_node()->in_forward_declare_context() ||
-            IsPointerOrReferenceAsWritten(param_type)) {
-          ReportTypeUse(GetLocation(&param_tl), deref_param_type,
-                        "(for autocast)");
-        }
-      } else {
-        VERRS(6) << "WARNING: nullptr TypeSourceInfo for "
-                 << PrintableDecl(*param)
-                 << " (type " << PrintableType(param_type) << ")\n";
-      }
     }
     return true;
   }
@@ -2209,22 +2154,7 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
     ReportIfReferenceVararg(expr->getArgs(), expr->getNumArgs(),
                             expr->getConstructor());
 
-    // 'Autocast' -- calling a one-arg, non-explicit constructor
-    // -- is a special case when it's done for a function call.
-    // iwyu requires the function-writer to provide the #include
-    // for the casted-to type, just so we don't have to require it
-    // here.  *However*, the function-author can override this
-    // iwyu requirement, in which case we're responsible for the
-    // casted-to type.  See IwyuBaseASTVisitor::VisitFunctionDecl.
-    // Explicitly written CXXTemporaryObjectExpr are ignored here.
-    if (expr->getStmtClass() == Stmt::StmtClass::CXXConstructExprClass) {
-      const Type* type = Desugar(expr->getType().getTypePtr());
-      if (current_ast_node()->template HasAncestorOfType<CallExpr>() &&
-          ContainsKey(GetCallerResponsibleTypesForAutocast(current_ast_node()),
-                      RemoveReferenceAsWritten(type))) {
-        ReportTypeUse(CurrentLoc(), type);
-      }
-    }
+    HandleAutocastOnCallSite(expr);
 
     return true;
   }
@@ -2611,6 +2541,13 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
       // in source files, or for builtins, or for friend declarations.
       if (!IsInHeader(decl) || IsFriendDecl(decl))
         return pair(false, nullptr);
+      for (const ParmVarDecl* param : decl->parameters()) {
+        if (node->StackContainsContent(param)) {
+          if (HasImplicitConversionConstructor(GetTypeOf(param)))
+            return pair(true, "(for autocast)");
+          return pair(false, nullptr);
+        }
+      }
       const Type* return_type = decl->getReturnType().getTypePtr();
       if (node->StackContainsContent(return_type) &&
           !decl->isThisDeclarationADefinition() &&
@@ -2744,6 +2681,14 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
     }
   }
 
+  void ReportWithAdditionalBlockedTypes(
+      const Type* type, const set<const Type*>& additional_blocked_types) {
+    set<const Type*> new_blocked_types = additional_blocked_types;
+    new_blocked_types.insert(blocked_types_.begin(), blocked_types_.end());
+    ValueSaver<set<const Type*>> s(&blocked_types_, new_blocked_types);
+    ReportTypeUse(CurrentLoc(), type);
+  }
+
   void HandleFnReturnOnCallSite(const FunctionDecl* callee) {
     // Usually the function-author is responsible for providing the
     // full type information for the return type of the function, but
@@ -2753,10 +2698,23 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
     if (IsPointerOrReferenceAsWritten(return_type))
       return;
 
-    set<const Type*> merged_blocked = GetProvidedTypesForFnReturn(callee);
-    merged_blocked.insert(blocked_types_.begin(), blocked_types_.end());
-    ValueSaver<set<const Type*>> s(&blocked_types_, merged_blocked);
-    ReportTypeUse(CurrentLoc(), return_type);
+    ReportWithAdditionalBlockedTypes(return_type,
+                                     GetProvidedTypesForFnReturn(callee));
+  }
+
+  void HandleAutocastOnCallSite(clang::CXXConstructExpr* expr) {
+    // 'Autocast' -- calling a one-arg, non-explicit constructor
+    // -- is a special case when it's done for a function call.
+    // iwyu requires the function-writer to provide the #include
+    // for the casted-to type, just so we don't have to require it
+    // here.  *However*, the function-author can override this
+    // iwyu requirement, in which case we're responsible for the
+    // casted-to type.  See IwyuBaseASTVisitor::CanBeProvidedTypeComponent.
+    if (!IsAutocastExpr(current_ast_node()))
+      return;
+    const Type* type = expr->getType().getTypePtr();
+    ReportWithAdditionalBlockedTypes(
+        type, GetProvidedTypesForAutocast(current_ast_node()));
   }
 
   // Do not add any variables here!  If you do, they will not be shared
@@ -4352,9 +4310,16 @@ class IwyuAstConsumer
       InsertAllInto(GetTplTypeResugarMapForClass(parent_type), &resugar_map);
     }
 
+    set<const Type*> provided_types =
+        ExtractProvidedTypeComponents(resugar_map);
+    if (IsAutocastExpr(current_ast_node())) {
+      const set<const Type*> provided_for_autocast =
+          GetProvidedTypesForAutocast(current_ast_node());
+      provided_types.insert(provided_for_autocast.begin(),
+                            provided_for_autocast.end());
+    }
     instantiated_template_visitor_.ScanInstantiatedFunction(
-        callee, parent_type, current_ast_node(), resugar_map,
-        ExtractProvidedTypeComponents(resugar_map));
+        callee, parent_type, current_ast_node(), resugar_map, provided_types);
     return true;
   }
 

--- a/iwyu_ast_util.h
+++ b/iwyu_ast_util.h
@@ -443,6 +443,10 @@ bool IsCXXConstructExprInInitializer(const ASTNode* ast_node);
 // Returns true if this node is a CXXConstructExpr in CXXNewExpr.
 bool IsCXXConstructExprInNewExpr(const ASTNode* ast_node);
 
+// Determines if the given node represents implicit one-argument constructor
+// call in context of function argument initialization - so called 'autocast'.
+bool IsAutocastExpr(const ASTNode*);
+
 // If ASTNode is of a kind that has a qualifier (something that
 // comes before the ::), return that, else return nullptr.
 const clang::NestedNameSpecifier* GetQualifier(const ASTNode* ast_node);

--- a/tests/cxx/badinc.cc
+++ b/tests/cxx/badinc.cc
@@ -188,7 +188,6 @@ typedef I1_Class Cc_typedef_array[kI1ConstInt];
 // using the no-arg Cc_tpl_typedef ctor, which requires the full
 // definition of I2_Class.
 // IWYU: I1_TemplateClass is...*badinc-i1.h.*#included\.
-// IWYU: I1_TemplateClass is...*badinc-i1.h.*for autocast
 // IWYU: I1_Class is...*badinc-i1.h
 // IWYU: I2_Class is...*badinc-i2.h
 // IWYU: I2_Class::~I2_Class is...*badinc-i2-inl.h

--- a/tests/cxx/implicit_ctor-d1.h
+++ b/tests/cxx/implicit_ctor-d1.h
@@ -14,17 +14,14 @@
 // reference to it.  This is because the class has an implicit
 // constructor.
 
-// IWYU: IndirectWithImplicitCtor needs a declaration
 // IWYU: IndirectWithImplicitCtor is...*implicit_ctor-i2.h.*for autocast
 int ImplicitCtorFn(IndirectWithImplicitCtor);
 
-// IWYU: IndirectWithImplicitCtor needs a declaration
 // IWYU: IndirectWithImplicitCtor is...*implicit_ctor-i2.h.*for autocast
 int ImplicitCtorRefFn(const IndirectWithImplicitCtor&);
 
 // Reporting types for "autocast" for header-defined functions still makes sense
 // as opposed to function definitions in source files.
-// IWYU: IndirectWithImplicitCtor needs a declaration
 // IWYU: IndirectWithImplicitCtor is...*implicit_ctor-i2.h.*for autocast
 inline int InlineImplicitCtorRefFn(const IndirectWithImplicitCtor&) {
   return 1;

--- a/tests/cxx/iwyu_stricter_than_cpp-autocast.h
+++ b/tests/cxx/iwyu_stricter_than_cpp-autocast.h
@@ -17,6 +17,7 @@
 // (2) do not directly #include the definition of the relevant type.
 
 #include "tests/cxx/iwyu_stricter_than_cpp-d1.h"
+#include "tests/cxx/iwyu_stricter_than_cpp-d4.h"
 
 // --- Autocast types.
 
@@ -25,7 +26,6 @@ struct IndirectStruct2;
 
 void FnValues(
     // Requires the full type because it does not obey rule (1)
-    // IWYU: IndirectStruct1 needs a declaration
     // IWYU: IndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h.*for autocast
     IndirectStruct1 ic1,
     // This also does not obey rule (1): it's -d1 that does the fwd-declaring.
@@ -39,7 +39,6 @@ void FnValues(
     IndirectStruct2 ic2);
 
 void FnRefs(
-    // IWYU: IndirectStruct1 needs a declaration
     // IWYU: IndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h.*for autocast
     const IndirectStruct1& ic1,
     // IWYU: IndirectStructForwardDeclaredInD1 is...*iwyu_stricter_than_cpp-i1.h.*for autocast
@@ -48,7 +47,6 @@ void FnRefs(
     const IndirectStruct2& ic2);
 
 inline void HeaderDefinedFnRefs(
-    // IWYU: IndirectStruct1 needs a declaration
     // IWYU: IndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h.*for autocast
     const IndirectStruct1& ic1,
     // IWYU: IndirectStructForwardDeclaredInD1 is...*iwyu_stricter_than_cpp-i1.h.*for autocast
@@ -65,40 +63,69 @@ template <typename T>
 struct TplIndirectStruct2;
 
 void TplFnValues(
-    // IWYU: TplIndirectStruct1 needs a declaration
     // IWYU: TplIndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h.*for autocast
     TplIndirectStruct1<char> ic1,
-    // A bit of an asymmetry with the non-tpl case: 'struct
-    // IndirectStructForwardDeclaredInD1' does not need to be
-    // forward-declared because it's elaborated, but template types
-    // need to be forward-declared even when they're elaborated.  (Of
-    // course, the fwd-decl requirement will be superceded by the
-    // full-type requirement due to autocast, but we report both.)
-    // IWYU: TplIndirectStructForwardDeclaredInD1 needs a declaration
     // IWYU: TplIndirectStructForwardDeclaredInD1 is...*iwyu_stricter_than_cpp-i1.h.*for autocast
     struct TplIndirectStructForwardDeclaredInD1<char> icfdid1,
     TplDirectStruct1<char> dc1, struct TplDirectStruct2<char> dc2,
     TplIndirectStruct2<char> ic2);
 
 void TplFnRefs(
-    // IWYU: TplIndirectStruct1 needs a declaration
     // IWYU: TplIndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h.*for autocast
     const TplIndirectStruct1<char>& ic1,
-    // IWYU: TplIndirectStructForwardDeclaredInD1 needs a declaration
     // IWYU: TplIndirectStructForwardDeclaredInD1 is...*iwyu_stricter_than_cpp-i1.h.*for autocast
     const struct TplIndirectStructForwardDeclaredInD1<char>& icfdid1,
     const TplDirectStruct3<char>& dc1, const struct TplDirectStruct4<char>& dc2,
     const TplIndirectStruct2<char>& ic2);
 
 inline void HeaderDefinedTplFnRefs(
-    // IWYU: TplIndirectStruct1 needs a declaration
     // IWYU: TplIndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h.*for autocast
     const TplIndirectStruct1<char>& ic1,
-    // IWYU: TplIndirectStructForwardDeclaredInD1 needs a declaration
     // IWYU: TplIndirectStructForwardDeclaredInD1 is...*iwyu_stricter_than_cpp-i1.h.*for autocast
     const struct TplIndirectStructForwardDeclaredInD1<char>& icfdid1,
     const TplDirectStruct5<char>& dc1, const struct TplDirectStruct6<char>& dc2,
     const TplIndirectStruct2<char>& ic2) {
+}
+
+// --- With user-defined types as template parameters.
+
+// struct IndirectStruct2; (fwd-declared above)
+template <typename TFullTypeUsed, typename TForwardDeclarable>
+struct TplIndirectStruct3;
+
+void TplFnValues(
+    // IWYU: IndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h.*for autocast
+    TplIndirectStruct3<IndirectStruct1, IndirectStruct2>
+        only_argument_type_provided,
+    TplIndirectStruct3<IndirectStruct2, IndirectStruct2> all_forward_declared,
+    // IWYU: IndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h.*for autocast
+    TplDirectStruct7<IndirectStruct1, IndirectStruct2>
+        all_needed_types_provided,
+    TplDirectStruct7<IndirectStruct2, IndirectStruct2> only_template_provided);
+
+void TplFnRefs(
+    // IWYU: IndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h.*for autocast
+    const TplIndirectStruct3<IndirectStruct1, IndirectStruct2>&
+        only_argument_type_provided,
+    const TplIndirectStruct3<IndirectStruct2, IndirectStruct2>&
+        all_forward_declared,
+    // IWYU: IndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h.*for autocast
+    const TplDirectStruct7<IndirectStruct1, IndirectStruct2>&
+        all_needed_types_provided,
+    const TplDirectStruct7<IndirectStruct2, IndirectStruct2>&
+        only_template_provided);
+
+inline void HeaderDefinedTplFnRefs(
+    // IWYU: IndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h.*for autocast
+    const TplIndirectStruct3<IndirectStruct1, IndirectStruct2>&
+        only_argument_type_provided,
+    const TplIndirectStruct3<IndirectStruct2, IndirectStruct2>&
+        all_forward_declared,
+    // IWYU: IndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h.*for autocast
+    const TplDirectStruct7<IndirectStruct1, IndirectStruct2>&
+        all_needed_types_provided,
+    const TplDirectStruct7<IndirectStruct2, IndirectStruct2>&
+        only_template_provided) {
 }
 
 // --- The rules do not apply for friend functions declarations.
@@ -108,11 +135,20 @@ struct AutocastStruct {
   friend void ClassFn1(const IndirectStruct1&);
   // IWYU: TplIndirectStruct1 needs a declaration
   friend void ClassFn2(TplIndirectStruct1<char>);
+  friend void ClassFn3(
+      // IWYU: IndirectStruct1 needs a declaration
+      const TplIndirectStruct3<IndirectStruct1, IndirectStruct2>&);
 };
+
+// IWYU should not print the comment "for autocast" when the type info is
+// mandatory.
+inline void Fn(
+    // IWYU: IndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h", which isn't directly #included\.
+    TplDirectStruct7<decltype(IndirectStruct1::c), IndirectStruct2>) {
+}
 
 // Test that IWYU finds constructors even if they are not instantiated.
 
-// IWYU: NonInstantiated needs a declaration
 // IWYU: NonInstantiated is...*iwyu_stricter_than_cpp-i1.h.*for autocast
 void Fn(NonInstantiated<char>);
 
@@ -136,8 +172,10 @@ tests/cxx/iwyu_stricter_than_cpp-autocast.h should remove these lines:
 
 The full include-list for tests/cxx/iwyu_stricter_than_cpp-autocast.h:
 #include "tests/cxx/iwyu_stricter_than_cpp-d1.h"  // for DirectStruct1, DirectStruct2, DirectStruct3, DirectStruct4, DirectStruct5, DirectStruct6, TplDirectStruct1, TplDirectStruct2, TplDirectStruct3, TplDirectStruct4, TplDirectStruct5, TplDirectStruct6
+#include "tests/cxx/iwyu_stricter_than_cpp-d4.h"  // for TplDirectStruct7
 #include "tests/cxx/iwyu_stricter_than_cpp-i1.h"  // for AutocastInPartialSpec (ptr only), IndirectStruct1, IndirectStructForwardDeclaredInD1, NoAutocastForSpec (ptr only), NonInstantiated, TplIndirectStruct1, TplIndirectStructForwardDeclaredInD1
 struct IndirectStruct2;  // lines XX-XX
 template <typename T> struct TplIndirectStruct2;  // lines XX-XX+1
+template <typename TFullTypeUsed, typename TForwardDeclarable> struct TplIndirectStruct3;  // lines XX-XX+1
 
 ***** IWYU_SUMMARY */

--- a/tests/cxx/iwyu_stricter_than_cpp-d4.h
+++ b/tests/cxx/iwyu_stricter_than_cpp-d4.h
@@ -14,6 +14,13 @@
 
 template <typename T1, typename T2>
 struct TplDirectStruct7 {
+  TplDirectStruct7() = default;
+
+  TplDirectStruct7(int) {
+    // Type T1 is used both in class and in constructor definition.
+    (void)sizeof(T1);
+  }
+
   static constexpr auto s = sizeof(T1);
   T2* t2;
 };

--- a/tests/cxx/iwyu_stricter_than_cpp-i5.h
+++ b/tests/cxx/iwyu_stricter_than_cpp-i5.h
@@ -9,6 +9,13 @@
 
 template <typename T1, typename T2>
 struct TplIndirectStruct3 {
+  TplIndirectStruct3() = default;
+
+  TplIndirectStruct3(int) {
+    // Type T1 is used both in class and in constructor definition.
+    (void)sizeof(T1);
+  }
+
   static constexpr auto s = sizeof(T1);
   T2* t2;
 };

--- a/tests/cxx/iwyu_stricter_than_cpp.cc
+++ b/tests/cxx/iwyu_stricter_than_cpp.cc
@@ -263,6 +263,36 @@ void TestAutocast() {
       6, 7, 8, 9,
       // IWYU: TplIndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
       10);
+
+  TplFnValues(
+      // IWYU: TplIndirectStruct3 is...*iwyu_stricter_than_cpp-i5.h
+      /*only_argument_type_provided=*/1,
+      // IWYU: TplIndirectStruct3 is...*iwyu_stricter_than_cpp-i5.h
+      // IWYU: IndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
+      /*all_forward_declared=*/2,
+      /*all_needed_types_provided=*/3,
+      // IWYU: IndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
+      /*only_template_provided=*/4);
+
+  TplFnRefs(
+      // IWYU: TplIndirectStruct3 is...*iwyu_stricter_than_cpp-i5.h
+      /*only_argument_type_provided=*/1,
+      // IWYU: TplIndirectStruct3 is...*iwyu_stricter_than_cpp-i5.h
+      // IWYU: IndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
+      /*all_forward_declared=*/2,
+      /*all_needed_types_provided=*/3,
+      // IWYU: IndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
+      /*only_template_provided=*/4);
+
+  HeaderDefinedTplFnRefs(
+      // IWYU: TplIndirectStruct3 is...*iwyu_stricter_than_cpp-i5.h
+      /*only_argument_type_provided=*/1,
+      // IWYU: TplIndirectStruct3 is...*iwyu_stricter_than_cpp-i5.h
+      // IWYU: IndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
+      /*all_forward_declared=*/2,
+      /*all_needed_types_provided=*/3,
+      // IWYU: IndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
+      /*only_template_provided=*/4);
 }
 
 template <typename Ret, Ret Fn()>


### PR DESCRIPTION
Similar to https://github.com/include-what-you-use/include-what-you-use/pull/1248 and https://github.com/include-what-you-use/include-what-you-use/pull/1304.

At the call site, not only argument type reporting is handled (in `VisitCXXConstructExpr`) but also constructor call in case of template (`HandleFunctionCall`). It is because traversal of implicit constructor call in "autocast" context should not produce provided type reportings as well.

`comment` parameter of `ReportTypeUse` function becomes unused and is removed.

One subtle thing: copy and move constructor usages are not reported as "autocast" ones. In fact, they are reported nowhere at all (along with some other implicit construction cases), and it is a bug. It could be fixed by removing that filtering in `IsAutocastExpr`, in principle, but, besides being conceptually incorrect, it results in redundant reporting for passed-by-value function templated parameter when template argument is "providing" type alias, which may be undesirable.