### PR TITLE
Update precomputed STL type list

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -3538,7 +3538,8 @@ class InstantiatedTemplateVisitor
     // This says how the template-args are used by this hard-coded type
     // (a set<>, or map<>, or ...), to avoid having to recurse into them.
     const map<const Type*, const Type*>& resugar_map_for_precomputed_type =
-        FullUseCache::GetPrecomputedResugarMap(tpl_type);
+        FullUseCache::GetPrecomputedResugarMap(tpl_type,
+                                               compiler()->getLangOpts());
     // But we need to reconcile that with the types-of-interest, as
     // stored in resugar_map_.  To do this, we take only those entries
     // from resugar_map_for_precomputed_type that are also present in

--- a/iwyu_cache.cc
+++ b/iwyu_cache.cc
@@ -36,18 +36,18 @@ namespace include_what_you_use {
 // required full use of MyClass, but not of allocator<MyClass>).
 // TODO(csilvers): put this somewhere easier to modify, and add to it.
 static const char* const kFullUseTypes[] = {
-  "__gnu_cxx::hash_map",
-  "__gnu_cxx::hash_multimap",
-  "__gnu_cxx::hash_multiset",
-  "__gnu_cxx::hash_set",
-  "std::deque",
-  "std::list",
-  "std::map",
-  "std::multimap",
-  "std::multiset",
-  "std::set",
-  "std::slist",
-  "std::vector",
+    "__gnu_cxx::hash_map",
+    "__gnu_cxx::hash_multimap",
+    "__gnu_cxx::hash_multiset",
+    "__gnu_cxx::hash_set",
+    "std::deque",
+    "std::list",
+    "std::map",
+    "std::multimap",
+    "std::multiset",
+    "std::set",
+    "std::slist",
+    "std::vector",
 };
 
 // If the passed-in tpl_decl is one of the classes we have hard-coded
@@ -60,8 +60,8 @@ static const char* const kFullUseTypes[] = {
 // to instantiate methods, making the hard-coding much easier.
 map<const Type*, const Type*> FullUseCache::GetPrecomputedResugarMap(
     const TemplateSpecializationType* tpl_type) {
-  static const int fulluse_size = (sizeof(kFullUseTypes) /
-                                   sizeof(*kFullUseTypes));
+  static const int fulluse_size =
+      (sizeof(kFullUseTypes) / sizeof(*kFullUseTypes));
   static const set<string> fulluse_types(kFullUseTypes,
                                          kFullUseTypes + fulluse_size);
 
@@ -76,8 +76,8 @@ map<const Type*, const Type*> FullUseCache::GetPrecomputedResugarMap(
           DynCastFrom(tpl_decl)) {
     const TemplateArgumentList& all_tpl_args = tpl_spec_decl->getTemplateArgs();
     for (unsigned i = 0; i < all_tpl_args.size(); ++i) {
-      CHECK_((all_tpl_args.get(i).getKind() == TemplateArgument::Type)
-             && "kFullUseType types must contain only 'type' template args");
+      CHECK_((all_tpl_args.get(i).getKind() == TemplateArgument::Type) &&
+             "kFullUseType types must contain only 'type' template args");
     }
   }
 

--- a/iwyu_cache.cc
+++ b/iwyu_cache.cc
@@ -48,6 +48,10 @@ static const char* const kFullUseTypes[] = {
     "std::multiset",
     "std::set",
     "std::slist",
+    "std::unordered_map",
+    "std::unordered_multimap",
+    "std::unordered_multiset",
+    "std::unordered_set",
 };
 
 // If the passed-in tpl_decl is one of the classes we have hard-coded
@@ -64,7 +68,7 @@ map<const Type*, const Type*> FullUseCache::GetPrecomputedResugarMap(
       (sizeof(kFullUseTypes) / sizeof(*kFullUseTypes));
   set<string> fulluse_types(kFullUseTypes, kFullUseTypes + fulluse_size);
   if (!lang_opts.CPlusPlus17)
-    fulluse_types.insert({"std::list", "std::vector"});
+    fulluse_types.insert({"std::forward_list", "std::list", "std::vector"});
 
   const NamedDecl* tpl_decl = TypeToDeclAsWritten(tpl_type);
   if (!ContainsKey(fulluse_types, GetWrittenQualifiedNameAsString(tpl_decl)))

--- a/iwyu_cache.h
+++ b/iwyu_cache.h
@@ -23,6 +23,7 @@
 #include "iwyu_stl_util.h"
 
 namespace clang {
+class LangOptions;
 class NamedDecl;
 class TemplateSpecializationType;
 class Type;
@@ -114,7 +115,8 @@ class FullUseCache {
   // available via GetFullUseType(), which does not have this problem
   // with sugaring.
   static map<const clang::Type*, const clang::Type*> GetPrecomputedResugarMap(
-      const clang::TemplateSpecializationType* tpl_type);
+      const clang::TemplateSpecializationType* tpl_type,
+      const clang::LangOptions&);
 
  private:
   map<Key, Value> cache_;

--- a/tests/cxx/precomputed_tpl_args.cc
+++ b/tests/cxx/precomputed_tpl_args.cc
@@ -11,6 +11,7 @@
 
 // Tests the precomputed template-arg-use list in iwyu_cache.cc.
 
+#include <list>
 #include <vector>
 #include <set>
 #include <map>
@@ -80,6 +81,34 @@ TemplatedClass<IndirectClass> tc_ic;
 // IWYU: SpecializationClass is...*precomputed_tpl_args-i1.h
 TemplatedClass<SpecializationClass> tc_sc;
 
+void Fn() {
+  // Since C++17, full contained type isn't needed for std::vector, std::list,
+  // and std::forward_list instantiations.
+  // IWYU: IndirectClass needs a declaration
+  (void)sizeof(std::vector<IndirectClass>);
+  // IWYU: IndirectClass needs a declaration
+  (void)sizeof(std::list<IndirectClass>);
+
+  // Full type is still needed for the other standard containers.
+  // IWYU: IndirectClass needs a declaration
+  // IWYU: IndirectClass is...*precomputed_tpl_args-i1.h
+  (void)sizeof(std::set<IndirectClass>);
+  // IWYU: IndirectClass needs a declaration
+  // IWYU: IndirectClass is...*precomputed_tpl_args-i1.h
+  (void)sizeof(std::multiset<IndirectClass>);
+  // IWYU: IndirectClass needs a declaration
+  // IWYU: IndirectClass is...*precomputed_tpl_args-i1.h
+  (void)sizeof(std::map<IndirectClass, int>);
+  // IWYU: IndirectClass needs a declaration
+  // IWYU: IndirectClass is...*precomputed_tpl_args-i1.h
+  (void)sizeof(std::multimap<IndirectClass, int>);
+
+  // Full type is required for, e.g., destroying sequence containers.
+  // IWYU: IndirectClass needs a declaration
+  std::list<IndirectClass>* l = nullptr;
+  // IWYU: IndirectClass is...*precomputed_tpl_args-i1.h
+  delete l;
+}
 
 /**** IWYU_SUMMARY
 
@@ -90,8 +119,9 @@ tests/cxx/precomputed_tpl_args.cc should remove these lines:
 
 The full include-list for tests/cxx/precomputed_tpl_args.cc:
 #include <bitset>  // for bitset
-#include <map>  // for map
-#include <set>  // for set
+#include <list>  // for list
+#include <map>  // for map, multimap
+#include <set>  // for multiset, set
 #include <vector>  // for vector
 #include "tests/cxx/precomputed_tpl_args-d1.h"  // for D1SpecializationClass, less
 #include "tests/cxx/precomputed_tpl_args-i1.h"  // for IndirectClass, SpecializationClass, less

--- a/tests/cxx/precomputed_tpl_args.cc
+++ b/tests/cxx/precomputed_tpl_args.cc
@@ -11,10 +11,13 @@
 
 // Tests the precomputed template-arg-use list in iwyu_cache.cc.
 
+#include <forward_list>
 #include <list>
 #include <vector>
 #include <set>
 #include <map>
+#include <unordered_map>
+#include <unordered_set>
 #include <bitset>
 #include "tests/cxx/precomputed_tpl_args-d1.h"
 
@@ -88,6 +91,8 @@ void Fn() {
   (void)sizeof(std::vector<IndirectClass>);
   // IWYU: IndirectClass needs a declaration
   (void)sizeof(std::list<IndirectClass>);
+  // IWYU: IndirectClass needs a declaration
+  (void)sizeof(std::forward_list<IndirectClass>);
 
   // Full type is still needed for the other standard containers.
   // IWYU: IndirectClass needs a declaration
@@ -102,12 +107,28 @@ void Fn() {
   // IWYU: IndirectClass needs a declaration
   // IWYU: IndirectClass is...*precomputed_tpl_args-i1.h
   (void)sizeof(std::multimap<IndirectClass, int>);
+  // IWYU: IndirectClass needs a declaration
+  // IWYU: IndirectClass is...*precomputed_tpl_args-i1.h
+  (void)sizeof(std::unordered_set<IndirectClass>);
+  // IWYU: IndirectClass needs a declaration
+  // IWYU: IndirectClass is...*precomputed_tpl_args-i1.h
+  (void)sizeof(std::unordered_multiset<IndirectClass>);
+  // IWYU: IndirectClass needs a declaration
+  // IWYU: IndirectClass is...*precomputed_tpl_args-i1.h
+  (void)sizeof(std::unordered_map<IndirectClass, int>);
+  // IWYU: IndirectClass needs a declaration
+  // IWYU: IndirectClass is...*precomputed_tpl_args-i1.h
+  (void)sizeof(std::unordered_multimap<IndirectClass, int>);
 
   // Full type is required for, e.g., destroying sequence containers.
   // IWYU: IndirectClass needs a declaration
   std::list<IndirectClass>* l = nullptr;
   // IWYU: IndirectClass is...*precomputed_tpl_args-i1.h
   delete l;
+  // IWYU: IndirectClass needs a declaration
+  std::forward_list<IndirectClass>* fl = nullptr;
+  // IWYU: IndirectClass is...*precomputed_tpl_args-i1.h
+  delete fl;
 }
 
 /**** IWYU_SUMMARY
@@ -119,9 +140,12 @@ tests/cxx/precomputed_tpl_args.cc should remove these lines:
 
 The full include-list for tests/cxx/precomputed_tpl_args.cc:
 #include <bitset>  // for bitset
+#include <forward_list>  // for forward_list
 #include <list>  // for list
 #include <map>  // for map, multimap
 #include <set>  // for multiset, set
+#include <unordered_map>  // for unordered_map, unordered_multimap
+#include <unordered_set>  // for unordered_multiset, unordered_set
 #include <vector>  // for vector
 #include "tests/cxx/precomputed_tpl_args-d1.h"  // for D1SpecializationClass, less
 #include "tests/cxx/precomputed_tpl_args-i1.h"  // for IndirectClass, SpecializationClass, less

--- a/tests/cxx/precomputed_tpl_args_cpp14.cc
+++ b/tests/cxx/precomputed_tpl_args_cpp14.cc
@@ -1,0 +1,63 @@
+//===--- precomputed_tpl_args_cpp14.cc - test input file for iwyu ---------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_ARGS: -I . --std=c++14
+
+// Tests full contained type requirements for STL containers in C++14.
+// Full contained type info is required for an instantiation according
+// to the standard even if no one member function is called.
+
+#include <deque>
+#include <list>
+#include <map>
+#include <set>
+#include <vector>
+#include "tests/cxx/direct.h"
+
+void Fn() {
+  // IWYU: IndirectClass needs a declaration
+  // IWYU: IndirectClass is...*indirect.h
+  (void)sizeof(std::vector<IndirectClass>);
+  // IWYU: IndirectClass needs a declaration
+  // IWYU: IndirectClass is...*indirect.h
+  (void)sizeof(std::deque<IndirectClass>);
+  // IWYU: IndirectClass needs a declaration
+  // IWYU: IndirectClass is...*indirect.h
+  (void)sizeof(std::list<IndirectClass>);
+  // IWYU: IndirectClass needs a declaration
+  // IWYU: IndirectClass is...*indirect.h
+  (void)sizeof(std::set<IndirectClass>);
+  // IWYU: IndirectClass needs a declaration
+  // IWYU: IndirectClass is...*indirect.h
+  (void)sizeof(std::multiset<IndirectClass>);
+  // IWYU: IndirectClass needs a declaration
+  // IWYU: IndirectClass is...*indirect.h
+  (void)sizeof(std::map<IndirectClass, int>);
+  // IWYU: IndirectClass needs a declaration
+  // IWYU: IndirectClass is...*indirect.h
+  (void)sizeof(std::multimap<IndirectClass, int>);
+}
+
+/**** IWYU_SUMMARY
+
+tests/cxx/precomputed_tpl_args_cpp14.cc should add these lines:
+#include "tests/cxx/indirect.h"
+
+tests/cxx/precomputed_tpl_args_cpp14.cc should remove these lines:
+- #include "tests/cxx/direct.h"  // lines XX-XX
+
+The full include-list for tests/cxx/precomputed_tpl_args_cpp14.cc:
+#include <deque>  // for deque
+#include <list>  // for list
+#include <map>  // for map, multimap
+#include <set>  // for multiset, set
+#include <vector>  // for vector
+#include "tests/cxx/indirect.h"  // for IndirectClass
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/precomputed_tpl_args_cpp14.cc
+++ b/tests/cxx/precomputed_tpl_args_cpp14.cc
@@ -14,9 +14,12 @@
 // to the standard even if no one member function is called.
 
 #include <deque>
+#include <forward_list>
 #include <list>
 #include <map>
 #include <set>
+#include <unordered_map>
+#include <unordered_set>
 #include <vector>
 #include "tests/cxx/direct.h"
 
@@ -32,6 +35,9 @@ void Fn() {
   (void)sizeof(std::list<IndirectClass>);
   // IWYU: IndirectClass needs a declaration
   // IWYU: IndirectClass is...*indirect.h
+  (void)sizeof(std::forward_list<IndirectClass>);
+  // IWYU: IndirectClass needs a declaration
+  // IWYU: IndirectClass is...*indirect.h
   (void)sizeof(std::set<IndirectClass>);
   // IWYU: IndirectClass needs a declaration
   // IWYU: IndirectClass is...*indirect.h
@@ -42,6 +48,18 @@ void Fn() {
   // IWYU: IndirectClass needs a declaration
   // IWYU: IndirectClass is...*indirect.h
   (void)sizeof(std::multimap<IndirectClass, int>);
+  // IWYU: IndirectClass needs a declaration
+  // IWYU: IndirectClass is...*indirect.h
+  (void)sizeof(std::unordered_set<IndirectClass>);
+  // IWYU: IndirectClass needs a declaration
+  // IWYU: IndirectClass is...*indirect.h
+  (void)sizeof(std::unordered_multiset<IndirectClass>);
+  // IWYU: IndirectClass needs a declaration
+  // IWYU: IndirectClass is...*indirect.h
+  (void)sizeof(std::unordered_map<IndirectClass, int>);
+  // IWYU: IndirectClass needs a declaration
+  // IWYU: IndirectClass is...*indirect.h
+  (void)sizeof(std::unordered_multimap<IndirectClass, int>);
 }
 
 /**** IWYU_SUMMARY
@@ -54,9 +72,12 @@ tests/cxx/precomputed_tpl_args_cpp14.cc should remove these lines:
 
 The full include-list for tests/cxx/precomputed_tpl_args_cpp14.cc:
 #include <deque>  // for deque
+#include <forward_list>  // for forward_list
 #include <list>  // for list
 #include <map>  // for map, multimap
 #include <set>  // for multiset, set
+#include <unordered_map>  // for unordered_map, unordered_multimap
+#include <unordered_set>  // for unordered_multiset, unordered_set
 #include <vector>  // for vector
 #include "tests/cxx/indirect.h"  // for IndirectClass
 


### PR DESCRIPTION
C++17 doesn't require full contained type info for `std::vector`, `std::list`, and `std::forward_list` instantiations (see [N4510](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/n4510.html)). The full info is needed only when any of container class members is referenced.

Some more STL containers have been added to precomputed list. Unordered associative containers need contained type to be complete at instantiation point. `std::forward_list` - only before C++17.