### PR TITLE
Correct traversal of class template explicit instantiations

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -576,15 +576,6 @@ class BaseAstVisitor : public RecursiveASTVisitor<Derived> {
     return true;
   }
 
-  // Class template specialization are similar to regular C++ classes,
-  // particularly they need the same custom handling of implicit destructors.
-  bool TraverseClassTemplateSpecializationDecl(
-      clang::ClassTemplateSpecializationDecl* decl) {
-    if (!Base::TraverseClassTemplateSpecializationDecl(decl))
-      return false;
-    return Base::TraverseCXXRecordDecl(decl);
-  }
-
   //------------------------------------------------------------
   // (5) Add TraverseImplicitDestructorCall and HandleFunctionCall.
 
@@ -3127,7 +3118,8 @@ class InstantiatedTemplateVisitor
         VERRS(6) << "Recursively traversing " << PrintableDecl(cts_decl)
                  << " which was full-used and does not involve a known"
                  << " template param\n";
-        TraverseDecl(const_cast<ClassTemplateSpecializationDecl*>(cts_decl));
+        TraverseCXXRecordDecl(
+            const_cast<ClassTemplateSpecializationDecl*>(cts_decl));
       }
     }
   }

--- a/iwyu.cc
+++ b/iwyu.cc
@@ -3981,16 +3981,18 @@ class IwyuAstConsumer
   // are handled in 'VisitTemplateSpecializationType', as usual.
   bool VisitClassTemplateSpecializationDecl(
       clang::ClassTemplateSpecializationDecl* decl) {
-    if (CanIgnoreCurrentASTNode())
-      return true;
-
     if (!IsExplicitInstantiation(decl)) {
-      ReportDeclForwardDeclareUse(CurrentLoc(), decl->getSpecializedTemplate());
+      if (!CanIgnoreCurrentASTNode()) {
+        ReportDeclForwardDeclareUse(CurrentLoc(),
+                                    decl->getSpecializedTemplate());
+      }
     } else if (IsExplicitInstantiationDefinitionAsWritten(decl)) {
       // Explicit instantiation definition causes instantiation of all
       // the template methods. Scan them here to assure that all the needed
       // template argument types are '#include'd.
       const TypeLoc type_loc = decl->getTypeAsWritten()->getTypeLoc();
+      if (CanIgnoreLocation(GetLocation(&type_loc)))
+        return true;
       // Clang attributes 'ClassTemplateSpecializationDecl' to the original
       // template location. Construct a new node corresponding to the template
       // spec type location (as written) so that reportings from

--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -1055,6 +1055,15 @@ bool IsExplicitInstantiation(const clang::Decl* decl) {
          kind == clang::TSK_ExplicitInstantiationDefinition;
 }
 
+bool IsExplicitInstantiationDefinitionAsWritten(
+    const clang::ClassTemplateSpecializationDecl* decl) {
+  // When swithing instantiation declaration to definition, clang preserves
+  // the 'extern' keyword location info.
+  return decl->getSpecializationKind() ==
+             clang::TSK_ExplicitInstantiationDefinition &&
+         decl->getExternLoc().isInvalid();
+}
+
 bool IsInInlineNamespace(const Decl* decl) {
   const DeclContext* dc = decl->getDeclContext();
   for (; dc; dc = dc->getParent()) {

--- a/iwyu_ast_util.h
+++ b/iwyu_ast_util.h
@@ -37,6 +37,7 @@ class CXXRecordDecl;
 class CallExpr;
 class CastExpr;
 class ClassTemplateDecl;
+class ClassTemplateSpecializationDecl;
 class Expr;
 class FunctionDecl;
 class NamedDecl;
@@ -623,6 +624,14 @@ bool IsFriendDecl(const clang::Decl* decl);
 // Returns true if this decl is an explicit template instantiation declaration
 // or definition.
 bool IsExplicitInstantiation(const clang::Decl* decl);
+
+// If an explicit instantiation definition follows the corresponding explicit
+// instantiation declaration, clang marks the first declaration as definition.
+// This function returns true if the given specialization declaration
+// corresponds to the genuine instantiation definition, as written
+// in the source.
+bool IsExplicitInstantiationDefinitionAsWritten(
+    const clang::ClassTemplateSpecializationDecl*);
 
 // Returns true if this decl is nested inside an inline namespace.
 bool IsInInlineNamespace(const clang::Decl* decl);

--- a/tests/cxx/expl_inst_select.cc
+++ b/tests/cxx/expl_inst_select.cc
@@ -19,7 +19,6 @@
 template class Template<char>;
 
 // An explicit instantiation declaration for later use.
-// IWYU: Template needs a declaration...*
 // IWYU: Template is...*expl_inst_select-i1.h
 extern template class Template<int>;
 

--- a/tests/cxx/explicit_instantiation-template.h
+++ b/tests/cxx/explicit_instantiation-template.h
@@ -21,6 +21,20 @@ class Template {
   Inner<T> x;
 };
 
+template <typename T>
+class ClassWithUsingMethod {
+  void Fn() {
+    T t;
+  }
+};
+
+template <typename T>
+class ClassWithMethodUsingPtr {
+  void Fn() {
+    T* t;
+  }
+};
+
 #endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_EXPLICIT_INSTANTIATION_TEMPLATE_H_
 
 /**** IWYU_SUMMARY

--- a/tests/cxx/explicit_instantiation-template.h
+++ b/tests/cxx/explicit_instantiation-template.h
@@ -9,6 +9,27 @@
 #ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_EXPLICIT_INSTANTIATION_TEMPLATE_H_
 #define INCLUDE_WHAT_YOU_USE_TESTS_CXX_EXPLICIT_INSTANTIATION_TEMPLATE_H_
 
-template<typename T> class Template {};
+#include "tests/cxx/direct.h"
+
+template <typename T>
+class Inner {
+  T t;
+};
+
+template <typename T>
+class Template {
+  Inner<T> x;
+};
 
 #endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_EXPLICIT_INSTANTIATION_TEMPLATE_H_
+
+/**** IWYU_SUMMARY
+
+tests/cxx/explicit_instantiation-template.h should add these lines:
+
+tests/cxx/explicit_instantiation-template.h should remove these lines:
+- #include "tests/cxx/direct.h"  // lines XX-XX
+
+The full include-list for tests/cxx/explicit_instantiation-template.h:
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/explicit_instantiation-template2.h
+++ b/tests/cxx/explicit_instantiation-template2.h
@@ -1,0 +1,15 @@
+//===--- explicit_instantiation-template2.h - test input file for iwyu ----===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+template <typename T>
+class ClassWithUsingMethod2 {
+  void Fn() {
+    T t;
+  }
+};

--- a/tests/cxx/explicit_instantiation.cc
+++ b/tests/cxx/explicit_instantiation.cc
@@ -7,7 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-// IWYU_ARGS: -Xiwyu --check_also="tests/cxx/explicit_instantiation-spec.h" -I .
+// IWYU_ARGS: -Xiwyu --check_also=tests/cxx/explicit_instantiation-spec.h \
+//            -Xiwyu --check_also=tests/cxx/explicit_instantiation-template.h \
+//            -I .
 
 #include "tests/cxx/explicit_instantiation-spec.h"
 #include "tests/cxx/explicit_instantiation-template_direct.h"
@@ -40,10 +42,20 @@ extern template class Template<char>;
 extern template class Template<int*>;
 template class Template<int*>;
 
+// IWYU: Template is...*explicit_instantiation-template.h
+// IWYU: IndirectClass needs a declaration
+// IWYU: IndirectClass is...*indirect.h
+extern template class Template<IndirectClass>;
+// IWYU: Template is...*explicit_instantiation-template.h
+// IWYU: IndirectClass needs a declaration
+// IWYU: IndirectClass is...*indirect.h
+template class Template<IndirectClass>;
+
 /**** IWYU_SUMMARY
 
 tests/cxx/explicit_instantiation.cc should add these lines:
 #include "tests/cxx/explicit_instantiation-template.h"
+#include "tests/cxx/indirect.h"
 
 tests/cxx/explicit_instantiation.cc should remove these lines:
 - #include "tests/cxx/explicit_instantiation-template_direct.h"  // lines XX-XX
@@ -51,5 +63,6 @@ tests/cxx/explicit_instantiation.cc should remove these lines:
 The full include-list for tests/cxx/explicit_instantiation.cc:
 #include "tests/cxx/explicit_instantiation-spec.h"  // for Template
 #include "tests/cxx/explicit_instantiation-template.h"  // for Template
+#include "tests/cxx/indirect.h"  // for IndirectClass
 
 ***** IWYU_SUMMARY */

--- a/tests/cxx/explicit_instantiation.cc
+++ b/tests/cxx/explicit_instantiation.cc
@@ -51,6 +51,41 @@ extern template class Template<IndirectClass>;
 // IWYU: IndirectClass is...*indirect.h
 template class Template<IndirectClass>;
 
+// Instantiation of class methods with explicit class instantiation definition
+// (but not declaration) requires template argument type info for parameters
+// used inside the methods.
+// IWYU: ClassWithUsingMethod is...*explicit_instantiation-template.h
+// IWYU: IndirectClass needs a declaration
+extern template class ClassWithUsingMethod<IndirectClass>;
+// One more instantiation declaration of the same specialization so as to test
+// that method definitions to be scanned are taken from the correct declaration
+// (clang places them in the first one).
+// IWYU: ClassWithUsingMethod is...*explicit_instantiation-template.h
+// IWYU: IndirectClass needs a declaration
+extern template class ClassWithUsingMethod<IndirectClass>;
+// IWYU: ClassWithUsingMethod is...*explicit_instantiation-template.h
+// IWYU: IndirectClass needs a declaration
+// IWYU: IndirectClass is...*indirect.h
+template class ClassWithUsingMethod<IndirectClass>;
+
+// Instantiation definition only.
+// IWYU: ClassWithUsingMethod is...*explicit_instantiation-template.h
+// IWYU: IndirectTemplate needs a declaration
+// IWYU: IndirectTemplate is...*indirect.h
+template class ClassWithUsingMethod<IndirectTemplate<int>>;
+
+// The template argument is considered to be provided with type alias.
+// IWYU: IndirectTemplate is...*indirect.h
+typedef IndirectTemplate<char> ProvidingTypedef;
+// IWYU: ClassWithUsingMethod is...*explicit_instantiation-template.h
+template class ClassWithUsingMethod<ProvidingTypedef>;
+
+// The type template parameter is not used in a context requiring the full type
+// info.
+// IWYU: ClassWithMethodUsingPtr is...*explicit_instantiation-template.h
+// IWYU: IndirectClass needs a declaration
+template class ClassWithMethodUsingPtr<IndirectClass>;
+
 /**** IWYU_SUMMARY
 
 tests/cxx/explicit_instantiation.cc should add these lines:
@@ -62,7 +97,7 @@ tests/cxx/explicit_instantiation.cc should remove these lines:
 
 The full include-list for tests/cxx/explicit_instantiation.cc:
 #include "tests/cxx/explicit_instantiation-spec.h"  // for Template
-#include "tests/cxx/explicit_instantiation-template.h"  // for Template
-#include "tests/cxx/indirect.h"  // for IndirectClass
+#include "tests/cxx/explicit_instantiation-template.h"  // for ClassWithMethodUsingPtr, ClassWithUsingMethod, Template
+#include "tests/cxx/indirect.h"  // for IndirectClass, IndirectTemplate
 
 ***** IWYU_SUMMARY */

--- a/tests/cxx/explicit_instantiation.cc
+++ b/tests/cxx/explicit_instantiation.cc
@@ -13,6 +13,7 @@
 
 #include "tests/cxx/explicit_instantiation-spec.h"
 #include "tests/cxx/explicit_instantiation-template_direct.h"
+#include "tests/cxx/explicit_instantiation-template2.h"
 
 // Test that all explicit instantiations variants of the base template
 // require the full type:
@@ -86,6 +87,12 @@ template class ClassWithUsingMethod<ProvidingTypedef>;
 // IWYU: IndirectClass needs a declaration
 template class ClassWithMethodUsingPtr<IndirectClass>;
 
+// Test traversal of instantiated class methods when the instantiated template
+// file is not analyzed (not included with 'check_also' command line option).
+// IWYU: IndirectClass needs a declaration
+// IWYU: IndirectClass is...*indirect.h
+template class ClassWithUsingMethod2<IndirectClass>;
+
 /**** IWYU_SUMMARY
 
 tests/cxx/explicit_instantiation.cc should add these lines:
@@ -98,6 +105,7 @@ tests/cxx/explicit_instantiation.cc should remove these lines:
 The full include-list for tests/cxx/explicit_instantiation.cc:
 #include "tests/cxx/explicit_instantiation-spec.h"  // for Template
 #include "tests/cxx/explicit_instantiation-template.h"  // for ClassWithMethodUsingPtr, ClassWithUsingMethod, Template
+#include "tests/cxx/explicit_instantiation-template2.h"  // for ClassWithUsingMethod2
 #include "tests/cxx/indirect.h"  // for IndirectClass, IndirectTemplate
 
 ***** IWYU_SUMMARY */


### PR DESCRIPTION
Clang attributes `ClassTemplateSpecializationDecl`s of explicit instantiations to the instantiated template definition location. Traversing them may cause reporting of template arguments incorrectly to that location (which is usually in a header). Hence, the standard traversal of explicitly instantiated specializations is avoided.

`TraverseClassTemplateSpecializationDecl` handler was added in #774 so as to analyze explicit specializations. It was seemingly an upstream issue fixed in [that commit](https://github.com/llvm/llvm-project/commit/c119a17e7fd6fb528d8c1e1bbb0a). At now, default `TraverseClassTemplateSpecializationDecl` implementation works well: traverses explicit specialization definition, but only the name in case of an implicit specialization.

`TraverseCXXRecordDecl` is directly called on `ClassTemplateSpecializationDecl` in `AnalyzeTemplateTypeParmUse` to handle implicit specialization which may be needed on instantiation of some other template (when the former doesn't occur to be written as `TemplateSpecializationType` in the initial template arguments, or in the template body). `alias_template.cc` test showed relating regression.

`Inner` class template isn't very much needed for the test purpose (a field of type `T` may be sufficient in `Template`), but it is added to assure that the correct instantiated template visitation logic is used.

Explicit instantiation definitions cause instantiation of class template member functions. This PR adds scanning them in the usual way, taking into account type template argument provision status.