### PR TITLE
Filter out offload compile jobs in driver

### DIFF
--- a/iwyu_driver.cc
+++ b/iwyu_driver.cc
@@ -203,6 +203,13 @@ std::vector<const Command*> FilterJobs(const JobList& jobs) {
       continue;
     }
 
+    Action::OffloadKind offload_kind = action.getOffloadingDeviceKind();
+    if (offload_kind != Action::OFK_None) {
+      VERRS(2) << "warning: ignoring offload job for device toolchain: "
+               << action.GetOffloadKindName(offload_kind) << "\n";
+      continue;
+    }
+
     StringRef tool = job.getCreator().getName();
     if (tool != "clang") {
       VERRS(2) << "warning: ignoring job from unexpected tool: " << tool

--- a/tests/driver/offload_apple.c
+++ b/tests/driver/offload_apple.c
@@ -1,0 +1,21 @@
+//===--- offload_apple.c - test input file for IWYU -----------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// Check that IWYU ignores the extra offload compiler job produced when
+// compiling for Apple's HIP.
+
+// IWYU_ARGS: -target arm64-apple-macosx11.0.0 -x hip -nogpulib -nogpuinc
+
+// IWYU~: ignoring offload job for device toolchain: hip
+
+/**** IWYU_SUMMARY(0)
+
+(tests/driver/offload_apple.c has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/driver/offload_openmp.c
+++ b/tests/driver/offload_openmp.c
@@ -1,0 +1,26 @@
+//===--- offload_openmp.c - test input file for IWYU ----------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// Check that IWYU ignores the extra offload compiler job produced when
+// compiling for OpenMP.
+
+// IWYU_ARGS: -fopenmp -fopenmp-targets=nvptx64 -nocudalib
+
+// This first diagnostic only happens because I don't have an nvptx64 toolchain
+// on my machine -- this test should maybe be conditional on the presence of
+// such a toolchain.
+// IWYU~: Executable ".*" doesn't exist!; consider passing it via '-march'
+
+// IWYU~: ignoring offload job for device toolchain: openmp
+
+/**** IWYU_SUMMARY(0)
+
+(tests/driver/offload_openmp.c has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
Some compile commands produce two jobs: one for compiling the host code, and one for compiling device offload.

Explicitly filter out device offload jobs.

Fixes issue #1279.