### PR TITLE
Improve 'decltype' test

### DIFF
--- a/tests/cxx/decltype-d1.h
+++ b/tests/cxx/decltype-d1.h
@@ -1,0 +1,10 @@
+//===--- decltype-d1.h - test input file for iwyu -------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/decltype-i1.h"

--- a/tests/cxx/decltype-i1.h
+++ b/tests/cxx/decltype-i1.h
@@ -1,0 +1,15 @@
+//===--- decltype-i1.h - test input file for iwyu -------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// No fields of type T so that the defaulted constructor doesn't need
+// the complete parameter type.
+template <typename T>
+struct Tpl {
+  static constexpr auto s = sizeof(T);
+};

--- a/tests/cxx/decltype.cc
+++ b/tests/cxx/decltype.cc
@@ -11,19 +11,20 @@
 
 // Tests reporting types under 'decltype' specifier.
 
+#include "tests/cxx/decltype-d1.h"
 #include "tests/cxx/direct.h"
 
 struct WithStatic {
   // IWYU: IndirectClass needs a declaration
   static IndirectClass obj;
-  // IWYU: IndirectTemplate needs a declaration
+  // IWYU: Tpl needs a declaration
   // IWYU: IndirectClass needs a declaration
-  static IndirectTemplate<IndirectClass> tpl;
+  static Tpl<IndirectClass> tpl;
 };
 
 // TODO: IWYU: IndirectClass is...*indirect.h
 decltype(WithStatic::obj) obj;
-// TODO: IWYU: IndirectTemplate is...*indirect.h
+// TODO: IWYU: Tpl is...*decltype-i1.h
 // IWYU: IndirectClass is...*indirect.h
 decltype(WithStatic::tpl) tpl;
 
@@ -31,11 +32,14 @@ decltype(WithStatic::tpl) tpl;
 
 tests/cxx/decltype.cc should add these lines:
 #include "tests/cxx/indirect.h"
+template <typename T> struct Tpl;
 
 tests/cxx/decltype.cc should remove these lines:
+- #include "tests/cxx/decltype-d1.h"  // lines XX-XX
 - #include "tests/cxx/direct.h"  // lines XX-XX
 
 The full include-list for tests/cxx/decltype.cc:
-#include "tests/cxx/indirect.h"  // for IndirectClass, IndirectTemplate (ptr only)
+#include "tests/cxx/indirect.h"  // for IndirectClass
+template <typename T> struct Tpl;
 
 ***** IWYU_SUMMARY */


### PR DESCRIPTION
... so that it doesn't pass on the branch from #1340. `Tpl` needs complete type of the template parameter, but not for construction.