### PR TITLE
Automatically add -Qunused-arguments for IWYU jobs

### DIFF
--- a/iwyu_driver.cc
+++ b/iwyu_driver.cc
@@ -256,6 +256,7 @@ bool ExecuteAction(int argc, const char** argv,
   // preprocessing-only.
   if (!HasPreprocessOnlyArgs(args)) {
     args.push_back("-fsyntax-only");
+    args.push_back("-Qunused-arguments");
   }
 
   // Build a compilation, get the job list and filter out irrelevant jobs.

--- a/tests/driver/compile_and_link.c
+++ b/tests/driver/compile_and_link.c
@@ -1,0 +1,24 @@
+//===--- compile_and_link.c - test input file for -------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// The presence of -o and -l would nominally create a linker job. That is
+// filtered out implicitly by -fsyntax-only, which means nobody claims the
+// -lblah switch. Check that IWYU doesn't warn about ''linker' input unused'.
+
+// IWYU_ARGS: -o program -lblah
+
+int main() {
+  return 0;
+}
+
+/**** IWYU_SUMMARY
+
+(tests/driver/compile_and_link.c has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
IWYU forcefully adds '-fsyntax-only' to the command line to avoid generating outputs. But that means more full-fledged compile commands containing more than one job type will potentially end up with unused flags because the jobs are discarded in syntax-only mode. For example:

    include-what-you-use -o program -lsomething t.c

would warn that the '-lsomething' switch was unused, since the linker job is short-circuited by '-fsyntax-only'.

Also add -Qunused-arguments to silence this kind of warning when we add -fsyntax-only.

Improves the situation described in #815, which already seems less severe, probably due to Clang driver changes.