### PR TITLE
Bounce ToolChain around so we can use it in InitGlobals

### DIFF
--- a/iwyu_driver.cc
+++ b/iwyu_driver.cc
@@ -20,7 +20,6 @@
 #include <string>
 #include <utility>
 
-#include "iwyu_globals.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Option/ArgList.h"
@@ -193,8 +192,6 @@ bool ExecuteAction(int argc, const char** argv,
   if (!compilation)
     return false;
 
-  ParseToolChain(compilation->getDefaultToolChain());
-
   // FIXME: This is copied from ASTUnit.cpp; simplify and eliminate.
 
   // We expect to get back exactly one command job, if we didn't something
@@ -239,7 +236,8 @@ bool ExecuteAction(int argc, const char** argv,
     return false;
 
   // Create and execute the IWYU frontend action.
-  unique_ptr<FrontendAction> action(make_iwyu_action());
+  const ToolChain& toolchain = compilation->getDefaultToolChain();
+  unique_ptr<FrontendAction> action(make_iwyu_action(toolchain));
   return compiler->ExecuteAction(*action);
 }
 

--- a/iwyu_driver.h
+++ b/iwyu_driver.h
@@ -15,13 +15,19 @@
 
 namespace clang {
 class FrontendAction;
+
+namespace driver {
+class ToolChain;
+}
 }
 
 namespace include_what_you_use {
 
 using clang::FrontendAction;
+using clang::driver::ToolChain;
 
-typedef std::function<std::unique_ptr<FrontendAction>()> ActionFactory;
+typedef std::function<std::unique_ptr<FrontendAction>(const ToolChain&)>
+    ActionFactory;
 
 // Use Clang's Driver to parse the command-line arguments, set up the state for
 // the compilation, and execute the right action. IWYU action type is injected

--- a/iwyu_globals.h
+++ b/iwyu_globals.h
@@ -59,8 +59,8 @@ class OptionsParser {
   const char** clang_argv_;
 };
 
-void ParseToolChain(const clang::driver::ToolChain&);
-void InitGlobals(clang::CompilerInstance& compiler);
+void InitGlobals(clang::CompilerInstance& compiler,
+                 const clang::driver::ToolChain& toolchain);
 
 // Can be called by tests -- doesn't need a SourceManager or
 // argc/argv.  Note that GlobalSourceManager() and DefaultDataGetter()


### PR DESCRIPTION
The Clang ToolChain is part of the Compilation, which is a transient structure set up by the Driver to eventually get a fully initialized CompilerInstance.

The ToolChain also seems to be the only place where we can query for which C++ standard library is in effect for the compilation unit.

Rather than initializing globals both partway through iwyu_driver and inside IwyuAction, funnel the ToolChain through to IwyuAction's constructor and pass it to InitGlobals in IwyuAction::CreateASTConsumer.

This resolves some unfortunate temporal coupling in iwyu_globals where we had to assume that ParseToolChain had been called before InitGlobals.

No functional change intended.