### PR TITLE
Analyze class template bases

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -120,6 +120,7 @@
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclBase.h"
+#include "clang/AST/DeclCXX.h"
 #include "clang/AST/DeclTemplate.h"
 #include "clang/AST/ExprConcepts.h"
 #include "clang/AST/NestedNameSpecifier.h"
@@ -148,6 +149,7 @@ using clang::ASTConsumer;
 using clang::ASTContext;
 using clang::ASTFrontendAction;
 using clang::Attr;
+using clang::CXXBaseSpecifier;
 using clang::CXXConstructExpr;
 using clang::CXXConstructorDecl;
 using clang::CXXDeleteExpr;
@@ -3485,6 +3487,11 @@ class InstantiatedTemplateVisitor
       if (isa<CXXMethodDecl>(*it) || isa<FunctionTemplateDecl>(*it))
         continue;
       if (!TraverseDecl(*it))
+        return false;
+    }
+
+    for (const CXXBaseSpecifier& base : class_decl->bases()) {
+      if (!TraverseType(base.getType()))
         return false;
     }
 

--- a/tests/cxx/template_base.cc
+++ b/tests/cxx/template_base.cc
@@ -1,0 +1,62 @@
+//===--- template_base.cc - test input file for iwyu ----------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_ARGS: -I .
+
+// Tests reporting types needed for class template base instantiation.
+
+#include "tests/cxx/direct.h"
+
+template <typename T>
+struct DirectInheritance : T {
+  struct Inner {};
+};
+
+template <typename T>
+struct InheritanceFromTplInheritedFromT : DirectInheritance<T> {};
+
+template <typename T>
+struct TplInBaseNNS : InheritanceFromTplInheritedFromT<T>::Inner {};
+
+// IWYU: IndirectClass needs a declaration
+// IWYU: IndirectClass is...*indirect.h
+constexpr auto s1 = sizeof(TplInBaseNNS<IndirectClass>);
+
+template <typename T>
+// TODO(bolshakov): forward-declaration is probably sufficient.
+// IWYU: IndirectTemplate is...*indirect.h
+struct InheritanceFromTplWithTMember : IndirectTemplate<T> {};
+
+// IWYU: IndirectClass needs a declaration
+// IWYU: IndirectClass is...*indirect.h
+constexpr auto s2 = sizeof(InheritanceFromTplWithTMember<IndirectClass>);
+
+template <typename T>
+struct PtrOnly {
+  T* t;
+};
+
+template <typename T>
+struct InheritanceFromPtrOnly : PtrOnly<T> {};
+
+// IWYU: IndirectClass needs a declaration
+constexpr auto s3 = sizeof(InheritanceFromPtrOnly<IndirectClass>);
+
+/**** IWYU_SUMMARY
+
+tests/cxx/template_base.cc should add these lines:
+#include "tests/cxx/indirect.h"
+
+tests/cxx/template_base.cc should remove these lines:
+- #include "tests/cxx/direct.h"  // lines XX-XX
+
+The full include-list for tests/cxx/template_base.cc:
+#include "tests/cxx/indirect.h"  // for IndirectClass, IndirectTemplate
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
Previously, class template bases were handled on definitions of template specialization type variables due to the traversal of member initializer list of (probably implicit) constructor. It didn't work for other contexts, such as taking `sizeof` template specialization type.