### PR TITLE
Avoid fwd-decl warnings along with full use ones

### DIFF
--- a/tests/cxx/alias_template.cc
+++ b/tests/cxx/alias_template.cc
@@ -20,14 +20,12 @@ template<class T> struct FullUseTemplateArgInSizeof {
 // Test that we go through alias template and handle aliased template
 // specialization.
 template<class T> using Alias = FullUseTemplateArgInSizeof<T>;
-// IWYU: IndirectClass needs a declaration
 // IWYU: IndirectClass is...*indirect.h
 Alias<IndirectClass> alias;
 
 // Test following through entire chain of aliases.
 template<class T> using AliasChain1 = FullUseTemplateArgInSizeof<T>;
 template<class T> using AliasChain2 = AliasChain1<T>;
-// IWYU: IndirectClass needs a declaration
 // IWYU: IndirectClass is...*indirect.h
 AliasChain2<IndirectClass> aliasChain;
 
@@ -44,13 +42,11 @@ struct FullUseTemplateArgAsVar {
 template <typename T>
 using AliasNested = FullUseTemplateArgAsVar<FullUseTemplateArgAsVar<T>>;
 
-// IWYU: IndirectClass needs a declaration
 // IWYU: IndirectClass is...*indirect.h
 AliasNested<IndirectClass> aliasNested;
 
 template <typename T>
 using AliasNested2 = FullUseTemplateArgInSizeof<FullUseTemplateArgInSizeof<T>>;
-// IWYU: IndirectClass needs a declaration
 // IWYU: IndirectClass is...*indirect.h
 AliasNested2<IndirectClass> aliasNested2;
 

--- a/tests/cxx/badinc.cc
+++ b/tests/cxx/badinc.cc
@@ -288,7 +288,6 @@ struct Cc_DeclOrderStruct {
 // IWYU: I1_Enum is...*badinc-i1.h
 template<class T, I1_Enum E = I11> struct Cc_TemplateStruct { };
 // IWYU: I1_Enum is...*badinc-i1.h
-// IWYU: I1_Class needs a declaration
 // IWYU: I1_Class is...*badinc-i1.h
 template<I1_Enum E> struct Cc_TemplateStruct<I1_Class, E> { I1_Class i; };
 // IWYU: I1_Class needs a declaration
@@ -316,7 +315,6 @@ template<class T, I1_Enum E> int Cc_TemplateFunction() { return T().a(); }
 // IWYU: I1_Class needs a declaration
 // IWYU: I1_Enum is...*badinc-i1.h
 template<> int Cc_TemplateFunction<I1_Class, I12>() { return 3; }
-// IWYU: I1_Class needs a declaration
 // IWYU: I1_Class is...*badinc-i1.h
 // IWYU: I1_Enum is...*badinc-i1.h
 template<> int Cc_TemplateFunction<I1_Class, I13>() { return I1_Class().a(); }
@@ -394,7 +392,6 @@ class Cc_DeclareOnlyClass {
 // IWYU: I2_Class::~I2_Class is...*badinc-i2-inl.h
 struct Cc_ImplicitConstructorStruct {
   // IWYU: I1_TemplateClass is...*badinc-i1.h
-  // IWYU: I1_Class needs a declaration
   // IWYU: I1_Class is...*badinc-i1.h
   // IWYU: I2_Class needs a declaration
   I1_TemplateClass<I1_Class, I2_Class> i1tc;
@@ -410,7 +407,6 @@ struct Cc_ImplicitInitializerStruct {
   // IWYU: I2_Class::~I2_Class is...*badinc-i2-inl.h
   Cc_ImplicitInitializerStruct() {}
   // IWYU: I1_TemplateClass is...*badinc-i1.h
-  // IWYU: I1_Class needs a declaration
   // IWYU: I1_Class is...*badinc-i1.h
   // IWYU: I2_Class needs a declaration
   I1_TemplateClass<I1_Class, I2_Class> i1tc;
@@ -491,7 +487,6 @@ int I2_Class::CcFileFn() { return 1; }
 // IWYU: I2_TemplateClass is...*badinc-i2.h
 template<typename FOO> int I2_TemplateClass<FOO>::CcFileFn() {
   // IWYU: I2_TemplateClass is...*badinc-i2.h
-  // IWYU: I2_TemplateClass needs a declaration
   // IWYU: I2_TemplateClass::I2_TemplateClass<.*> is...*badinc-i2-inl.h
   I2_TemplateClass<int>* ptr = new I2_TemplateClass<int>(42, "hi");  // NewExpr
 
@@ -519,13 +514,11 @@ template<typename FOO> int I2_TemplateClass<FOO>::CcFileFn() {
 
 // badinc.cc
 Cc_Struct cc_struct;
-// IWYU: I1_Class needs a declaration
 // IWYU: I1_Class is...*badinc-i1.h
 Cc_TypenameTemplateStruct<I1_Class> cc_typename_template_struct;
 Cc_Enum cc_enum = CC1;
 Cc_Subclass cc_subclass;
 MultipleInheritanceSubclass cc_multipleinheritancesubclass;
-// IWYU: I1_Class needs a declaration
 // IWYU: I1_Class is...*badinc-i1.h
 // IWYU: I1_Enum is...*badinc-i1.h
 int cc_template_function_val = Cc_TemplateFunction<I1_Class, I11>();
@@ -534,7 +527,6 @@ int cc_tricky_template_function_val =
     // IWYU: kI1ConstInt is...*badinc-i1.h
     // IWYU: I1_Enum is...*badinc-i1.h
     Cc_TemplateFunction<I1_Class, kI1ConstInt == 4 ? I12 : I13>();  // is I13
-// IWYU: I1_Class needs a declaration
 // IWYU: I1_Class is...*badinc-i1.h
 int cc_tpl_newer = Cc_TemplateNewer<I1_Class>();
 // IWYU: I1_Class needs a declaration
@@ -579,11 +571,9 @@ H_TemplateStruct<I1_TemplateClass<int> > h_template_struct_tplclass_arg;
 // IWYU: I2_TemplateClass::~I2_TemplateClass<.*> is...*badinc-i2-inl.h
 H_TemplateTemplateClass<> h_templatetemplateclass;
 // IWYU: I2_Class is...*badinc-i2.h
-// IWYU: I2_Class needs a declaration
 // IWYU: I2_TemplateFn is...*badinc-i2.h
 H_FunctionPtr h_functionpointer = I2_TemplateFn<I2_Class*>;
 // IWYU: I2_Class is...*badinc-i2.h
-// IWYU: I2_Class needs a declaration
 // IWYU: I2_TemplateFn is...*badinc-i2.h
 H_FunctionPtr h_functionpointer_amp = &((I2_TemplateFn<I2_Class*>));
 H_FunctionPtr &h_functionpointer_ref = h_functionpointer;
@@ -594,11 +584,9 @@ H_Class::H_Class_DefinedInI1 h_class_subclass_in_i1;
 H_Class::H_Class_DefinedInI1* h_class_subclass_in_i1_ptr;
 // This requires the full type for two reasons: because of the
 // H_ScopedPtr typedef and because we "own" the destructor call.
-// IWYU: I1_Class needs a declaration
 // IWYU: I1_Class is...*badinc-i1.h
 H_ScopedPtr<I1_Class> h_scoped_ptr;
 // This should also require I1_Class, because of the scoped_ptr it holds.
-// IWYU: I1_Class needs a declaration
 // IWYU: I1_Class is...*badinc-i1.h
 H_ScopedPtrHolder<I1_Class> h_scoped_ptr_holder;
 
@@ -696,13 +684,11 @@ I1_TemplateClass<I1_Class*> i1_templateclass3(NULL);
 // IWYU: I1_TemplateClass is...*badinc-i1.h
 // IWYU: I1_Class needs a declaration
 I1_TemplateClass<I1_Class>* i1_templateclass_ptr;
-// IWYU: I1_Class needs a declaration
 // IWYU: I1_Class is...*badinc-i1.h
 // IWYU: I1_TemplateClass is...*badinc-i1.h
 I1_TemplateClass<I1_Class> i1_templateclass_object;
 // IWYU: std::vector is...*<vector>
 // IWYU: I1_TemplateClass is...*badinc-i1.h
-// IWYU: I1_Class needs a declaration
 // IWYU: I1_Class is...*badinc-i1.h
 I1_TemplateClass<std::vector<I1_Class> > i1_nested_templateclass(i1_union);
 // We need full type info for i1_templateclass because we never
@@ -716,9 +702,7 @@ I1_TemplateClass<std::vector<I1_Class> >* i1_nested_templateclass_ptr;
 // IWYU: std::vector is...*<vector>
 I1_TemplateClass<std::vector<I1_Class>*> i1_nested_templateclass_ptr2(NULL);
 // IWYU: I1_TemplateSubclass is...*badinc-i1.h
-// IWYU: I1_Class needs a declaration
 // IWYU: I1_Class is...*badinc-i1.h
-// IWYU: I2_Class needs a declaration
 // IWYU: I2_Class is...*badinc-i2.h
 // IWYU: I2_Class::~I2_Class is...*badinc-i2-inl.h
 I1_TemplateSubclass<I1_Class, I2_Class> i1_template_subclass;
@@ -748,7 +732,6 @@ I1_TemplateClass<D1_I1_Typedef*> i1_templateclass_with_typedef_ptr(NULL);
 I1_TemplateClass<D1_Enum> i1_templateclass_d(D11);
 // I1_Class is needed as a used template arg to this template-constructor.
 // IWYU: I1_Class is...*badinc-i1.h
-// IWYU: I2_Struct needs a declaration
 // IWYU: I2_Struct is...*badinc-i2.h
 // IWYU: I1_TemplateClass is...*badinc-i1.h
 I1_TemplateClass<I2_Struct> i1_templateclass_tpl_ctor(i1_class, true);
@@ -757,7 +740,6 @@ I1_TemplateClass<I2_Struct> i1_templateclass_tpl_ctor(i1_class, true);
 #define CC_DEFINE_VAR(typ)  typ cc_define_var ## __LINE__
 // IWYU: I1_TemplateClass is...*badinc-i1.h
 // IWYU: I2_Class is...*badinc-i2.h
-// IWYU: I2_Class needs a declaration
 CC_DEFINE_VAR(I1_TemplateClass<I2_Class>::I1_TemplateClass_int);
 
 // IWYU: I1_TemplateMethodOnlyClass is...*badinc-i1.h
@@ -769,11 +751,9 @@ I1_TemplateMethodOnlyClass<I1_Class> i1_template_method_only_class;
 I1_TemplateMethodOnlyClass<I2_TemplateClass<const I1_Class> > i1_tpl_tpl_class;
 // IWYU: I1_TemplateClassFwdDeclaredInD2 needs a declaration
 I1_TemplateClassFwdDeclaredInD2<int, float>* i1_tpl_class_fwd_declared_in_d2;
-// IWYU: I1_Class needs a declaration
 // IWYU: I1_Class is...*badinc-i1.h
 // IWYU: I1_TypedefOnly_Class is...*badinc-i1.h
 I1_TypedefOnly_Class<I1_Class> i1_typedefonly_class;
-// IWYU: I1_Class needs a declaration
 // IWYU: I1_Class is...*badinc-i1.h
 // IWYU: I1_TypedefOnly_Class is...*badinc-i1.h
 I1_TypedefOnly_Class<I1_Class>::i i1_typedefonly_class_int;
@@ -908,9 +888,8 @@ int TestOperator(const D4_ClassForOperator& d4_classop) {
   return 1 << d4_classop;
 }
 
-// Test we properly find both uses (one ptr-only and one not) when on same line.
+// Test we properly find the full use when ptr-only use is on same line.
 // IWYU: I1_PtrAndUseOnSameLine is...*badinc-i1.h
-// IWYU: I1_PtrAndUseOnSameLine needs a declaration
 int TestSameLine(I1_PtrAndUseOnSameLine* i1_ptruse) { return i1_ptruse->a(); }
 
 // Test casting: try passing in an I1_SubclassesI2Class* here.
@@ -987,7 +966,6 @@ class Cc_TemplateDerived
     : public Cc_TemplateFullyUse<T> {  // test traversing the base class
 };
 
-// IWYU: I1_Class needs a declaration
 // IWYU: I1_Class is...*badinc-i1.h
 Cc_TemplateDerived<I1_Class> cc_template_derived1;
 
@@ -1144,7 +1122,6 @@ int main() {
   // IWYU: I1_TemplateMethodOnlyClass is...*badinc-i1.h
   i1_template_method_only_class.b();
   // IWYU: I1_TemplateMethodOnlyClass is...*badinc-i1.h
-  // IWYU: I2_Class needs a declaration
   // IWYU: I2_Class is...*badinc-i2.h
   // IWYU: I2_Class::~I2_Class is...*badinc-i2-inl.h
   i1_template_method_only_class.c<I2_Class>();
@@ -1174,21 +1151,16 @@ int main() {
   i1_template_method_only_class.s(local_i2_class_ptr);
   // IWYU: I1_TemplateMethodOnlyClass is...*badinc-i1.h
   // IWYU: I1_Class is...*badinc-i1.h
-  // IWYU: I2_Class needs a declaration
   // IWYU: I2_Class is...*badinc-i2.h
   i1_template_method_only_class.s<I2_Class*>(local_i2_class_ptr);
   // IWYU: I1_Class is...*badinc-i1.h
-  // IWYU: I1_Class needs a declaration
   // IWYU: I1_TemplateMethodOnlyClass is...*badinc-i1.h
   // IWYU: I2_Class is...*badinc-i2.h
   I1_TemplateMethodOnlyClass<I1_Class>::s(local_i2_class_ptr);
   // IWYU: I1_Class is...*badinc-i1.h
-  // IWYU: I1_Class needs a declaration
   // IWYU: I1_TemplateMethodOnlyClass is...*badinc-i1.h
-  // IWYU: I2_Class needs a declaration
   // IWYU: I2_Class is...*badinc-i2.h
   I1_TemplateMethodOnlyClass<I1_Class>::s<I2_Class*>(local_i2_class_ptr);
-  // IWYU: I1_Class needs a declaration
   // IWYU: I1_Class is...*badinc-i1.h
   // IWYU: I2_Class needs a declaration
   // IWYU: I1_TemplateMethodOnlyClass is...*badinc-i1.h
@@ -1202,7 +1174,6 @@ int main() {
   // IWYU: I2_Class is...*badinc-i2.h
   I1_TemplateMethodOnlyClass<Cc_typedef>::s(local_i2_class_ptr);
   // IWYU: I1_TemplateMethodOnlyClass is...*badinc-i1.h
-  // IWYU: I2_Class needs a declaration
   // IWYU: I2_Class is...*badinc-i2.h
   I1_TemplateMethodOnlyClass<Cc_typedef>::s<I2_Class*>(local_i2_class_ptr);
 
@@ -1222,7 +1193,6 @@ int main() {
   // IWYU: I1_Class is...*badinc-i1.h
   // IWYU: I1_Base needs a declaration
   (void)(static_cast<I1_Base&>(i1_class));
-  // IWYU: I1_Class needs a declaration
   // IWYU: I1_Class is...*badinc-i1.h
   (void)(static_cast<I1_Class*>(i1_base_ptr));
   // Full type information isn't needed since 0 isn't a pointer.
@@ -1254,13 +1224,11 @@ int main() {
   // They may be siblings, which is why we can't say the target
   // brings in the source, like we can for a normal down-cast.
   // IWYU: I1_Base is...*badinc-i1.h
-  // IWYU: I1_Class needs a declaration
   // IWYU: I1_Class is...*badinc-i1.h
   i1_class_ptr = dynamic_cast<I1_Class*>(i1_base_ptr);
   // IWYU: I1_SiblingClass needs a declaration
   I1_SiblingClass* i1_sibling_class_ptr = 0;
   // IWYU: I1_Class is...*badinc-i1.h
-  // IWYU: I1_SiblingClass needs a declaration
   // IWYU: I1_SiblingClass is...*badinc-i1.h
   i1_sibling_class_ptr = dynamic_cast<I1_SiblingClass*>(i1_class_ptr);
 
@@ -1277,7 +1245,6 @@ int main() {
   // C-style cast doesn't require the full type either, according
   // to the language, but we ask for full type when it's an up-cast
   // or a down-cast.
-  // IWYU: I1_Class needs a declaration
   // IWYU: I1_Class is...*badinc-i1.h
   i1_class_ptr = (I1_Class*)(i1_base_ptr);
 
@@ -1418,7 +1385,6 @@ int main() {
   (void)(__is_enum(I1_Class));
 
   // Check out template iwyu determinations.
-  // IWYU: I1_Class needs a declaration
   // IWYU: I1_Class is...*badinc-i1.h
   // IWYU: I1_const_ptr is...*badinc-i1.h
   I1_const_ptr<I1_Class> local_i1_const_ptr(NULL);
@@ -1442,7 +1408,6 @@ int main() {
   // IWYU: I1_const_ptr is...*badinc-i1.h
   (void)(i1_class == local_i1_const_ptr);
   // Also check the default (implicit) operator=
-  // IWYU: I1_Class needs a declaration
   // IWYU: I1_Class is...*badinc-i1.h
   // IWYU: I1_const_ptr is...*badinc-i1.h
   I1_const_ptr<I1_Class> local_i1_const_ptr2(NULL);
@@ -1450,7 +1415,6 @@ int main() {
   local_i1_const_ptr2 = local_i1_const_ptr;
 
   // We need the full I1_Class definition for the destructor.
-  // IWYU: I1_Class needs a declaration
   // IWYU: I1_Class is...*badinc-i1.h
   // IWYU: I1_const_ptr is...*badinc-i1.h
   (void)I1_const_ptr<I1_Class>(NULL);
@@ -1505,7 +1469,6 @@ int main() {
       // IWYU: std::vector is...*<vector>
       // IWYU: I2_Enum is...*badinc-i2.h
       = new std::vector<I2_Enum>;
-  // IWYU: I1_Class needs a declaration
   // IWYU: I1_Class is...*badinc-i1.h
   // IWYU: kI1ConstInt is...*badinc-i1.h
   I1_Class* newed_i1_class_array = new I1_Class[kI1ConstInt];
@@ -1515,7 +1478,6 @@ int main() {
   delete[] newed_i1_class_array;
   // IWYU: I1_Class is...*badinc-i1.h
   delete[] ((((newed_i1_class_array))));
-  // IWYU: I1_Base needs a declaration
   // IWYU: I1_Base is...*badinc-i1.h
   // IWYU: I1_Class is...*badinc-i1.h
   delete[] static_cast<I1_Base*>(newed_i1_class_array);
@@ -1526,20 +1488,16 @@ int main() {
   // IWYU: I2_Class needs a declaration
   // IWYU: I1_Struct needs a declaration
   I1_TemplateClass<I2_Class, I1_Struct>* newed_i1_template_class
-      // IWYU: I1_Struct needs a declaration
       // IWYU: I1_Struct is...*badinc-i1.h
       // IWYU: I1_TemplateClass is...*badinc-i1.h
-      // IWYU: I2_Class needs a declaration
       // IWYU: I2_Class is...*badinc-i2.h
       = new I1_TemplateClass<I2_Class, I1_Struct>;
   // IWYU: I1_TemplateClass is...*badinc-i1.h
   // IWYU: I2_Class needs a declaration
   // IWYU: I1_Struct needs a declaration
   I1_TemplateClass<I2_Class, I1_Struct>* newed_i1_template_class_array
-      // IWYU: I1_Struct needs a declaration
       // IWYU: I1_Struct is...*badinc-i1.h
       // IWYU: I1_TemplateClass is...*badinc-i1.h
-      // IWYU: I2_Class needs a declaration
       // IWYU: I2_Class is...*badinc-i2.h
       // IWYU: kI1ConstInt is...*badinc-i1.h
       = new I1_TemplateClass<I2_Class, I1_Struct>[kI1ConstInt];
@@ -1549,10 +1507,8 @@ int main() {
   I1_TemplateClass<I2_Class, I1_Struct>* newed_i1_template_class_ctor
       // IWYU: I1_Struct needs a declaration
       // IWYU: I1_TemplateClass is...*badinc-i1.h
-      // IWYU: I2_Class needs a declaration
       // IWYU: I2_Class is...*badinc-i2.h
       = new I1_TemplateClass<I2_Class, I1_Struct>(i1_union);
-  // IWYU: I1_Class needs a declaration
   // IWYU: I1_Class is...*badinc-i1.h
   // IWYU: i1_ns::I1_NamespaceClass is...*badinc-i1.h
   I1_Class* i1_class_tpl_ctor = new I1_Class(&i1_namespace_class, 1);
@@ -1597,7 +1553,6 @@ int main() {
   // IWYU: I2_Struct needs a declaration
   CC_TemplateClass<I1_Struct, I2_Struct>* cc_template_class =
       // IWYU: I1_Struct needs a declaration
-      // IWYU: I2_Struct needs a declaration
       // IWYU: I2_Struct is...*badinc-i2.h
       new CC_TemplateClass<I1_Struct,I2_Struct>;
   // IWYU: I1_Struct is...*badinc-i1.h
@@ -1613,17 +1568,13 @@ int main() {
   // IWYU: i1_ns::I1_NamespaceClass is...*badinc-i1.h
   (void)I1_Class(&i1_namespace_class, 1);
   // IWYU: I2_Class::~I2_Class is...*badinc-i2-inl.h
-  // IWYU: I1_Struct needs a declaration
   // IWYU: I1_Struct is...*badinc-i1.h
   // IWYU: I1_TemplateClass is...*badinc-i1.h
-  // IWYU: I2_Class needs a declaration
   // IWYU: I2_Class is...*badinc-i2.h
   I1_TemplateClass<I2_Class, I1_Struct> local_i1_templateclass(i1_union);
   // IWYU: I2_Class::~I2_Class is...*badinc-i2-inl.h
-  // IWYU: I1_Struct needs a declaration
   // IWYU: I1_Struct is...*badinc-i1.h
   // IWYU: I1_TemplateClass is...*badinc-i1.h
-  // IWYU: I2_Class needs a declaration
   // IWYU: I2_Class is...*badinc-i2.h
   (void)I1_TemplateClass<I2_Class, I1_Struct>(i1_union);
 

--- a/tests/cxx/binary_type_trait.cc
+++ b/tests/cxx/binary_type_trait.cc
@@ -13,9 +13,7 @@
 
 int main() {
     // IWYU: BinaryTypeTraitBase is...*binary_type_trait-i1.h
-    // IWYU: BinaryTypeTraitBase needs a declaration
     // IWYU: BinaryTypeTraitDerived is...*binary_type_trait-i2.h
-    // IWYU: BinaryTypeTraitDerived needs a declaration
     static_assert(__is_convertible_to(BinaryTypeTraitDerived*, BinaryTypeTraitBase*),
         "Derived should be convertible to the Base class");
 
@@ -25,9 +23,7 @@ int main() {
         "Indirect pointers shouldn't be convertible");
 
     // IWYU: BinaryTypeTraitBase is...*binary_type_trait-i1.h
-    // IWYU: BinaryTypeTraitBase needs a declaration
     // IWYU: BinaryTypeTraitDerived is...*tests/cxx/binary_type_trait-i2.h
-    // IWYU: BinaryTypeTraitDerived needs a declaration
     static_assert(__is_convertible_to(BinaryTypeTraitDerived&, BinaryTypeTraitBase&),
         "Derived should be convertible to the Base class");
 }

--- a/tests/cxx/casts.cc
+++ b/tests/cxx/casts.cc
@@ -25,7 +25,6 @@ template<typename T> void TestTemplateCastBug(CastsClass* foo) {
 int main() {
   // IWYU: CastsClass needs a declaration
   CastsClass* cc = 0;
-  // IWYU: CastsSubclass needs a declaration
   // IWYU: CastsSubclass is...*casts-i1.h
   TestTemplateCastBug<CastsSubclass>(cc);
 

--- a/tests/cxx/catch.cc
+++ b/tests/cxx/catch.cc
@@ -21,7 +21,6 @@ int main() {
   }
 
   try {
-  // IWYU: CatchByRef needs a declaration...*
   // IWYU: CatchByRef...*catch-byref.h
   } catch (const CatchByRef& cbr) {
     // IWYU: LogException...*catch-logex.h
@@ -29,7 +28,6 @@ int main() {
   }
 
   try {
-  // IWYU: CatchByPtr needs a declaration...*
   // IWYU: CatchByPtr...*catch-byptr.h
   } catch (const CatchByPtr* cpr) {
     // IWYU: LogException...*catch-logex.h
@@ -38,7 +36,6 @@ int main() {
 
   // Make sure we see through elaborated types
   try {
-  // IWYU: CatchElab needs a declaration...*
   // IWYU: CatchElab...*catch-elab.h
   } catch (const Namespace::CatchElab&) {
   }
@@ -52,11 +49,9 @@ int main() {
     puts("Unknown exception");
   }
 
-  // IWYU: CatchMacro1 needs a declaration...*
   // IWYU: CatchMacro1...*catch-macro-1.h
   CHECK_THROW_1(CatchMacro1);
 
-  // IWYU: CatchMacro2 needs a declaration...*
   // IWYU: CatchMacro2...*catch-macro-2.h
   CHECK_THROW_2(CatchMacro2);
 

--- a/tests/cxx/explicit_instantiation.cc
+++ b/tests/cxx/explicit_instantiation.cc
@@ -44,11 +44,9 @@ extern template class Template<int*>;
 template class Template<int*>;
 
 // IWYU: Template is...*explicit_instantiation-template.h
-// IWYU: IndirectClass needs a declaration
 // IWYU: IndirectClass is...*indirect.h
 extern template class Template<IndirectClass>;
 // IWYU: Template is...*explicit_instantiation-template.h
-// IWYU: IndirectClass needs a declaration
 // IWYU: IndirectClass is...*indirect.h
 template class Template<IndirectClass>;
 
@@ -65,13 +63,11 @@ extern template class ClassWithUsingMethod<IndirectClass>;
 // IWYU: IndirectClass needs a declaration
 extern template class ClassWithUsingMethod<IndirectClass>;
 // IWYU: ClassWithUsingMethod is...*explicit_instantiation-template.h
-// IWYU: IndirectClass needs a declaration
 // IWYU: IndirectClass is...*indirect.h
 template class ClassWithUsingMethod<IndirectClass>;
 
 // Instantiation definition only.
 // IWYU: ClassWithUsingMethod is...*explicit_instantiation-template.h
-// IWYU: IndirectTemplate needs a declaration
 // IWYU: IndirectTemplate is...*indirect.h
 template class ClassWithUsingMethod<IndirectTemplate<int>>;
 
@@ -89,7 +85,6 @@ template class ClassWithMethodUsingPtr<IndirectClass>;
 
 // Test traversal of instantiated class methods when the instantiated template
 // file is not analyzed (not included with 'check_also' command line option).
-// IWYU: IndirectClass needs a declaration
 // IWYU: IndirectClass is...*indirect.h
 template class ClassWithUsingMethod2<IndirectClass>;
 

--- a/tests/cxx/funcptrs.cc
+++ b/tests/cxx/funcptrs.cc
@@ -58,7 +58,6 @@ void FreeFunctions() {
   Enum (*fptr)(Class*) = &Function;
 
   // IWYU: Class needs a declaration
-  // IWYU: Retval needs a declaration
   // IWYU: Retval is...*funcptrs-i1.h
   // IWYU: FunctionTemplate is...*funcptrs-i1.h
   int (*template_fptr)(Class*) = &FunctionTemplate<Retval>;
@@ -67,7 +66,6 @@ void FreeFunctions() {
   // IWYU: Function is...*funcptrs-i1.h
   FunctionThatTakesFptr(Function);
 
-  // IWYU: Retval needs a declaration
   // IWYU: Retval is...*funcptrs-i1.h
   // IWYU: FunctionTemplate is...*funcptrs-i1.h
   FunctionThatTakesFptr(FunctionTemplate<Retval>);
@@ -76,7 +74,6 @@ void FreeFunctions() {
   // IWYU: Function is...*funcptrs-i1.h
   &Function;
 
-  // IWYU: Retval needs a declaration
   // IWYU: Retval is...*funcptrs-i1.h
   // IWYU: FunctionTemplate is...*funcptrs-i1.h
   &FunctionTemplate<Retval>;
@@ -98,7 +95,6 @@ void ClassMembers() {
   int (*static_method_ptr)() = &Class::StaticMemberFunction;
 
   // IWYU: Class is...*funcptrs-i1.h
-  // IWYU: Retval needs a declaration
   // IWYU: Retval is...*funcptrs-i1.h
   int (*static_template_method_ptr)() = &Class::StaticMemberTemplate<Retval>;
 
@@ -106,7 +102,6 @@ void ClassMembers() {
   int (Class::*method_ptr)() const = &Class::MemberFunction;
 
   // IWYU: Class is...*funcptrs-i1.h
-  // IWYU: Retval needs a declaration
   // IWYU: Retval is...*funcptrs-i1.h
   int (Class::*template_method_ptr)() const = &Class::MemberTemplate<Retval>;
 
@@ -114,7 +109,6 @@ void ClassMembers() {
   // IWYU: Class is...*funcptrs-i1.h
   FunctionThatTakesFptr(Class::StaticMemberFunction);
 
-  // IWYU: Retval needs a declaration
   // IWYU: Retval is...*funcptrs-i1.h
   // IWYU: Class is...*funcptrs-i1.h
   FunctionThatTakesFptr(Class::StaticMemberTemplate<Retval>);
@@ -123,7 +117,6 @@ void ClassMembers() {
   // IWYU: Class is...*funcptrs-i1.h
   FunctionThatTakesMptr(&Class::MemberFunction);
 
-  // IWYU: Retval needs a declaration
   // IWYU: Retval is...*funcptrs-i1.h
   // IWYU: Class is...*funcptrs-i1.h
   FunctionThatTakesMptr(&Class::MemberTemplate<Retval>);
@@ -132,7 +125,6 @@ void ClassMembers() {
   // IWYU: Class is...*funcptrs-i1.h
   &Class::StaticMemberFunction;
 
-  // IWYU: Retval needs a declaration
   // IWYU: Retval is...*funcptrs-i1.h
   // IWYU: Class is...*funcptrs-i1.h
   &Class::StaticMemberTemplate<Retval>;
@@ -140,7 +132,6 @@ void ClassMembers() {
   // IWYU: Class is...*funcptrs-i1.h
   &Class::MemberFunction;
 
-  // IWYU: Retval needs a declaration
   // IWYU: Retval is...*funcptrs-i1.h
   // IWYU: Class is...*funcptrs-i1.h
   &Class::MemberTemplate<Retval>;
@@ -154,7 +145,6 @@ void ClassTemplateMembers() {
   int (*static_template_method_ptr)() =
       // IWYU: ClassTemplate is...*funcptrs-i1.h
       // IWYU: Class needs a declaration
-      // IWYU: Retval needs a declaration
       // IWYU: Retval is...*funcptrs-i1.h
       &ClassTemplate<Class>::StaticMemberTemplate<Retval>;
 
@@ -170,7 +160,6 @@ void ClassTemplateMembers() {
   int (ClassTemplate<Class>::*template_method_ptr)() const =
       // IWYU: ClassTemplate is...*funcptrs-i1.h
       // IWYU: Class needs a declaration
-      // IWYU: Retval needs a declaration
       // IWYU: Retval is...*funcptrs-i1.h
       &ClassTemplate<Class>::MemberTemplate<Retval>;
 
@@ -179,7 +168,6 @@ void ClassTemplateMembers() {
   // IWYU: Class needs a declaration
   FunctionThatTakesFptr(ClassTemplate<Class>::StaticMemberFunction);
 
-  // IWYU: Retval needs a declaration
   // IWYU: Retval is...*funcptrs-i1.h
   // IWYU: ClassTemplate is...*funcptrs-i1.h
   // IWYU: Class needs a declaration
@@ -190,7 +178,6 @@ void ClassTemplateMembers() {
   // IWYU: Class needs a declaration
   FunctionThatTakesMptr(&ClassTemplate<Class>::MemberFunction);
 
-  // IWYU: Retval needs a declaration
   // IWYU: Retval is...*funcptrs-i1.h
   // IWYU: ClassTemplate is...*funcptrs-i1.h
   // IWYU: Class needs a declaration
@@ -201,7 +188,6 @@ void ClassTemplateMembers() {
   // IWYU: Class needs a declaration
   &ClassTemplate<Class>::StaticMemberFunction;
 
-  // IWYU: Retval needs a declaration
   // IWYU: Retval is...*funcptrs-i1.h
   // IWYU: ClassTemplate is...*funcptrs-i1.h
   // IWYU: Class needs a declaration
@@ -211,7 +197,6 @@ void ClassTemplateMembers() {
   // IWYU: Class needs a declaration
   &ClassTemplate<Class>::MemberFunction;
 
-  // IWYU: Retval needs a declaration
   // IWYU: Retval is...*funcptrs-i1.h
   // IWYU: ClassTemplate is...*funcptrs-i1.h
   // IWYU: Class needs a declaration

--- a/tests/cxx/iwyu_stricter_than_cpp.cc
+++ b/tests/cxx/iwyu_stricter_than_cpp.cc
@@ -318,7 +318,6 @@ void TestFunctionReturn() {
   // IWYU: DirectStruct2 needs a declaration
   const DirectStruct2& ds2 = DoesNotForwardDeclareAndIncludesFn();
 
-  // IWYU: IndirectStruct2 needs a declaration
   // IWYU: IndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
   const IndirectStruct2& is2 = DoesEverythingRightFn();
 
@@ -337,7 +336,6 @@ void TestFunctionReturn() {
   // IWYU: TplDirectStruct2 needs a declaration
   const TplDirectStruct2<int>& tds2 = TplDoesNotForwardDeclareAndIncludesFn();
 
-  // IWYU: TplIndirectStruct2 needs a declaration
   // IWYU: TplIndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
   const TplIndirectStruct2<int>& tis2 = TplDoesEverythingRightFn();
 
@@ -377,12 +375,9 @@ void TestFunctionReturn() {
 
   // IWYU: IndirectStruct1 needs a declaration
   // IWYU: IndirectStruct2 needs a declaration
-  // IWYU: TplIndirectStruct3 needs a declaration
   // IWYU: TplIndirectStruct3 is...*iwyu_stricter_than_cpp-i5.h
   Call<TplIndirectStruct3<IndirectStruct1, IndirectStruct2>,
        TplOnlyArgumentTypeProvidedFn>();
-  // IWYU: IndirectStruct2 needs a declaration
-  // IWYU: TplIndirectStruct3 needs a declaration
   // IWYU: TplIndirectStruct3 is...*iwyu_stricter_than_cpp-i5.h
   // IWYU: IndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
   Call<TplIndirectStruct3<IndirectStruct2, IndirectStruct2>,
@@ -392,7 +387,6 @@ void TestFunctionReturn() {
   // IWYU: TplDirectStruct7 needs a declaration
   Call<TplDirectStruct7<IndirectStruct1, IndirectStruct2>,
        TplAllNeededTypesProvidedFn>();
-  // IWYU: IndirectStruct2 needs a declaration
   // IWYU: TplDirectStruct7 needs a declaration
   // IWYU: IndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
   Call<TplDirectStruct7<IndirectStruct2, IndirectStruct2>,

--- a/tests/cxx/member_expr.cc
+++ b/tests/cxx/member_expr.cc
@@ -88,7 +88,6 @@ int PtrFn(const IndirectTemplate<IndirectClass>* ic) {
 
 void TemplateStaticFn() {
   // IWYU: IndirectTemplate is...*indirect.h
-  // IWYU: IndirectClass needs a declaration
   // IWYU: IndirectClass is...*indirect.h
   IndirectTemplate<IndirectClass>::StaticMethod();
 }

--- a/tests/cxx/operator_new.cc
+++ b/tests/cxx/operator_new.cc
@@ -18,14 +18,12 @@
 // The most primitive ::operator new/delete are builtins, and are basically
 // wrappers around malloc.
 void ExplicitOperators() {
-  // IWYU: IndirectClass needs a declaration
   // IWYU: IndirectClass is...*indirect.h
   IndirectClass* elem = (IndirectClass*)::operator new(sizeof(IndirectClass));
   ::operator delete(elem);
 
   // IWYU: IndirectClass needs a declaration
   IndirectClass* arr =
-      // IWYU: IndirectClass needs a declaration
       // IWYU: IndirectClass is...*indirect.h
       (IndirectClass*)::operator new[](4 * sizeof(IndirectClass));
   ::operator delete[](arr);
@@ -50,13 +48,11 @@ void TplFnWithDelete(T p) {
 }
 
 void ExpressionsUserTypes() {
-  // IWYU: IndirectClass needs a declaration
   // IWYU: IndirectClass is...*indirect.h
   IndirectClass* elem = new IndirectClass;
   // IWYU: IndirectClass is...*indirect.h
   delete elem;
 
-  // IWYU: IndirectClass needs a declaration
   // IWYU: IndirectClass is...*indirect.h
   IndirectClass* arr = new IndirectClass[4];
   // IWYU: IndirectClass is...*indirect.h

--- a/tests/cxx/placement_new.cc
+++ b/tests/cxx/placement_new.cc
@@ -31,7 +31,6 @@ void PlacementNewBuiltinType() {
 
 // Placement new of user-defined type.
 void PlacementNewUserType() {
-  // IWYU: IndirectClass needs a declaration
   // IWYU: IndirectClass is...*indirect.h
   IndirectClass* icptr = new IndirectClass;
 
@@ -49,7 +48,6 @@ static char global_buffer[256];
 #define CONSTRUCT_GLOBAL(T) new (global_buffer) T;
 
 void PlacementNewInMacro() {
-  // IWYU: IndirectClass needs a declaration
   // IWYU: IndirectClass is...*indirect.h
   IndirectClass* a = CONSTRUCT_GLOBAL(IndirectClass);
 }
@@ -71,7 +69,6 @@ void PlacementNewInTemplate(T t) {
 
 // Placement new when the newed type _is_ a template.
 void PlacementNewOfTemplate() {
-  // IWYU: IndirectClass needs a declaration
   // IWYU: IndirectClass is...*indirect.h
   // IWYU: ClassTemplate is...*placement_new-i1.h
   char template_storage[sizeof(ClassTemplate<IndirectClass, IndirectClass>)];
@@ -82,7 +79,6 @@ void PlacementNewOfTemplate() {
       // Need <new> because of placement new, and requires both template and
       // arguments as complete types.
       //
-      // IWYU: IndirectClass needs a declaration
       // IWYU: IndirectClass is...*indirect.h
       // IWYU: ClassTemplate is...*placement_new-i1.h
       // IWYU: operator new is...*<new>
@@ -99,14 +95,12 @@ void PlacementNewOfTemplate() {
 // To use 'std::nothrow' we must include <new>, even if we don't need it for
 // 'new' itself.
 void NoThrow() {
-  // IWYU: IndirectClass needs a declaration
   // IWYU: IndirectClass is...*indirect.h
   // IWYU: std::nothrow is...*<new>
   IndirectClass* elem = new (std::nothrow) IndirectClass;
   // IWYU: IndirectClass is...*indirect.h
   delete elem;
 
-  // IWYU: IndirectClass needs a declaration
   // IWYU: IndirectClass is...*indirect.h
   // IWYU: std::nothrow is...*<new>
   IndirectClass* arr = new (std::nothrow) IndirectClass[4];
@@ -120,14 +114,12 @@ void NoThrow() {
 // for 'new' itself.
 // The aligned allocation mechanics are only available as of C++17.
 void ExplicitAlignedAllocation() {
-  // IWYU: IndirectClass needs a declaration
   // IWYU: IndirectClass is...*indirect.h
   // IWYU: std::align_val_t is...*<new>
   IndirectClass* elem = new (std::align_val_t(32)) IndirectClass;
   // IWYU: IndirectClass is...*indirect.h
   delete elem;
 
-  // IWYU: IndirectClass needs a declaration
   // IWYU: IndirectClass is...*indirect.h
   // IWYU: std::align_val_t is...*<new>
   IndirectClass* arr = new (std::align_val_t(32)) IndirectClass[10];

--- a/tests/cxx/pointer_arith.cc
+++ b/tests/cxx/pointer_arith.cc
@@ -48,7 +48,6 @@ void PointerArithmetic() {
 }
 
 // IWYU: IndirectTemplate is...*indirect.h
-// IWYU: IndirectClass needs a declaration
 // IWYU: IndirectClass is...*indirect.h
 IndirectTemplate<IndirectClass> itc1, itc2;
 

--- a/tests/cxx/precomputed_tpl_args.cc
+++ b/tests/cxx/precomputed_tpl_args.cc
@@ -25,23 +25,19 @@ template <typename T> struct Identity {
   T t;
 };
 
-// IWYU: IndirectClass needs a declaration
 // IWYU: IndirectClass is...*precomputed_tpl_args-i1.h
 std::vector<IndirectClass> ic_vec;
 
-// IWYU: IndirectClass needs a declaration
 // IWYU: IndirectClass is...*precomputed_tpl_args-i1.h
 std::vector<Identity<IndirectClass> > i_ic_vec;
 
 // IWYU: IndirectClass needs a declaration
 std::vector<IndirectClass*> icptr_vec;
 
-// IWYU: IndirectClass needs a declaration
 // IWYU: IndirectClass is...*precomputed_tpl_args-i1.h
 std::set<IndirectClass> ic_set;
 
 // This class provides a specialization of less that we should see.
-// IWYU: SpecializationClass needs a declaration
 // IWYU: SpecializationClass is...*precomputed_tpl_args-i1.h
 // IWYU: std::less is...*precomputed_tpl_args-i1.h
 std::set<SpecializationClass> sc_set;
@@ -68,19 +64,15 @@ std::bitset<5> bitset;
 
 template<typename T> class TemplatedClass {
   // IWYU: SpecializationClass is...*precomputed_tpl_args-i1.h
-  // IWYU: SpecializationClass needs a declaration
   std::map<SpecializationClass, T> t1;
   // IWYU: IndirectClass is...*precomputed_tpl_args-i1.h
-  // IWYU: IndirectClass needs a declaration
   std::map<T, IndirectClass> t3;
 };
 
-// IWYU: IndirectClass needs a declaration
 // IWYU: IndirectClass is...*precomputed_tpl_args-i1.h
 TemplatedClass<IndirectClass> tc_ic;
 
 // TODO(csilvers): IWYU: std::less is...*precomputed_tpl_args-i1.h
-// IWYU: SpecializationClass needs a declaration
 // IWYU: SpecializationClass is...*precomputed_tpl_args-i1.h
 TemplatedClass<SpecializationClass> tc_sc;
 
@@ -95,28 +87,20 @@ void Fn() {
   (void)sizeof(std::forward_list<IndirectClass>);
 
   // Full type is still needed for the other standard containers.
-  // IWYU: IndirectClass needs a declaration
   // IWYU: IndirectClass is...*precomputed_tpl_args-i1.h
   (void)sizeof(std::set<IndirectClass>);
-  // IWYU: IndirectClass needs a declaration
   // IWYU: IndirectClass is...*precomputed_tpl_args-i1.h
   (void)sizeof(std::multiset<IndirectClass>);
-  // IWYU: IndirectClass needs a declaration
   // IWYU: IndirectClass is...*precomputed_tpl_args-i1.h
   (void)sizeof(std::map<IndirectClass, int>);
-  // IWYU: IndirectClass needs a declaration
   // IWYU: IndirectClass is...*precomputed_tpl_args-i1.h
   (void)sizeof(std::multimap<IndirectClass, int>);
-  // IWYU: IndirectClass needs a declaration
   // IWYU: IndirectClass is...*precomputed_tpl_args-i1.h
   (void)sizeof(std::unordered_set<IndirectClass>);
-  // IWYU: IndirectClass needs a declaration
   // IWYU: IndirectClass is...*precomputed_tpl_args-i1.h
   (void)sizeof(std::unordered_multiset<IndirectClass>);
-  // IWYU: IndirectClass needs a declaration
   // IWYU: IndirectClass is...*precomputed_tpl_args-i1.h
   (void)sizeof(std::unordered_map<IndirectClass, int>);
-  // IWYU: IndirectClass needs a declaration
   // IWYU: IndirectClass is...*precomputed_tpl_args-i1.h
   (void)sizeof(std::unordered_multimap<IndirectClass, int>);
 

--- a/tests/cxx/precomputed_tpl_args_cpp14.cc
+++ b/tests/cxx/precomputed_tpl_args_cpp14.cc
@@ -24,40 +24,28 @@
 #include "tests/cxx/direct.h"
 
 void Fn() {
-  // IWYU: IndirectClass needs a declaration
   // IWYU: IndirectClass is...*indirect.h
   (void)sizeof(std::vector<IndirectClass>);
-  // IWYU: IndirectClass needs a declaration
   // IWYU: IndirectClass is...*indirect.h
   (void)sizeof(std::deque<IndirectClass>);
-  // IWYU: IndirectClass needs a declaration
   // IWYU: IndirectClass is...*indirect.h
   (void)sizeof(std::list<IndirectClass>);
-  // IWYU: IndirectClass needs a declaration
   // IWYU: IndirectClass is...*indirect.h
   (void)sizeof(std::forward_list<IndirectClass>);
-  // IWYU: IndirectClass needs a declaration
   // IWYU: IndirectClass is...*indirect.h
   (void)sizeof(std::set<IndirectClass>);
-  // IWYU: IndirectClass needs a declaration
   // IWYU: IndirectClass is...*indirect.h
   (void)sizeof(std::multiset<IndirectClass>);
-  // IWYU: IndirectClass needs a declaration
   // IWYU: IndirectClass is...*indirect.h
   (void)sizeof(std::map<IndirectClass, int>);
-  // IWYU: IndirectClass needs a declaration
   // IWYU: IndirectClass is...*indirect.h
   (void)sizeof(std::multimap<IndirectClass, int>);
-  // IWYU: IndirectClass needs a declaration
   // IWYU: IndirectClass is...*indirect.h
   (void)sizeof(std::unordered_set<IndirectClass>);
-  // IWYU: IndirectClass needs a declaration
   // IWYU: IndirectClass is...*indirect.h
   (void)sizeof(std::unordered_multiset<IndirectClass>);
-  // IWYU: IndirectClass needs a declaration
   // IWYU: IndirectClass is...*indirect.h
   (void)sizeof(std::unordered_map<IndirectClass, int>);
-  // IWYU: IndirectClass needs a declaration
   // IWYU: IndirectClass is...*indirect.h
   (void)sizeof(std::unordered_multimap<IndirectClass, int>);
 }

--- a/tests/cxx/sizeof_in_template_arg.cc
+++ b/tests/cxx/sizeof_in_template_arg.cc
@@ -26,7 +26,6 @@ struct Public {
 };
 
 // IWYU: IndirectClass is...*indirect.h
-// IWYU: IndirectClass needs a declaration
 Public<IndirectClass> p;
 
 /**** IWYU_SUMMARY

--- a/tests/cxx/sizeof_reference.cc
+++ b/tests/cxx/sizeof_reference.cc
@@ -44,14 +44,12 @@ template <typename T> struct SizeofTakingStructTplRef2 {
 };
 
 // IWYU: IndirectClass is...*indirect.h
-// IWYU: IndirectClass needs a declaration
 size_t s = sizeof(IndirectClass&);
 
 // This needs the full type of IndirectTemplateStruct, but also
 // IndirectClass, which is used in the IndirectTemplateStruct
 // instantiation.
 // IWYU: IndirectClass is...*indirect.h
-// IWYU: IndirectClass needs a declaration
 size_t s2 = sizeof(IndirectTemplateStruct<IndirectClass>&);
 
 // This does not need the full type information for IndirectClass.
@@ -61,7 +59,6 @@ size_t s3 = sizeof(IndirectTemplateStruct<IndirectClass&>);
 // This needs the full type information of IndirectClass because the
 // subclass takes the sizeof().
 // IWYU: IndirectClass is...*indirect.h
-// IWYU: IndirectClass needs a declaration
 size_t s4 = sizeof(SizeofTakingStruct<IndirectClass&>);
 
 // Also check when sizeof is on a variable, not a type.
@@ -73,11 +70,9 @@ IndirectClass& ref = dummy;
 size_t s5 = sizeof(dummy);
 
 // IWYU: IndirectClass is...*indirect.h
-// IWYU: IndirectClass needs a declaration
 SizeofTakingStruct<IndirectClass&> sizeof_taking_struct1;
 
 // IWYU: IndirectClass is...*indirect.h
-// IWYU: IndirectClass needs a declaration
 SizeofTakingStructRef<IndirectClass> sizeof_taking_struct2;
 
 // sizeof(IndirectTemplateStruct<IndirectClass&>) doesn't require IndirectClass
@@ -95,7 +90,6 @@ SizeofTakingStructTpl<IndirectClass&> sizeof_taking_struct3;
 SizeofTakingStructTplRef<IndirectClass> sizeof_taking_struct4;
 
 // IWYU: IndirectClass is...*indirect.h
-// IWYU: IndirectClass needs a declaration
 SizeofTakingStructTplRef2<IndirectClass> sizeof_taking_struct5;
 
 // sizeof(IndirectTemplateStruct<IndirectClass&>) doesn't require IndirectClass

--- a/tests/cxx/template_args.cc
+++ b/tests/cxx/template_args.cc
@@ -28,12 +28,10 @@ template <typename R, typename A1> struct FunctionStruct<R(A1)> {
 };
 
 void FunctionProtoClassArguments() {
-  // IWYU: IndirectClass needs a declaration
   // IWYU: IndirectClass is...*indirect.h
   FunctionStruct<char(IndirectClass&)> f1;
   (void)f1;
 
-  // IWYU: IndirectClass needs a declaration
   // IWYU: IndirectClass is...*indirect.h
   FunctionStruct<IndirectClass(char)> f2;
   (void)f2;
@@ -61,19 +59,15 @@ void PointerClassArguments() {
   // IWYU: IndirectClass needs a declaration
   IndirectClass* ic = 0;
 
-  // IWYU: IndirectClass needs a declaration
   // IWYU: IndirectClass is...*indirect.h
   PointerStruct<IndirectClass*>::a(ic);
 
-  // IWYU: IndirectClass needs a declaration
   // IWYU: IndirectClass is...*indirect.h
   DoublePointerStruct<IndirectClass**>::a(&ic);
 
-  // IWYU: IndirectClass needs a declaration
   // IWYU: IndirectClass is...*indirect.h
   PointerStruct2<IndirectClass>::a(ic);
 
-  // IWYU: IndirectClass needs a declaration
   // IWYU: IndirectClass is...*indirect.h
   DoublePointerStruct2<IndirectClass>::a(&ic);
 }
@@ -90,7 +84,6 @@ struct StaticTemplateFieldStruct {
 };
 
 void NestedTemplateArguments() {
-  // IWYU: IndirectClass needs a declaration
   // IWYU: IndirectClass is...*indirect.h
   Outer<Inner<IndirectClass> > oi;
   (void)oi;
@@ -170,15 +163,12 @@ void TestCreateTemporary() {
   ct.a();
 
   // IWYU: IndirectClass is...*indirect.h
-  // IWYU: IndirectClass needs a declaration
   ct.b<IndirectClass>();
 
   // IWYU: IndirectClass is...*indirect.h
-  // IWYU: IndirectClass needs a declaration
   CreateTemporary<IndirectClass>::statica();
 
   // IWYU: IndirectClass is...*indirect.h
-  // IWYU: IndirectClass needs a declaration
   CreateTemporary<int>::staticb<IndirectClass>();
 }
 

--- a/tests/cxx/template_base.cc
+++ b/tests/cxx/template_base.cc
@@ -24,7 +24,6 @@ struct InheritanceFromTplInheritedFromT : DirectInheritance<T> {};
 template <typename T>
 struct TplInBaseNNS : InheritanceFromTplInheritedFromT<T>::Inner {};
 
-// IWYU: IndirectClass needs a declaration
 // IWYU: IndirectClass is...*indirect.h
 constexpr auto s1 = sizeof(TplInBaseNNS<IndirectClass>);
 
@@ -33,7 +32,6 @@ template <typename T>
 // IWYU: IndirectTemplate is...*indirect.h
 struct InheritanceFromTplWithTMember : IndirectTemplate<T> {};
 
-// IWYU: IndirectClass needs a declaration
 // IWYU: IndirectClass is...*indirect.h
 constexpr auto s2 = sizeof(InheritanceFromTplWithTMember<IndirectClass>);
 

--- a/tests/cxx/typedef_in_template.cc
+++ b/tests/cxx/typedef_in_template.cc
@@ -39,17 +39,14 @@ void Declarations() {
   // of corresponding template argument type.
 
   // IWYU: Class1 is...*typedef_in_template-i1.h
-  // IWYU: Class1 needs a declaration
   // IWYU: Class2 needs a declaration
   Container<Class1, Class2>::value_type vt;
 
   // IWYU: Class1 needs a declaration
   // IWYU: Class2 is...*typedef_in_template-i2.h
-  // IWYU: Class2 needs a declaration
   Container<Class1, Class2>::pair_type pt;
 
   // IWYU: Class1 is...*typedef_in_template-i1.h
-  // IWYU: Class1 needs a declaration
   // IWYU: Class2 needs a declaration
   Container<Class1, Class2>::alias_type at;
 }
@@ -70,11 +67,9 @@ struct UsesAliasedParameter {
 };
 
 // IWYU: IndirectClass is...*indirect.h
-// IWYU: IndirectClass needs a declaration
 UsesAliasedParameter<IndirectClass> a;
 
 // IWYU: IndirectClass is...*indirect.h
-// IWYU: IndirectClass needs a declaration
 UsesAliasedParameter<IndirectClass>::TAlias a2;
 
 // Try a more complex example, through an additional layer of indirection.
@@ -85,7 +80,6 @@ struct IndirectlyUsesAliasedParameter {
 };
 
 // IWYU: IndirectClass is...*indirect.h
-// IWYU: IndirectClass needs a declaration
 IndirectlyUsesAliasedParameter<IndirectClass> b;
 
 template <typename T>
@@ -95,7 +89,6 @@ struct NestedUseOfAliasedParameter {
 };
 
 // IWYU: IndirectClass is...*indirect.h
-// IWYU: IndirectClass needs a declaration
 NestedUseOfAliasedParameter<IndirectClass> c;
 
 /**** IWYU_SUMMARY

--- a/tests/cxx/virtual_tpl_method.cc
+++ b/tests/cxx/virtual_tpl_method.cc
@@ -32,19 +32,16 @@ template <typename T> struct Deleter {
 
 // Note we require the full type even though we don't call Delete.
 // IWYU: IndirectClass is...*indirect.h
-// IWYU: IndirectClass needs a declaration
 Deleter<IndirectClass> d(0);
 
 // IWYU: IndirectClass needs a declaration
 Deleter<IndirectClass>* pd
 // Another way to instantiate a template, also requirs the full type.
 // IWYU: IndirectClass is...*indirect.h
-// IWYU: IndirectClass needs a declaration
     = new Deleter<IndirectClass>(0);
 
 // This also instantiates the template, and thus requires the deleted-type.
 // IWYU: IndirectClass is...*indirect.h
-// IWYU: IndirectClass needs a declaration
 int id = Deleter<IndirectClass>::NothingToDoWithDelete();
 
 


### PR DESCRIPTION
The output with 3rd verbosity level is filtered from fwd-decl warnings when there is a full use of the same entity in the same line. This makes the output cleaner.