### PR TITLE
Accept multiple inputs, but only use the first

### DIFF
--- a/tests/driver/multiple_inputs.c
+++ b/tests/driver/multiple_inputs.c
@@ -7,16 +7,16 @@
 //
 //===----------------------------------------------------------------------===//
 
-// Check that include-what-you-use exits with error and diagnostic for
-// multiple inputs. Pass the current filename three times (first is implicit,
-// following two provided by args-line below).
+// Check that include-what-you-use allows multiple inputs but discards all but
+// one, with a diagnostic. The multiple_inputs.c file is already implicitly
+// added to IWYU command, use IWYU_ARGS to add it twice more.
 
 // IWYU_ARGS: tests/driver/multiple_inputs.c tests/driver/multiple_inputs.c
 
-// IWYU~: expected exactly one compiler job
+// IWYU~: ignoring 2 extra jobs
 
-/**** IWYU_SUMMARY(1)
+/**** IWYU_SUMMARY
 
-// No IWYU summary expected.
+(tests/driver/multiple_inputs.c has correct #includes/fwd-decls)
 
 ***** IWYU_SUMMARY */


### PR DESCRIPTION
Print diagnostic for how many and which extra jobs were dropped.