### PR TITLE
Remove EnumDecl visitation

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -1627,17 +1627,6 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
     return true;
   }
 
-  bool VisitEnumDecl(EnumDecl* decl) {
-    if (CanIgnoreCurrentASTNode())
-      return true;
-
-    clang::QualType integer_type = decl->getIntegerType();
-    if (const clang::Type* type = integer_type.getTypePtrOrNull()) {
-      ReportTypeUse(CurrentLoc(), type);
-    }
-    return true;
-  }
-
   // If you say 'typedef Foo Bar', C++ says you just need to
   // forward-declare Foo.  But iwyu would rather you fully define Foo,
   // so all users of Bar don't have to.  We make two exceptions:


### PR DESCRIPTION
It was introduced in #742 to report underlying type aliases but it is seemingly not needed anymore, probably after #775 where `TypedefType` visitation has been added.

Actually, type aliases and typedefs cannot be forward-declared and thus should be reported if and only if they're explicitly written in the source (what `VisitTypedefType` already does). An enum underlying type itself [should be of integral type](https://eel.is/c++draft/dcl.enum#2) and hence cannot be defined in any of user's headers.

No functional change.