### PR TITLE
Filter out jobs with unsupported action class in driver

### DIFF
--- a/iwyu_driver.cc
+++ b/iwyu_driver.cc
@@ -195,6 +195,14 @@ std::string JobsToString(const JobList& jobs, const char* sep) {
 std::vector<const Command*> FilterJobs(const JobList& jobs) {
   std::vector<const Command*> res;
   for (const Command& job : jobs) {
+    const Action& action = job.getSource();
+    if (action.getKind() != Action::CompileJobClass &&
+        action.getKind() != Action::PreprocessJobClass) {
+      VERRS(2) << "warning: ignoring unsupported job type: "
+               << action.getClassName() << "\n";
+      continue;
+    }
+
     StringRef tool = job.getCreator().getName();
     if (tool != "clang") {
       VERRS(2) << "warning: ignoring job from unexpected tool: " << tool

--- a/tests/driver/generate_pch.c
+++ b/tests/driver/generate_pch.c
@@ -1,0 +1,23 @@
+//===--- generate_pch.c - test input file for IWYU ------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// Check that IWYU ignores the 'precompile' job produced by a PCH-generating
+// command. Since that's the only job, it proceeds to fail because there's no
+// compiler job to replace.
+
+// IWYU_ARGS: -o generate_pch.c.pch -xc-header
+
+// IWYU~: ignoring unsupported job type.*precompile
+// IWYU~: expected exactly one compiler job
+
+/**** IWYU_SUMMARY(1)
+
+// No IWYU summary expected.
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
In FilterJobs, drop any job that is not Compile or Preprocess. Other action classes cannot be handled by IWYU.