### PR TITLE
Add support for driver test assertions without location

### DIFF
--- a/tests/driver/multiple_inputs.c
+++ b/tests/driver/multiple_inputs.c
@@ -1,0 +1,22 @@
+//===--- multiple_inputs.c - test input file for --------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// Check that include-what-you-use exits with error and diagnostic for
+// multiple inputs. Pass the current filename three times (first is implicit,
+// following two provided by args-line below).
+
+// IWYU_ARGS: tests/driver/multiple_inputs.c tests/driver/multiple_inputs.c
+
+// IWYU~: expected exactly one compiler job
+
+/**** IWYU_SUMMARY(1)
+
+// No IWYU summary expected.
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
Add '// IWYU~:' to complement '// IWYU:'.

This new form checks for diagnostics anywhere in the output, e.g. driver
diagnostics without `<file>:<line>:` decoration. Designed to catch errors
like:

    error: unable to handle compilation, expected exactly one compiler job
    error: unknown argument: '-fdump-rtl-expand'
    warning: argument unused during compilation: '-fobjc-exceptions'

Add a motivating testcase for multiple inputs.