### PR TITLE
Keep forward-declare lines containing macro expansions

### DIFF
--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -1654,4 +1654,9 @@ bool IsDeclaredInsideFunction(const Decl* decl) {
   return isa<FunctionDecl>(decl_ctx);
 }
 
+bool IsDeclaredInsideMacro(const clang::Decl* decl) {
+  SourceRange range = decl->getSourceRange();
+  return range.getBegin().isMacroID() || range.getEnd().isMacroID();
+}
+
 }  // namespace include_what_you_use

--- a/iwyu_ast_util.h
+++ b/iwyu_ast_util.h
@@ -893,6 +893,9 @@ std::string GetKindName(const clang::TypeLoc typeloc);
 // visible from said function.
 bool IsDeclaredInsideFunction(const clang::Decl* decl);
 
+// Returns true if decl is partially inside a macro.
+bool IsDeclaredInsideMacro(const clang::Decl* decl);
+
 }  // namespace include_what_you_use
 
 #endif  // INCLUDE_WHAT_YOU_USE_IWYU_AST_UTIL_H_

--- a/iwyu_output.cc
+++ b/iwyu_output.cc
@@ -1894,6 +1894,19 @@ void CalculateDesiredIncludesAndForwardDeclares(
       line.set_desired();
     }
   }
+
+  // Keep all forward-decls fully declared inside a macro. Otherwise IWYU will
+  // suggest to remove the expansion of a macro which might do any number of
+  // other things with side effects.
+  for (OneIncludeOrForwardDeclareLine& line : *lines) {
+    if (!line.is_desired() && !line.IsIncludeLine() &&
+        IsDeclaredInsideMacro(line.fwd_decl())) {
+      VERRS(6) << "Retaining unused forward-declare inside macro: "
+               << GetFilePath(line.fwd_decl()) << ":" << line.LineNumberString()
+               << ": " << line.line() << "\n";
+      line.set_desired();
+    }
+  }
 }
 
 bool IsRemovablePrefixHeader(const FileEntry* file_entry,

--- a/tests/cxx/forward_declare_in_macro.cc
+++ b/tests/cxx/forward_declare_in_macro.cc
@@ -9,35 +9,48 @@
 
 // IWYU_ARGS: -I .
 
-// Tests that when we forward-declare in a macro, that the line
-// numbers that iwyu emits about where the forward-declare lives in
-// the code, use the macro-instantiation location, never the
-// macro-spelling location.  In this case, the instantiation is here
-// in the .cc file, while the macro-spelling location is in the .h
-// file at line 11.
+// This test case used to be about proving that forward-declares inside macros
+// are not reported for a line range beginning in the macro-spelling location
+// (forward_declare_in_macro.h:11) and ending in the macro-expansion location
+// (forward_declare_in_macro.cc:XX). So it was important that the macro
+// expansion below was not on line 11, or the 'lines XX-XX' diagnostic would
+// still match.
+//
+// We've since abandoned trying to remove whole macros when a forward
+// declaration in them is unused, because a macro can do many useful things
+// _and also_ forward-declare a symbol.
+//
+// We'll maintain the line 11 constraint and leave this note here, in case
+// someone wants to try and recover the old behavior.
 
 #include "tests/cxx/forward_declare_in_macro.h"
 
-// Important that this not be on line 11.  Note that this macro is
-// carefully constructed so the beginning of it is in
-// forward_declare_in_macro.h, while the end of it is in macro.cc
-// (because the macro begins with 'normal' text and ends with a macro
-// parameter).  If iwyu incorrectly uses spelling location, the macro
-// will begin in forward_declare_in_macro.h:11 and end in
-// forward_declare_in_macro.cc:<nextline>, which will show as iwyu
-// thinking this forward-declaration spans many lines.  If iwyu
-// correctly uses instantiation location, on the other hand, it will
-// show as iwyu thinking this forward-declaration spans only one line.
-FORWARD_DECLARE_CLASS(MyClass);
+// Forward declaration unused but entirely inside a macro, will not be removed.
+FORWARD_DECLARE_CLASS(MyKeepClass);
+
+// The _declaration_ is in this file, but the symbol name is conjured using a
+// macro. This is ostensibly safe to remove, but we keep it.
+class CLASSNAME(RemoveClass);
+
+// TAIL_DECL generates a class name (OneConflicted) from the argument, but
+// injects another forward decl entirely inside the macro (TwoConflicted).
+// Will be kept even though none of the decls are used.
+class TAIL_DECL(Conflicted);
+
+class NormalFwdDecl;
 
 /**** IWYU_SUMMARY
 
 tests/cxx/forward_declare_in_macro.cc should add these lines:
 
 tests/cxx/forward_declare_in_macro.cc should remove these lines:
-- class MyClass;  // lines XX-XX
+- class NormalFwdDecl;  // lines XX-XX
 
 The full include-list for tests/cxx/forward_declare_in_macro.cc:
 #include "tests/cxx/forward_declare_in_macro.h"
+class MyKeepClass;  // lines XX-XX
+class MyRemoveClass;  // lines XX-XX
+class OneConflicted;  // lines XX-XX
+class TwoConflicted;  // lines XX-XX
 
 ***** IWYU_SUMMARY */

--- a/tests/cxx/forward_declare_in_macro.h
+++ b/tests/cxx/forward_declare_in_macro.h
@@ -10,6 +10,10 @@
 // Important that this macro be on line 11 of this file.
 #define FORWARD_DECLARE_CLASS(cls)   class cls
 
+#define CLASSNAME(cls) My##cls
+
+#define TAIL_DECL(cls) One##cls; class Two##cls
+
 /**** IWYU_SUMMARY
 
 (tests/cxx/forward_declare_in_macro.h has correct #includes/fwd-decls)


### PR DESCRIPTION
IWYU used to look through macros to be able to remove unused forward declaration lines even if they were the result of a macro expansion.

Macros are tricky, though. As demonstrated in #1296, a macro can do more than one thing, e.g. declare two symbols or even generate code with side effects. Consider for example:

    #define PROLOG_PIN(x)  class Pin##x; TogglePin(x);

    void foo() {
        PROLOG_PIN(2)
        // Pin2 class is unused, macro would be removed and hardware
        // would be unhappy.
    }

Work around this by force-keeping any forward declaration whose location is even partially inside a macro.

Fixes issue #1296.