### PR TITLE
Move frontend execution into iwyu_driver

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -4388,7 +4388,7 @@ class IwyuAction : public ASTFrontendAction {
 
 using include_what_you_use::OptionsParser;
 using include_what_you_use::IwyuAction;
-using include_what_you_use::CreateCompilerInstance;
+using include_what_you_use::ExecuteAction;
 
 int main(int argc, char **argv) {
   llvm::llvm_shutdown_obj scoped_shutdown;
@@ -4403,16 +4403,9 @@ int main(int argc, char **argv) {
   //   path/to/iwyu -Xiwyu --verbose=4 [-Xiwyu --other_iwyu_flag]... \
   //       CLANG_FLAGS... foo.cc
   OptionsParser options_parser(argc, argv);
-
-  std::unique_ptr<clang::CompilerInstance> compiler(CreateCompilerInstance(
-      options_parser.clang_argc(), options_parser.clang_argv()));
-  if (!compiler) {
+  if (!ExecuteAction(options_parser.clang_argc(), options_parser.clang_argv(),
+                     []() { return std::make_unique<IwyuAction>(); })) {
     return EXIT_FAILURE;
   }
-
-  // Create and execute the frontend to generate an LLVM bitcode module.
-  std::unique_ptr<clang::ASTFrontendAction> action(new IwyuAction);
-  compiler->ExecuteAction(*action);
-
   return EXIT_SUCCESS;
 }

--- a/iwyu_driver.cc
+++ b/iwyu_driver.cc
@@ -11,6 +11,7 @@
 // argv.
 
 // Everything below is adapted from clang/examples/clang-interpreter/main.cpp.
+#include "iwyu_driver.h"
 
 #include <cctype>
 #include <cstdint>
@@ -155,8 +156,6 @@ void ExpandArgv(int argc, const char **argv,
   }
 }
 
-}  // anonymous namespace
-
 CompilerInstance* CreateCompilerInstance(int argc, const char **argv) {
   std::string path = GetExecutablePath(argv[0]);
   IntrusiveRefCntPtr<DiagnosticOptions> diagnostic_options =
@@ -238,6 +237,20 @@ CompilerInstance* CreateCompilerInstance(int argc, const char **argv) {
     return nullptr;
 
   return compiler;
+}
+
+}  // anonymous namespace
+
+bool ExecuteAction(int argc, const char** argv, ActionFactory make_iwyu_action) {
+  unique_ptr<clang::CompilerInstance> compiler(
+      CreateCompilerInstance(argc, argv));
+  if (!compiler) {
+    return false;
+  }
+
+  // Create and execute the IWYU frontend action.
+  unique_ptr<FrontendAction> action(make_iwyu_action());
+  return compiler->ExecuteAction(*action);
 }
 
 }  // namespace include_what_you_use

--- a/iwyu_driver.h
+++ b/iwyu_driver.h
@@ -10,15 +10,23 @@
 #ifndef INCLUDE_WHAT_YOU_USE_IWYU_DRIVER_H_
 #define INCLUDE_WHAT_YOU_USE_IWYU_DRIVER_H_
 
+#include <functional>
+#include <memory>
+
 namespace clang {
-class CompilerInstance;
+class FrontendAction;
 }
 
 namespace include_what_you_use {
 
-// Creates a CompilerInstance object based on the commandline
-// arguments, or NULL if there's an error of some sort.
-clang::CompilerInstance* CreateCompilerInstance(int argc, const char **argv);
+using clang::FrontendAction;
+
+typedef std::function<std::unique_ptr<FrontendAction>()> ActionFactory;
+
+// Use Clang's Driver to parse the command-line arguments, set up the state for
+// the compilation, and execute the right action. IWYU action type is injected
+// via factory callback.
+bool ExecuteAction(int argc, const char** argv, ActionFactory make_iwyu_action);
 
 }  // namespace include_what_you_use
 


### PR DESCRIPTION
This keeps all the setup code in a single place, so we can make smarter choices for globals, frontend actions, etc.

No functional change.