### PR TITLE
Fix handling aliased indirect types

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -1725,7 +1725,7 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
     if (CanIgnoreCurrentASTNode())
       return true;
 
-    if (const Type* type = stmt->getRangeInit()->getType().getTypePtrOrNull()) {
+    if (const Type* type = GetTypeOf(stmt->getRangeInit())) {
       ReportTypeUse(CurrentLoc(), type, DerefKind::RemoveRefs);
 
       // TODO: We should probably find a way to require inclusion of any
@@ -1992,11 +1992,10 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
         // No need to report on non-ref types, RecursiveASTVisitor will get 'em.
       }
     } else {
-      const Expr* arg_expr = expr->getArgumentExpr();
-      const Type* dereftype = arg_expr->getType().getTypePtr();
+      const Expr* arg_expr = expr->getArgumentExpr()->IgnoreParenImpCasts();
       // This reports even if the expr ends up not being a reference, but
       // that's ok (if potentially redundant).
-      ReportTypeUse(GetLocation(arg_expr->IgnoreParenImpCasts()), dereftype,
+      ReportTypeUse(GetLocation(arg_expr), GetTypeOf(arg_expr),
                     DerefKind::RemoveRefs);
     }
     return true;

--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -74,6 +74,7 @@ using clang::DependentTemplateSpecializationType;
 using clang::ElaboratedType;
 using clang::ElaboratedTypeKeyword;
 using clang::EnumDecl;
+using clang::ExplicitCastExpr;
 using clang::Expr;
 using clang::ExprWithCleanups;
 using clang::FileEntry;
@@ -1227,6 +1228,10 @@ bool IsImplicitlyInstantiatedDfn(const clang::FunctionDecl* decl) {
 // --- Utilities for Type.
 
 const Type* GetTypeOf(const Expr* expr) {
+  if (const auto* decl_ref_expr = dyn_cast<DeclRefExpr>(expr))
+    return decl_ref_expr->getDecl()->getType().getTypePtr();
+  if (const auto* cast_expr = dyn_cast<ExplicitCastExpr>(expr))
+    return cast_expr->getTypeAsWritten().getTypePtr();
   return expr->getType().getTypePtr();
 }
 

--- a/tests/cxx/binary_type_trait.cc
+++ b/tests/cxx/binary_type_trait.cc
@@ -19,9 +19,7 @@ int main() {
     static_assert(__is_convertible_to(BinaryTypeTraitDerived*, BinaryTypeTraitBase*),
         "Derived should be convertible to the Base class");
 
-    // IWYU: BinaryTypeTraitBase is...*binary_type_trait-i1.h
     // IWYU: BinaryTypeTraitBase needs a declaration
-    // IWYU: BinaryTypeTraitDerived is...*binary_type_trait-i2.h
     // IWYU: BinaryTypeTraitDerived needs a declaration
     static_assert(!__is_convertible_to(BinaryTypeTraitDerived**, BinaryTypeTraitBase**),
         "Indirect pointers shouldn't be convertible");

--- a/tests/cxx/ptr_ref_aliases-d1.h
+++ b/tests/cxx/ptr_ref_aliases-d1.h
@@ -1,0 +1,32 @@
+//===--- ptr_ref_aliases-d1.h - test input file for iwyu ------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/ptr_ref_aliases-i1.h"
+
+struct Indirect;
+
+using NonProvidingPtrAlias = Indirect*;
+using NonProvidingRefAlias = Indirect&;
+
+using NonProvidingDoubleRefAlias = NonProvidingRefAlias&;
+using NonProvidingDoublePtrAlias = NonProvidingPtrAlias*;
+using NonProvidingRefPtrAlias = NonProvidingPtrAlias&;
+using NonProvidingDoubleRefPtrAlias = NonProvidingRefPtrAlias&;
+
+/**** IWYU_SUMMARY
+
+tests/cxx/ptr_ref_aliases-d1.h should add these lines:
+
+tests/cxx/ptr_ref_aliases-d1.h should remove these lines:
+- #include "tests/cxx/ptr_ref_aliases-i1.h"  // lines XX-XX
+
+The full include-list for tests/cxx/ptr_ref_aliases-d1.h:
+struct Indirect;  // lines XX-XX
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/ptr_ref_aliases-d2.h
+++ b/tests/cxx/ptr_ref_aliases-d2.h
@@ -1,0 +1,28 @@
+//===--- ptr_ref_aliases-d2.h - test input file for iwyu ------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/ptr_ref_aliases-i1.h"
+
+// IWYU: Indirect is...*ptr_ref_aliases-i2.h
+using ProvidingPtrAlias = Indirect*;
+// IWYU: Indirect is...*ptr_ref_aliases-i2.h
+using ProvidingRefAlias = Indirect&;
+
+/**** IWYU_SUMMARY
+
+tests/cxx/ptr_ref_aliases-d2.h should add these lines:
+#include "tests/cxx/ptr_ref_aliases-i2.h"
+
+tests/cxx/ptr_ref_aliases-d2.h should remove these lines:
+- #include "tests/cxx/ptr_ref_aliases-i1.h"  // lines XX-XX
+
+The full include-list for tests/cxx/ptr_ref_aliases-d2.h:
+#include "tests/cxx/ptr_ref_aliases-i2.h"  // for Indirect
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/ptr_ref_aliases-d3.h
+++ b/tests/cxx/ptr_ref_aliases-d3.h
@@ -1,0 +1,15 @@
+//===--- ptr_ref_aliases-d3.h - test input file for iwyu ------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef PTR_REF_ALIASES_D3_H_
+#define PTR_REF_ALIASES_D3_H_
+
+struct IndirectBase {};
+
+#endif

--- a/tests/cxx/ptr_ref_aliases-i1.h
+++ b/tests/cxx/ptr_ref_aliases-i1.h
@@ -1,0 +1,10 @@
+//===--- ptr_ref_aliases-i1.h - test input file for iwyu ------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/ptr_ref_aliases-i2.h"

--- a/tests/cxx/ptr_ref_aliases-i2.h
+++ b/tests/cxx/ptr_ref_aliases-i2.h
@@ -1,0 +1,22 @@
+//===--- ptr_ref_aliases-i2.h - test input file for iwyu ------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef PTR_REF_ALIASES_I2_H_
+#define PTR_REF_ALIASES_I2_H_
+
+#include "tests/cxx/ptr_ref_aliases-d3.h"
+
+struct Indirect : IndirectBase {
+  void Method();
+  int* begin() const;
+  int* end() const;
+  Indirect& operator<<(int);
+};
+
+#endif

--- a/tests/cxx/ptr_ref_aliases.cc
+++ b/tests/cxx/ptr_ref_aliases.cc
@@ -1,0 +1,182 @@
+//===--- ptr_ref_aliases.cc - test input file for iwyu --------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_ARGS: -Xiwyu --check_also=tests/cxx/ptr_ref_aliases-d1.h \
+//            -Xiwyu --check_also=tests/cxx/ptr_ref_aliases-d2.h \
+//            -I .
+
+// Tests various cases of type alias usages when the underlying type is
+// a pointer or a reference. Particularly, tests that `DerefKind` parameter
+// value is correct.
+
+#include "tests/cxx/ptr_ref_aliases-d1.h"
+#include "tests/cxx/ptr_ref_aliases-d2.h"
+#include "tests/cxx/ptr_ref_aliases-d3.h"
+#include <typeinfo>
+
+NonProvidingPtrAlias GetPtr();
+NonProvidingRefAlias GetRef();
+
+NonProvidingPtrAlias ptr_nonprovided = GetPtr();
+NonProvidingRefAlias ref_nonprovided = GetRef();
+
+ProvidingPtrAlias ptr_provided = GetPtr();
+ProvidingRefAlias ref_provided = GetRef();
+
+struct Base {
+  virtual IndirectBase* RetPtr1();
+  virtual IndirectBase& RetRef1();
+  virtual IndirectBase* RetPtr2();
+  virtual IndirectBase& RetRef2();
+};
+
+struct Derived : Base {
+  // IWYU: Indirect is...*ptr_ref_aliases-i2.h
+  NonProvidingPtrAlias RetPtr1() override;
+  // IWYU: Indirect is...*ptr_ref_aliases-i2.h
+  NonProvidingRefAlias RetRef1() override;
+  ProvidingPtrAlias RetPtr2() override;
+  ProvidingRefAlias RetRef2() override;
+};
+
+void Fn() {
+  (void)sizeof(NonProvidingPtrAlias);
+  (void)sizeof(ptr_nonprovided);
+  // IWYU: Indirect is...*ptr_ref_aliases-i2.h
+  (void)sizeof(NonProvidingRefAlias);
+  // IWYU: Indirect is...*ptr_ref_aliases-i2.h
+  (void)sizeof(ref_nonprovided);
+  (void)sizeof(ProvidingRefAlias);
+  // TODO: avoid unwanted reporting.
+  // IWYU: Indirect is...*ptr_ref_aliases-i2.h
+  (void)sizeof(ref_provided);
+
+  // IWYU: Indirect is...*ptr_ref_aliases-i2.h
+  ptr_nonprovided->Method();
+  // IWYU: Indirect is...*ptr_ref_aliases-i2.h
+  ref_nonprovided.Method();
+  ptr_provided->Method();
+  // TODO: avoid unwanted reporting.
+  // IWYU: Indirect is...*ptr_ref_aliases-i2.h
+  ref_provided.Method();
+
+  try {
+    // IWYU: Indirect is...*ptr_ref_aliases-i2.h
+  } catch (NonProvidingPtrAlias) {
+    // IWYU: Indirect is...*ptr_ref_aliases-i2.h
+  } catch (NonProvidingRefAlias) {
+  }
+  try {
+  } catch (ProvidingPtrAlias) {
+  } catch (ProvidingRefAlias) {
+  }
+
+  // IWYU: Indirect is...*ptr_ref_aliases-i2.h
+  for (auto i : ref_nonprovided)
+    ;
+  // TODO: avoid unwanted reporting.
+  // IWYU: Indirect is...*ptr_ref_aliases-i2.h
+  for (auto i : ref_provided)
+    ;
+
+  IndirectBase* pB = nullptr;
+  // IWYU: Indirect is...*ptr_ref_aliases-i2.h
+  (void)static_cast<NonProvidingPtrAlias>(pB);
+  // IWYU: Indirect is...*ptr_ref_aliases-i2.h
+  (void)static_cast<NonProvidingRefAlias>(*pB);
+  (void)static_cast<ProvidingPtrAlias>(pB);
+  // TODO: avoid unwanted reporting.
+  // IWYU: Indirect is...*ptr_ref_aliases-i2.h
+  (void)static_cast<ProvidingRefAlias>(*pB);
+
+  // IWYU: Indirect is...*ptr_ref_aliases-i2.h
+  (void)ptr_nonprovided[1];
+  (void)ptr_provided[1];
+
+  // IWYU: Indirect is...*ptr_ref_aliases-i2.h
+  (void)(ptr_nonprovided + 1);
+  (void)(ptr_provided + 1);
+
+  // IWYU: Indirect is...*ptr_ref_aliases-i2.h
+  static_assert(__is_convertible_to(NonProvidingPtrAlias, IndirectBase*));
+  // IWYU: Indirect is...*ptr_ref_aliases-i2.h
+  static_assert(__is_convertible_to(NonProvidingRefAlias, IndirectBase&));
+  static_assert(__is_convertible_to(ProvidingPtrAlias, IndirectBase*));
+  static_assert(__is_convertible_to(ProvidingRefAlias, IndirectBase&));
+
+  // IWYU: Indirect is...*ptr_ref_aliases-i2.h
+  ref_nonprovided << 1;
+  // TODO: avoid unwanted reporting.
+  // IWYU: Indirect is...*ptr_ref_aliases-i2.h
+  ref_provided << 1;
+
+  // IWYU: Indirect is...*ptr_ref_aliases-i2.h
+  delete ptr_nonprovided;
+  delete ptr_provided;
+
+  int VarArgFn(...);
+  // It is important to keep VarArgFn calls in unevaluated context, otherwise
+  // CXXConstructExpr nodes appear which should be handled likewise other
+  // implicit construction cases. Btw, clang accepts such code without complete
+  // argument type, but gcc doesn't.
+  (void)sizeof(VarArgFn(ptr_nonprovided));
+  // IWYU: Indirect is...*ptr_ref_aliases-i2.h
+  (void)sizeof(VarArgFn(ref_nonprovided));
+  (void)sizeof(VarArgFn(ptr_provided));
+  // TODO: avoid unwanted reporting.
+  // IWYU: Indirect is...*ptr_ref_aliases-i2.h
+  (void)sizeof(VarArgFn(ref_provided));
+
+  const std::type_info& type_info1 = typeid(NonProvidingPtrAlias);
+  // IWYU: Indirect is...*ptr_ref_aliases-i2.h
+  const std::type_info& type_info2 = typeid(NonProvidingRefAlias);
+  const std::type_info& type_info3 = typeid(ProvidingPtrAlias);
+  const std::type_info& type_info4 = typeid(ProvidingRefAlias);
+}
+
+namespace ns {
+using ::NonProvidingPtrAlias;
+using ::NonProvidingRefAlias;
+using ::ProvidingPtrAlias;
+using ::ProvidingRefAlias;
+}  // namespace ns
+
+ns::NonProvidingPtrAlias ptr_nonprovided_with_using = GetPtr();
+ns::NonProvidingRefAlias ref_nonprovided_with_using = GetRef();
+
+ns::ProvidingPtrAlias ptr_provided_with_using = GetPtr();
+ns::ProvidingRefAlias ref_provided_with_using = GetRef();
+
+void TestSomeComplexIndirectionCases() {
+  // IWYU: Indirect is...*ptr_ref_aliases-i2.h
+  (void)sizeof(NonProvidingDoubleRefAlias);
+
+  NonProvidingRefPtrAlias GetPtrRef();
+  NonProvidingDoubleRefPtrAlias ptr_ref = GetPtrRef();
+  // IWYU: Indirect is...*ptr_ref_aliases-i2.h
+  (void)ptr_ref[1];
+  NonProvidingDoublePtrAlias ptr_ptr = nullptr;
+  (void)ptr_ptr[1];
+}
+
+/**** IWYU_SUMMARY
+
+tests/cxx/ptr_ref_aliases.cc should add these lines:
+#include "tests/cxx/ptr_ref_aliases-i2.h"
+
+tests/cxx/ptr_ref_aliases.cc should remove these lines:
+
+The full include-list for tests/cxx/ptr_ref_aliases.cc:
+#include <typeinfo>  // for type_info
+#include "tests/cxx/ptr_ref_aliases-d1.h"  // for NonProvidingDoublePtrAlias, NonProvidingDoubleRefAlias, NonProvidingDoubleRefPtrAlias, NonProvidingPtrAlias, NonProvidingRefAlias, NonProvidingRefPtrAlias
+#include "tests/cxx/ptr_ref_aliases-d2.h"  // for ProvidingPtrAlias, ProvidingRefAlias
+#include "tests/cxx/ptr_ref_aliases-d3.h"  // for IndirectBase
+#include "tests/cxx/ptr_ref_aliases-i2.h"  // for Indirect
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/ptr_ref_aliases.cc
+++ b/tests/cxx/ptr_ref_aliases.cc
@@ -53,8 +53,6 @@ void Fn() {
   // IWYU: Indirect is...*ptr_ref_aliases-i2.h
   (void)sizeof(ref_nonprovided);
   (void)sizeof(ProvidingRefAlias);
-  // TODO: avoid unwanted reporting.
-  // IWYU: Indirect is...*ptr_ref_aliases-i2.h
   (void)sizeof(ref_provided);
 
   // IWYU: Indirect is...*ptr_ref_aliases-i2.h
@@ -62,8 +60,6 @@ void Fn() {
   // IWYU: Indirect is...*ptr_ref_aliases-i2.h
   ref_nonprovided.Method();
   ptr_provided->Method();
-  // TODO: avoid unwanted reporting.
-  // IWYU: Indirect is...*ptr_ref_aliases-i2.h
   ref_provided.Method();
 
   try {
@@ -80,8 +76,6 @@ void Fn() {
   // IWYU: Indirect is...*ptr_ref_aliases-i2.h
   for (auto i : ref_nonprovided)
     ;
-  // TODO: avoid unwanted reporting.
-  // IWYU: Indirect is...*ptr_ref_aliases-i2.h
   for (auto i : ref_provided)
     ;
 
@@ -91,8 +85,6 @@ void Fn() {
   // IWYU: Indirect is...*ptr_ref_aliases-i2.h
   (void)static_cast<NonProvidingRefAlias>(*pB);
   (void)static_cast<ProvidingPtrAlias>(pB);
-  // TODO: avoid unwanted reporting.
-  // IWYU: Indirect is...*ptr_ref_aliases-i2.h
   (void)static_cast<ProvidingRefAlias>(*pB);
 
   // IWYU: Indirect is...*ptr_ref_aliases-i2.h
@@ -112,8 +104,6 @@ void Fn() {
 
   // IWYU: Indirect is...*ptr_ref_aliases-i2.h
   ref_nonprovided << 1;
-  // TODO: avoid unwanted reporting.
-  // IWYU: Indirect is...*ptr_ref_aliases-i2.h
   ref_provided << 1;
 
   // IWYU: Indirect is...*ptr_ref_aliases-i2.h
@@ -129,8 +119,6 @@ void Fn() {
   // IWYU: Indirect is...*ptr_ref_aliases-i2.h
   (void)sizeof(VarArgFn(ref_nonprovided));
   (void)sizeof(VarArgFn(ptr_provided));
-  // TODO: avoid unwanted reporting.
-  // IWYU: Indirect is...*ptr_ref_aliases-i2.h
   (void)sizeof(VarArgFn(ref_provided));
 
   const std::type_info& type_info1 = typeid(NonProvidingPtrAlias);


### PR DESCRIPTION
In some cases, IWYU produced redundant usage reports of type alias underlying types when the direct type under alias is a pointer or a reference. The reason is that the type alias uses were handled in `ReportTypeUse` uniformly regardless of context, and context-dependent dereferencing was in specific `Visit...` functions, but that dereferencing was not applied to type aliases (`typedef`s or C++11 type aliases). Indeed, it should not be applied to them in those functions because `ReportTypeUse` is the central place to analyze type aliases (with respect to underlying type "provision" status). But
the handling should be different in various contexts. E. g., when an alias hides a pointer:
```cpp
typedef Class* ClassPtr;
```
a use of such an alias in a variable declaration:
```cpp
ClassPtr object_ptr;
```
doesn't constitute full type use, whereas a use in a `catch(ClassPtr)` statement does.

Three cases have been found:
* direct use (doesn't require complete pointed-to or referenced type; e. g. in variable declarations; `UseKind::Direct`),
* referenced type use (e.g. in `sizeof` expressions; references are stripped before reporting; `UseKind::RemoveRefs`), and
* pointed-to type use (e.g. in array subscript expressions; at most one pointer and, possibly, references are stripped before reporting; `UseKind::RemoveRefsAndPtr`).

Hence, `UseKind` parameter is introduced into `ReportTypeUse` interface. Pointers and references are stripped from type alias underlying type during recursive calls of `ReportTypeUseInternal` with respect to the value of that parameter. Explicit pointer or refererence removals are removed (sorry for pun) from specific `Visit...` functions.

`VisitCXXDeleteExpr` function checked previously that the pointed-to type isn't a pointer itself. It isn't needed anymore as well, because `ReportTypeUse` performs at most one pointer removal.

In `InstantiatedTemplateVisitor::ReportTypeUse`, a slightly simplified `UseKind` handling logic is used because there is seemingly no need to handle type aliases (`resugar_map_` and `blocked_types_` define already which types can be reported and which should not due to their "provision" status). But that code (despite it duplicates base class logic somehow) is still needed: without it, the `type` may not be found in `resugar_map_`.

The changes in the `binary_type_trait` test look reasonable: full type is not needed to claim that pointers to pointers to different types aren't convertible to each other, even when the types are related by inheritance.

Determination of expression type is improved (`GetTypeOf` and related changes). But there is one suspicious thing: range-based `for` initializer expression type was checked for `nullptr` previously. I don't know whether that `nullptr` happens in real life or not.

Because C++11 type aliases and old C-style `typedef`s are handled by the same code, this PR is a step towards an important milestone: the full C89 support!