### PR TITLE
Move to StringRef::starts_with instead of deprecated alias

### DIFF
--- a/iwyu_driver.cc
+++ b/iwyu_driver.cc
@@ -254,7 +254,7 @@ bool ExecuteAction(int argc, const char** argv,
 
   // Drop -save-temps arguments to avoid multiple compilation jobs.
   llvm::erase_if(args, [](StringRef arg) {
-    return arg.startswith("-save-temps") || arg.startswith("--save-temps");
+    return arg.starts_with("-save-temps") || arg.starts_with("--save-temps");
   });
 
   // FIXME: This is a hack to try to force the driver to do something we can


### PR DESCRIPTION
Move to StringRef::starts_with instead of deprecated alias

StringRef::startswith was marked deprecated in
https://github.com/llvm/llvm-project/commit/5ac12951b4e9bbfcc5791282d0961ec2b65575e9
on 2023-12-17. Use the new string_view-compatible spelling.

No functional change.
