### PR TITLE
Don't require full type for '__is_same' arguments

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -130,6 +130,7 @@
 #include "clang/AST/Type.h"
 #include "clang/AST/TypeLoc.h"
 #include "clang/Basic/SourceLocation.h"
+#include "clang/Basic/TypeTraits.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Frontend/FrontendAction.h"
 #include "clang/Lex/Preprocessor.h"
@@ -212,6 +213,7 @@ using clang::TranslationUnitDecl;
 using clang::Type;
 using clang::TypeDecl;
 using clang::TypeLoc;
+using clang::TypeTrait;
 using clang::TypedefDecl;
 using clang::TypedefNameDecl;
 using clang::TypedefType;
@@ -1942,11 +1944,13 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
     if (CanIgnoreCurrentASTNode())
       return true;
 
-    // We assume that all type traits with >= 2 arguments require
-    // full type information even for pointer types. For example,
+    // We assume that all type traits with >= 2 arguments, except '__is_same',
+    // require full type information even for pointer types. For example,
     // this is the case for `__is_convertible_to` trait.
-    if (expr == nullptr || expr->getNumArgs() < 2)
+    if (expr == nullptr || expr->getNumArgs() < 2 ||
+        expr->getTrait() == TypeTrait::BTT_IsSame) {
       return true;
+    }
 
     for (const clang::TypeSourceInfo* arg : expr->getArgs()) {
       clang::QualType qual_type = arg->getType();


### PR DESCRIPTION
Full type definitions are not needed to decide whether two types are the same or not.

This fixes the 'precomputed_tpl_args' test that failed on the master branch due to interplay between #1323 and #1326.