### PR TITLE
Make blank lines around #pragma push/pop lines prettier

### DIFF
--- a/fix_includes.py
+++ b/fix_includes.py
@@ -88,6 +88,8 @@ _C_COMMENT_START_RE = re.compile(r'\s*/\*')
 _C_COMMENT_END_RE = re.compile(r'.*\*/\s*(.*)$')
 _COMMENT_LINE_RE = re.compile(r'\s*//')
 _PRAGMA_ONCE_LINE_RE = re.compile(r'\s*#\s*pragma\s+once')
+_PRAGMA_PUSH_LINE_RE = re.compile(r'\s*#\s*pragma.*push.*')
+_PRAGMA_POP_LINE_RE = re.compile(r'\s*#\s*pragma.*pop.*')
 _BLANK_LINE_RE = re.compile(r'\s*$')
 _IF_RE = re.compile(r'\s*#\s*if')               # compiles #if/ifdef/ifndef
 _ELSE_RE = re.compile(r'\s*#\s*(else|elif)\b')  # compiles #else/elif
@@ -136,6 +138,7 @@ _LINE_TYPES = [_COMMENT_LINE_RE, _BLANK_LINE_RE,
                _INCLUDE_RE, _FORWARD_DECLARE_RE,
                _HEADER_GUARD_RE, _HEADER_GUARD_DEFINE_RE,
                _PRAGMA_ONCE_LINE_RE,
+               _PRAGMA_PUSH_LINE_RE, _PRAGMA_POP_LINE_RE,
               ]
 
 # A regexp matching #include lines that should be a barrier for
@@ -1262,6 +1265,7 @@ def _ShouldInsertBlankLine(decorated_move_span, next_decorated_move_span,
             file_lines[next_line].type in (_NAMESPACE_START_RE,
                                            _NAMESPACE_START_ALLMAN_RE,
                                            _NAMESPACE_START_MIXED_RE,
+                                           _PRAGMA_PUSH_LINE_RE,
                                            None))
 
   # We never insert a blank line between two spans of the same kind.

--- a/fix_includes_test.py
+++ b/fix_includes_test.py
@@ -2743,6 +2743,53 @@ The full include-list for weird_pragma_once.h:
     self.RegisterFileContents({'weird_pragma_once.h': infile})
     self.ProcessAndTest(iwyu_output)
 
+  def testNoSpaceBeforePragmaPop(self):
+    """Tests that we don't inject a blank line before a #pragma pop """
+    infile = """\
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#include <cstdint>
+#pragma GCC diagnostic pop
+#include <exception>  ///-
+"""
+    iwyu_output = """\
+pragma_spaces.cc should add these lines:
+
+pragma_spaces.cc should remove these lines:
+- #include <exception>  // lines 5-5
+
+The full include-list for pragma_spaces.cc:
+#include <cstdint>
+---
+"""
+    self.RegisterFileContents({'pragma_spaces.cc': infile})
+    self.ProcessAndTest(iwyu_output)
+
+  def testSpaceBeforePragmaPush(self):
+    """Tests that we inject a blank line before a #pragma push """
+    infile = """\
+#include <cctype>
+///+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#include <cstdint>
+#pragma GCC diagnostic pop
+#include <exception>  ///-
+"""
+    iwyu_output = """\
+pragma_spaces.cc should add these lines:
+
+pragma_spaces.cc should remove these lines:
+- #include <exception>  // lines 6-6
+
+The full include-list for pragma_spaces.cc:
+#include <cctype>
+#include <cstdint>
+---
+"""
+    self.RegisterFileContents({'pragma_spaces.cc': infile})
+    self.ProcessAndTest(iwyu_output)
+
   def testAddIncludeAfterWeirdHeaderGuard(self):
     """Test that we are willing to insert .h's inside a non-standard h-guard."""
     infile = """\


### PR DESCRIPTION
Before we would transform from this:

    #pragma GCC diagnostic push
    #pragma GCC diagnostic ignored "-Warray-bounds"
    #include <cstdint>
    #pragma GCC diagnostic pop

to this:

    #pragma GCC diagnostic push
    #pragma GCC diagnostic ignored "-Warray-bounds"
    #include <cstdint>

    #pragma GCC diagnostic pop

because we didn't recognize push/pop pragmas as special. Usually they mark a group, and it's nicer to keep the trailing pop together with the line before.

Fix this, and also put a blank line before the push, so as to highlight the coming group.

The push/pop pragmas are loosely pattern matched, so the same rule will apply to similar pragmas like:

- #pragma pack(push)/#pragma pack(pop)
- #pragma warning(push)/#pragma warning(pop)
- #pragma push_macro/#pragma pop_macro

Fixes issue #1237.