### PR TITLE
Include FileEntry.h instead of forward-declaring

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -129,6 +129,7 @@
 #include "clang/AST/TemplateBase.h"
 #include "clang/AST/Type.h"
 #include "clang/AST/TypeLoc.h"
+#include "clang/Basic/FileEntry.h"
 #include "clang/Basic/SourceLocation.h"
 #include "clang/Basic/TypeTraits.h"
 #include "clang/Frontend/CompilerInstance.h"
@@ -138,7 +139,6 @@
 #include "clang/Sema/Sema.h"
 
 namespace clang {
-class FileEntry;
 class PPCallbacks;
 
 namespace driver {

--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -41,13 +41,10 @@
 #include "clang/AST/Type.h"
 #include "clang/AST/TypeLoc.h"
 #include "clang/Basic/Builtins.h"
+#include "clang/Basic/FileEntry.h"
 #include "clang/Basic/SourceLocation.h"
 #include "clang/Basic/SourceManager.h"
 #include "clang/Basic/Specifiers.h"
-
-namespace clang {
-class FileEntry;
-}  // namespace clang
 
 using clang::ASTDumper;
 using clang::BlockPointerType;

--- a/iwyu_globals.h
+++ b/iwyu_globals.h
@@ -15,9 +15,10 @@
 #include <string>                       // for string
 #include <vector>                       // for vector
 
+#include "clang/Basic/FileEntry.h"
+
 namespace clang {
 class CompilerInstance;
-class FileEntry;
 class HeaderSearch;
 class SourceManager;
 struct PrintingPolicy;

--- a/iwyu_include_picker.h
+++ b/iwyu_include_picker.h
@@ -50,9 +50,7 @@
 #include <utility>                      // for pair
 #include <vector>                       // for vector
 
-namespace clang {
-class FileEntry;
-}  // namespace clang
+#include "clang/Basic/FileEntry.h"
 
 namespace include_what_you_use {
 

--- a/iwyu_output.h
+++ b/iwyu_output.h
@@ -25,10 +25,10 @@
 #include "iwyu_stl_util.h"
 #include "iwyu_use_flags.h"
 #include "clang/AST/Decl.h"
+#include "clang/Basic/FileEntry.h"
 #include "clang/Basic/SourceLocation.h"
 
 namespace clang {
-class FileEntry;
 class UsingDecl;
 class ElaboratedTypeLoc;
 }  // namespace clang

--- a/iwyu_preprocessor.h
+++ b/iwyu_preprocessor.h
@@ -70,6 +70,7 @@
 #include "iwyu_output.h"
 #include "iwyu_port.h"  // for CHECK_
 
+#include "clang/Basic/FileEntry.h"
 #include "clang/Basic/SourceLocation.h"
 #include "clang/Basic/SourceManager.h"
 #include "clang/Lex/Preprocessor.h"
@@ -77,7 +78,6 @@
 #include "clang/Lex/Token.h"
 
 namespace clang {
-class FileEntry;
 class MacroInfo;
 class NamedDecl;
 }  // namespace clang

--- a/iwyu_verrs.h
+++ b/iwyu_verrs.h
@@ -12,11 +12,9 @@
 #ifndef INCLUDE_WHAT_YOU_USE_IWYU_VERRS_H_
 #define INCLUDE_WHAT_YOU_USE_IWYU_VERRS_H_
 
-#include "llvm/Support/raw_ostream.h"
+#include "clang/Basic/FileEntry.h"
 
-namespace clang {
-class FileEntry;
-}
+#include "llvm/Support/raw_ostream.h"
 
 namespace include_what_you_use {
 


### PR DESCRIPTION
Upcoming changes will move all uses of 'const FileEntry*' to 'OptionalFileEntryRef', and by then all files currently forward-declaring FileEntry will need a complete type.

No functional change.