### PR TITLE
Remove DesugarDependentTypedef

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -1903,8 +1903,6 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
     CHECK_(base_type && "Member's base does not have a type?");
     const Type* deref_base_type  // For myvar->a, base-type will have a *
         = expr->isArrow() ? RemovePointerFromType(base_type) : base_type;
-    if (CanIgnoreType(deref_base_type))
-      return true;
     // Technically, we should say the type is being used at the
     // location of base_expr.  That may be a different file than us in
     // cases like MACRO.b().  However, while one can imagine

--- a/iwyu.cc
+++ b/iwyu.cc
@@ -1407,37 +1407,6 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
     return true;
   }
 
-  // Returns the first type that is not a typedef in a template.  For example,
-  // for template
-  //
-  //   template<typename T> class Foo {
-  //     typedef T value_type;
-  //     typedef value_type& reference;
-  //   };
-  //
-  // for type 'reference' it will return type T with which Foo was instantiated.
-  const Type* DesugarDependentTypedef(const TypedefType* typedef_type) {
-    const DeclContext* parent =
-        typedef_type->getDecl()->getLexicalDeclContext();
-    if (const ClassTemplateSpecializationDecl* template_parent =
-            DynCastFrom(parent)) {
-      return DesugarDependentTypedef(typedef_type, template_parent);
-    }
-    return typedef_type;
-  }
-
-  const Type* DesugarDependentTypedef(
-      const TypedefType* typedef_type, const RecordDecl* parent) {
-    const Type* underlying_type =
-        typedef_type->getDecl()->getUnderlyingType().getTypePtr();
-    if (const TypedefType* underlying_typedef = DynCastFrom(underlying_type)) {
-      if (underlying_typedef->getDecl()->getLexicalDeclContext() == parent) {
-        return DesugarDependentTypedef(underlying_typedef, parent);
-      }
-    }
-    return underlying_type;
-  }
-
   set<const Type*> GetProvidedTypesForTypedef(
       const TypedefNameDecl* decl) const {
     const Type* underlying_type = decl->getUnderlyingType().getTypePtr();
@@ -1936,9 +1905,6 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
         = expr->isArrow() ? RemovePointerFromType(base_type) : base_type;
     if (CanIgnoreType(deref_base_type))
       return true;
-    if (const TypedefType* typedef_type = DynCastFrom(deref_base_type)) {
-      deref_base_type = DesugarDependentTypedef(typedef_type);
-    }
     // Technically, we should say the type is being used at the
     // location of base_expr.  That may be a different file than us in
     // cases like MACRO.b().  However, while one can imagine


### PR DESCRIPTION
It had been added in #214 but seemingly not needed at now, probably after blocking of reporting implicit typedefs in #1180. Type alias underlying types are extracted in the `ReportTypeUse` function, with respect to "provision" status (and substituted template parameter types are not considered as provided).

`CanIgnoreType` call is removed from `VisitMemberExpr`. `ReportTypeUse` overloads check it after #1179 already.

Btw, it seems like `CanIgnoreType` and `ResugarType` calls could be removed from `InstantiatedTemplateVisitor::VisitCXXConstructExpr` as well. A confusing point is that `ReportTypeUse` calls them in reverse order, but all tests passed at least.

No functional change.