### PR TITLE
Quick fix of crash on scanning noninstantiated implicit specialization

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -3476,6 +3476,12 @@ class InstantiatedTemplateVisitor
     if (ReplayClassMemberUsesFromPrecomputedList(type))
       return true;
 
+    // Sometimes, an implicit specialization occurs to be not instantiated.
+    // TODO(bolshakov): don't report them at all as full uses or figure out
+    // how to scan them.
+    if (!class_decl->hasDefinition())
+      return true;
+
     // Make sure all the types we report in the recursive TraverseDecl
     // calls, below, end up in the cache for class_decl.
     CacheStoringScope css(&cache_storers_, ClassMembersFullUseCache(),

--- a/tests/cxx/default_tpl_arg-d1.h
+++ b/tests/cxx/default_tpl_arg-d1.h
@@ -1,0 +1,10 @@
+//===--- default_tpl_arg-d1.h - test input file for iwyu ------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/default_tpl_arg-i1.h"

--- a/tests/cxx/default_tpl_arg-i1.h
+++ b/tests/cxx/default_tpl_arg-i1.h
@@ -1,0 +1,13 @@
+//===--- default_tpl_arg-i1.h - test input file for iwyu ------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+template <typename T>
+struct UninstantiatedTpl {
+  T t;
+};

--- a/tests/cxx/default_tpl_arg.cc
+++ b/tests/cxx/default_tpl_arg.cc
@@ -1,0 +1,41 @@
+//===--- default_tpl_arg.cc - test input file for iwyu --------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_ARGS: -I .
+
+// Tests handling default type template arguments. In particular, that IWYU
+// doesn't crash when they refer to uninstantiated template specializations.
+
+#include "tests/cxx/default_tpl_arg-d1.h"
+
+// IWYU: UninstantiatedTpl is...*default_tpl_arg-i1.h
+template <typename = UninstantiatedTpl<int>>
+struct Tpl {};
+
+template <typename T>
+struct Outer {
+  // IWYU: UninstantiatedTpl is...*default_tpl_arg-i1.h
+  template <typename = UninstantiatedTpl<T>>
+  struct Inner {};
+};
+
+Outer<int> o;
+
+/**** IWYU_SUMMARY
+
+tests/cxx/default_tpl_arg.cc should add these lines:
+#include "tests/cxx/default_tpl_arg-i1.h"
+
+tests/cxx/default_tpl_arg.cc should remove these lines:
+- #include "tests/cxx/default_tpl_arg-d1.h"  // lines XX-XX
+
+The full include-list for tests/cxx/default_tpl_arg.cc:
+#include "tests/cxx/default_tpl_arg-i1.h"  // for UninstantiatedTpl
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
This fixes #1331.

The crash had been introduced in #1325, because there is an assert in clang that the `bases()` method should be called only on class declarations having definitions. But clang doesn't instantiate definition of class template implicit specialization until that specialization is fully used.

Maybe, the root of the problem is that IWYU tries to provide the full type info when it is not actually needed, specifically, in default type template arguments. Not sure what the correct behavior should be. Currently, this goal isn't fully achieved because template internals aren't scanned when the specialization is not instantiated. Even worse, IWYU may give different suggestions to the header containing the template definition depending on the translation unit as part of which the header is analyzed.

For example, given:
```cpp
// Header.h
#include "Class.h"
template <typename T>
struct Tpl {
  T t;
};

template <typename T = Tpl<Class>>
struct Tpl2 {
  T t;
};

// Source.cpp
#include "Header.h"
Tpl2<> tpl;
```
IWYU suggests to keep `#include "Class.h"` in `Header.h` when analyzed along with `Source.cpp` but suggests to remove it when the `Header.h` is analyzed alone.

Switching to forward-declarations of template arguments can be easily achieved with adding the following lines into `IwyuBaseAstVisitor`:
```cpp
bool VisitTemplateTypeParmDecl(clang::TemplateTypeParmDecl* decl) {
  current_ast_node()->set_in_forward_declare_context(true);
  return true;
}
```
but there are two test cases having contradictory comments. [The first one](https://github.com/include-what-you-use/include-what-you-use/blob/0.21/tests/cxx/badinc.cc#L297) is a TODO stating that template arguments are fwd-declarable. [The second one](https://github.com/include-what-you-use/include-what-you-use/blob/0.21/tests/cxx/badinc.cc#L1003) claims that requiring full types for them is by-design. And, of course, there may be more cases when IWYU tries to scan uninstantiated specializations, when the full type is not really needed. @kimgr, wdyt?