### PR TITLE
Improve handling template parameter aliases

### DIFF
--- a/tests/cxx/typedef_in_template.cc
+++ b/tests/cxx/typedef_in_template.cc
@@ -101,6 +101,17 @@ struct NestedUseOfAliasedParameter {
 // IWYU: IndirectClass needs a declaration
 NestedUseOfAliasedParameter<IndirectClass> c;
 
+template <typename T>
+struct UsesAliasedSugaredParameter {
+  static T t1;
+  using TAlias = decltype(t1);
+  TAlias t2;
+};
+
+// IWYU: IndirectClass is...*indirect.h
+// IWYU: IndirectClass needs a declaration
+constexpr auto s2 = sizeof(UsesAliasedSugaredParameter<IndirectClass>);
+
 /**** IWYU_SUMMARY
 
 tests/cxx/typedef_in_template.cc should add these lines:

--- a/tests/cxx/typedef_in_template.cc
+++ b/tests/cxx/typedef_in_template.cc
@@ -72,6 +72,9 @@ struct UsesAliasedParameter {
 // IWYU: IndirectClass is...*indirect.h
 // IWYU: IndirectClass needs a declaration
 UsesAliasedParameter<IndirectClass> a;
+// IWYU: IndirectClass is...*indirect.h
+// IWYU: IndirectClass needs a declaration
+constexpr auto s1 = sizeof(UsesAliasedParameter<IndirectClass>);
 
 // IWYU: IndirectClass is...*indirect.h
 // IWYU: IndirectClass needs a declaration


### PR DESCRIPTION
Full uses of aliased template parameters are now handled in `IwyuBaseAstVisitor::VisitTypedefType`, in the common manner with handling type aliases outside template instantiations. This handler only reports type alias underlying types. The uses of the type alias declarations themselves are reported from `IwyuAstConsumer` implementation, as before, and not during implicitly instantiated template traversal, because they should be already reported at the traversal of the template as written.
    
`ReportTypeUse` function reports not only direct aliases of template parameters but also when the aliased template parameter was sugared. A corresponding test case is added.

The main goal of this PR is to simplify `AnalyzeTemplateTypeParmUse` function.