### PR TITLE
Don't "provide" types on tpl instantiation side

### DIFF
--- a/tests/cxx/badinc.cc
+++ b/tests/cxx/badinc.cc
@@ -930,12 +930,14 @@ template class I1_TemplateClass<I1_ClassPtr>;
 // First, make sure the implicit instantiation instantiates some methods too.
 // IWYU: I2_TemplateClass is...*badinc-i2.h
 int i2_tpl_class_a = i2_template_class_with_inl_constructor.a();
+// IWYU: I2_TemplateClass needs a declaration
 // IWYU: I2_TemplateClass is...*badinc-i2.h
 // IWYU: I2_TemplateClass::I2_TemplateClass<.*> is...*badinc-i2-inl.h
 // IWYU: I2_TemplateClass::~I2_TemplateClass<.*> is...*badinc-i2-inl.h
 // IWYU: I2_TemplateClass::InlFileTemplateClassFn is...*badinc-i2-inl.h
 typedef I2_TemplateClass<int> Cc_typedef_implicit_instantiation;
 // Make sure we can do the same typedef multiple times.
+// IWYU: I2_TemplateClass needs a declaration
 // IWYU: I2_TemplateClass is...*badinc-i2.h
 // IWYU: I2_TemplateClass::I2_TemplateClass<.*> is...*badinc-i2-inl.h
 // IWYU: I2_TemplateClass::~I2_TemplateClass<.*> is...*badinc-i2-inl.h

--- a/tests/cxx/badinc.h
+++ b/tests/cxx/badinc.h
@@ -289,6 +289,7 @@ typedef std::set<I2_Enum> H_I2Enum_Set;
 // IWYU: std::vector is...*<vector>
 // IWYU: I2_Class is...*badinc-i2.h
 typedef std::vector<I2_Class> H_I2Class_Vector_Unused;
+// IWYU: I2_TemplateClass needs a declaration
 // IWYU: I2_TemplateClass is...*badinc-i2.h
 // IWYU: I2_TemplateClass::I2_TemplateClass<.*> is...*badinc-i2-inl.h
 // IWYU: I2_TemplateClass::~I2_TemplateClass<.*> is...*badinc-i2-inl.h

--- a/tests/cxx/explicit_instantiation.cc
+++ b/tests/cxx/explicit_instantiation.cc
@@ -76,6 +76,7 @@ template class ClassWithUsingMethod<IndirectClass>;
 template class ClassWithUsingMethod<IndirectTemplate<int>>;
 
 // The template argument is considered to be provided with type alias.
+// IWYU: IndirectTemplate needs a declaration
 // IWYU: IndirectTemplate is...*indirect.h
 typedef IndirectTemplate<char> ProvidingTypedef;
 // IWYU: ClassWithUsingMethod is...*explicit_instantiation-template.h

--- a/tests/cxx/iwyu_stricter_than_cpp-autocast.h
+++ b/tests/cxx/iwyu_stricter_than_cpp-autocast.h
@@ -63,24 +63,30 @@ template <typename T>
 struct TplIndirectStruct2;
 
 void TplFnValues(
+    // IWYU: TplIndirectStruct1 needs a declaration
     // IWYU: TplIndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h.*for autocast
     TplIndirectStruct1<char> ic1,
+    // IWYU: TplIndirectStructForwardDeclaredInD1 needs a declaration
     // IWYU: TplIndirectStructForwardDeclaredInD1 is...*iwyu_stricter_than_cpp-i1.h.*for autocast
     struct TplIndirectStructForwardDeclaredInD1<char> icfdid1,
     TplDirectStruct1<char> dc1, struct TplDirectStruct2<char> dc2,
     TplIndirectStruct2<char> ic2);
 
 void TplFnRefs(
+    // IWYU: TplIndirectStruct1 needs a declaration
     // IWYU: TplIndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h.*for autocast
     const TplIndirectStruct1<char>& ic1,
+    // IWYU: TplIndirectStructForwardDeclaredInD1 needs a declaration
     // IWYU: TplIndirectStructForwardDeclaredInD1 is...*iwyu_stricter_than_cpp-i1.h.*for autocast
     const struct TplIndirectStructForwardDeclaredInD1<char>& icfdid1,
     const TplDirectStruct3<char>& dc1, const struct TplDirectStruct4<char>& dc2,
     const TplIndirectStruct2<char>& ic2);
 
 inline void HeaderDefinedTplFnRefs(
+    // IWYU: TplIndirectStruct1 needs a declaration
     // IWYU: TplIndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h.*for autocast
     const TplIndirectStruct1<char>& ic1,
+    // IWYU: TplIndirectStructForwardDeclaredInD1 needs a declaration
     // IWYU: TplIndirectStructForwardDeclaredInD1 is...*iwyu_stricter_than_cpp-i1.h.*for autocast
     const struct TplIndirectStructForwardDeclaredInD1<char>& icfdid1,
     const TplDirectStruct5<char>& dc1, const struct TplDirectStruct6<char>& dc2,
@@ -149,6 +155,7 @@ inline void Fn(
 
 // Test that IWYU finds constructors even if they are not instantiated.
 
+// IWYU: NonInstantiated needs a declaration
 // IWYU: NonInstantiated is...*iwyu_stricter_than_cpp-i1.h.*for autocast
 void Fn(NonInstantiated<char>);
 

--- a/tests/cxx/iwyu_stricter_than_cpp-fnreturn.h
+++ b/tests/cxx/iwyu_stricter_than_cpp-fnreturn.h
@@ -39,6 +39,7 @@ IndirectStruct2 DoesEverythingRightFn();
 
 // --- Now do it all again, with templates!
 
+// IWYU: TplIndirectStruct1 needs a declaration
 // IWYU: TplIndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h.*for fn return type
 TplIndirectStruct1<int> TplDoesNotForwardDeclareFn();
 
@@ -46,6 +47,7 @@ TplIndirectStruct1<int> TplDoesNotForwardDeclareFn();
 // IndirectStructForwardDeclaredInD1' does not need to be
 // forward-declared because it's elaborated, but template types need
 // to be forward-declared even when they're elaborated.
+// IWYU: TplIndirectStructForwardDeclaredInD1 needs a declaration
 // IWYU: TplIndirectStructForwardDeclaredInD1 is...*iwyu_stricter_than_cpp-i1.h.*for fn return type
 struct TplIndirectStructForwardDeclaredInD1<int>
 TplDoesNotForwardDeclareProperlyFn();

--- a/tests/cxx/iwyu_stricter_than_cpp-type_alias.h
+++ b/tests/cxx/iwyu_stricter_than_cpp-type_alias.h
@@ -42,11 +42,13 @@ using DoesEverythingRightAl = IndirectStruct2;
 
 // --- Now do it all again, with templates!
 
+// IWYU: TplIndirectStruct1 needs a declaration
 // IWYU: TplIndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h
 using TplDoesNotForwardDeclareAl = TplIndirectStruct1<int>;
 
 using TplDoesNotForwardDeclareProperlyAl
-// IWYU: TplIndirectStructForwardDeclaredInD1 is...*iwyu_stricter_than_cpp-i1.h
+    // IWYU: TplIndirectStructForwardDeclaredInD1 needs a declaration
+    // IWYU: TplIndirectStructForwardDeclaredInD1 is...*iwyu_stricter_than_cpp-i1.h
     = TplIndirectStructForwardDeclaredInD1<int>;
 
 template <typename T> struct TplDirectStruct1;

--- a/tests/cxx/iwyu_stricter_than_cpp-typedefs.h
+++ b/tests/cxx/iwyu_stricter_than_cpp-typedefs.h
@@ -42,9 +42,11 @@ typedef IndirectStruct2 DoesEverythingRight;
 
 // --- Now do it all again, with templates!
 
+// IWYU: IndirectStruct1 needs a declaration
 // IWYU: IndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h
 typedef TplIndirectStruct1<int> TplDoesNotForwardDeclare;
 
+// IWYU: IndirectStructForwardDeclaredInD1 needs a declaration
 // IWYU: IndirectStructForwardDeclaredInD1 is...*iwyu_stricter_than_cpp-i1.h
 typedef TplIndirectStructForwardDeclaredInD1<int>
 TplDoesNotForwardDeclareProperly;

--- a/tests/cxx/iwyu_stricter_than_cpp.cc
+++ b/tests/cxx/iwyu_stricter_than_cpp.cc
@@ -67,6 +67,12 @@ struct NonUsingType {
   T* t = nullptr;
 };
 
+template <typename T1, typename T2>
+struct WithAlias {
+  // IWYU: TplIndirectStruct2 needs a declaration
+  // IWYU: TplIndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
+  using Type = TplIndirectStruct2<T1>;
+};
 
 typedef DoesEverythingRight DoubleTypedef;
 
@@ -236,6 +242,11 @@ void TestTypeAliases() {
   // IWYU: IndirectStruct4 is...*iwyu_stricter_than_cpp-i4.h
   // IWYU: IndirectClass is...*indirect.h
   IndirectStruct4NonProvidingAl::IndirectClassNonProvidingAl nn;
+
+  // Test that IWYU should not suggest to provide underlying type of template
+  // internal type alias on instantiation side.
+  // IWYU: TplIndirectStruct2 needs a declaration
+  WithAlias<int, TplIndirectStruct2<int>> wa;
 }
 
 void TestAutocast() {
@@ -400,6 +411,7 @@ void TestFunctionReturn() {
 
   // -- Call from a template with "providing" alias as a template argument.
 
+  // IWYU: TplIndirectStruct3 needs a declaration
   // IWYU: TplIndirectStruct3 is...*iwyu_stricter_than_cpp-i5.h
   // IWYU: IndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
   using Alias = TplIndirectStruct3<IndirectStruct2, IndirectStruct2>;

--- a/tests/cxx/typedef_in_template.cc
+++ b/tests/cxx/typedef_in_template.cc
@@ -22,6 +22,7 @@ class Container {
   // C++11 alias declaration, should not be an iwyu violation for T1
   using alias_type = T1;
 
+  // IWYU: Pair needs a declaration
   // IWYU: Pair is...*typedef_in_template-i2.h
   typedef Pair<T2,T2> pair_type;
 };


### PR DESCRIPTION
The problem was in analyzing in `IwyuBaseAstVisitor` (and hence in `InstantiatedTemplateVisitor`) whether a written template specialzation type is provided. Only template author can decide to provide a type inside a template, not template user for implicitly generated specialization code. To fix it, the analysis is moved into `IwyuAstConsumer` which doesn't traverse implicit template instantiation code.

`IsProvidedTypeComponent` and `CanBeProvidedTypeComponent` are moved into the private section of `IwyuAstConsumer` because they are now (and should be) needed only in that visitor class.

The test case uses two template arguments: `T1` to avoid putting `TemplateSpecializationType` into `nodes_to_ignore_` set and `T2` to allow the type to be reported (IWYU can currently report only template argument types from instantiated template traversal). `typedef` could in principle be used instead of `using`.

Noisy fwd-decl suggestions are appeared in the tests because they aren't now filtered out inside `IwyuBaseAstVisitor::VisitTemplateSpecializationType`.