### PR TITLE
Accept -E to preprocess-only

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,6 +162,7 @@ else()
     clangAST
     clangSema
     clangFrontend
+    clangFrontendTool
     clangDriver
 
     # Revision [1] in clang moved PCHContainerOperations from Frontend

--- a/tests/driver/preprocess_gcc.c
+++ b/tests/driver/preprocess_gcc.c
@@ -1,0 +1,18 @@
+//===--- preprocess_gcc.c - test input file for iwyu ----------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// Check that include-what-you-use does not exit with error for -E
+
+// IWYU_ARGS: -E
+
+/**** IWYU_SUMMARY(0)
+
+// No IWYU summary expected.
+
+***** IWYU_SUMMARY */

--- a/tests/driver/preprocess_msvc.c
+++ b/tests/driver/preprocess_msvc.c
@@ -1,0 +1,18 @@
+//===--- preprocess_msvc.c - test input file for iwyu ---------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// Check that include-what-you-use does not exit with error for /E in CL mode.
+
+// IWYU_ARGS: --driver-mode=cl /E
+
+/**** IWYU_SUMMARY(0)
+
+// No IWYU summary expected.
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
Until now IWYU, like other Clang tools, have only accepted compile commands, rewritten them and replaced them with its own frontend action for IWYU analysis.

But it can be useful to ask IWYU about its preprocessor state to answer questions like:

* which macros were defined for this execution?
* what does the input look like after macro expansion?

For example, we've been discussing letting the test framework use '-dM -E' to dump macros and detect the active C and C++ standard library based on what definitions are available, and then use the reverse-engineered library names to enable/disable tests based on environment.

Thus, try to detect preprocess-only commands (both for MSVC and GCC-style spellings) and let Clang do whatever it sees fit for preprocessing jobs.