### PR TITLE
Add parallel APIs for new FileEntry types

### DIFF
--- a/iwyu_preprocessor.cc
+++ b/iwyu_preprocessor.cc
@@ -766,7 +766,7 @@ void IwyuPreprocessorInfo::FileSkipped(const FileEntryRef& file,
       GetInstantiationLoc(filename.getLocation());
   ERRSYM(GetFileEntry(include_loc))
       << "[ (#include)  ] " << include_name_as_written
-      << " (" << GetFilePath(&file.getFileEntry()) << ")\n";
+      << " (" << GetFilePath(file) << ")\n";
 
   AddDirectInclude(include_loc, &file.getFileEntry(), include_name_as_written);
   if (ShouldReportIWYUViolationsFor(&file.getFileEntry())) {


### PR DESCRIPTION
Clang is slowly moving toward encapsulating 'FileEntry*' as either 'FileEntryRef', guaranteed to have a value, or 'OptionalFileEntryRef', which can be empty or populated.

Add parallel APIs to get path from the new FileEntry types; leave the old ones in place. For functions returning a Ref type instead of a FileEntry pointer, name them Get...Ref.

Disable warnings around uses of the deprecated FileEntry::getName.

Add a new function, RawFileEntry, to allow decaying an OptionalFileEntryRef to a plain pointer again (which will soon become necessary).

Prefer the new functions internally in iwyu_location_util, and update a single use in iwyu_preprocessor to avoid decaying to pointer.