### PR TITLE
Never allow system headers to be associated

### DIFF
--- a/iwyu_location_util.cc
+++ b/iwyu_location_util.cc
@@ -30,9 +30,11 @@ using clang::CXXOperatorCallExpr;
 using clang::ClassTemplateSpecializationDecl;
 using clang::ConditionalOperator;
 using clang::FileEntry;
+using clang::FileID;
 using clang::FunctionDecl;
 using clang::MemberExpr;
 using clang::SourceLocation;
+using clang::SourceManager;
 using clang::UnaryOperator;
 using clang::UnresolvedMemberExpr;
 
@@ -183,6 +185,13 @@ bool IsInHeader(const clang::Decl* decl) {
     return false;
   }
   return !GlobalSourceManager()->isMainFile(*containing_file);
+}
+
+bool IsSystemHeader(const FileEntry* file) {
+  const SourceManager* sm = GlobalSourceManager();
+  FileID file_id = sm->translateFile(file);
+  SourceLocation loc = sm->getLocForStartOfFile(file_id);
+  return sm->isInSystemHeader(loc);
 }
 
 }  // namespace include_what_you_use

--- a/iwyu_location_util.h
+++ b/iwyu_location_util.h
@@ -231,6 +231,9 @@ inline bool IsBeforeInSameFile(const T& a, const U& b) {
 // Returns true if the given declaration is located in a header file.
 bool IsInHeader(const clang::Decl*);
 
+// Returns true if file is a system header.
+bool IsSystemHeader(const clang::FileEntry* file);
+
 }  // namespace include_what_you_use
 
 #endif  // INCLUDE_WHAT_YOU_USE_IWYU_LOCATION_UTIL_H_

--- a/iwyu_preprocessor.cc
+++ b/iwyu_preprocessor.cc
@@ -1051,6 +1051,8 @@ bool IwyuPreprocessorInfo::BelongsToMainCompilationUnit(
   // currently sometimes called with a nullptr main_file_.
   if (!includee)
     return false;
+  if (IsSystemHeader(includee))
+    return false;
   if (GetCanonicalName(GetFilePath(includee)) ==
       GetCanonicalName(GetFilePath(main_file_)))
     return true;

--- a/tests/cxx/stdint.cc
+++ b/tests/cxx/stdint.cc
@@ -1,0 +1,26 @@
+//===--- stdint.cc - test input file for IWYU -----------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU does some heuristic name matching to find the "associated header"; the
+// header declaring the public API for the current source file, e.g. "foo.h" for
+// "foo.cc". Make sure it doesn't consider system headers associated.
+//
+// If it fails, this test will print unwanted IWYU diagnostics from stdint.h.
+
+#include <stdint.h>
+
+int foo() {
+  return (int32_t)100;
+}
+
+/**** IWYU_SUMMARY
+
+(tests/cxx/stdint.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
Use `<stdint.h>` to test.

Fixes #1037.