### PR TITLE
Rewrite codebase to use OptionalFileEntryRef over FileEntry*

### DIFF
--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -74,7 +74,6 @@ using clang::EnumDecl;
 using clang::ExplicitCastExpr;
 using clang::Expr;
 using clang::ExprWithCleanups;
-using clang::FileEntry;
 using clang::FullSourceLoc;
 using clang::FunctionDecl;
 using clang::FunctionTemplateSpecializationInfo;
@@ -87,6 +86,7 @@ using clang::MemberPointerType;
 using clang::NamedDecl;
 using clang::NestedNameSpecifier;
 using clang::ObjCObjectType;
+using clang::OptionalFileEntryRef;
 using clang::OverloadExpr;
 using clang::PointerType;
 using clang::QualType;
@@ -205,10 +205,10 @@ SourceLocation ASTNode::GetLocation() const {
   if (retval.isValid()) {
     clang::SourceManager& sm = *GlobalSourceManager();
     FullSourceLoc full_loc(retval, sm);
-    const FileEntry* spelling_file =
-        sm.getFileEntryForID(sm.getFileID(full_loc.getSpellingLoc()));
-    const FileEntry* instantiation_file =
-        sm.getFileEntryForID(sm.getFileID(full_loc.getExpansionLoc()));
+    OptionalFileEntryRef spelling_file =
+        sm.getFileEntryRefForID(sm.getFileID(full_loc.getSpellingLoc()));
+    OptionalFileEntryRef instantiation_file =
+        sm.getFileEntryRefForID(sm.getFileID(full_loc.getExpansionLoc()));
     if (spelling_file != instantiation_file)
       return SourceLocation();
   }

--- a/iwyu_globals.cc
+++ b/iwyu_globals.cc
@@ -533,7 +533,7 @@ void AddGlobToReportIWYUViolationsFor(const string& glob) {
   commandline_flags->check_also.insert(NormalizeFilePath(glob));
 }
 
-bool ShouldReportIWYUViolationsFor(const clang::FileEntry* file) {
+bool ShouldReportIWYUViolationsFor(clang::OptionalFileEntryRef file) {
   const string filepath = GetFilePath(file);
   for (const string& glob : GlobalFlags().check_also)
     if (GlobMatchesPath(glob.c_str(), filepath.c_str()))
@@ -546,7 +546,7 @@ void AddGlobToKeepIncludes(const string& glob) {
   commandline_flags->keep.insert(NormalizeFilePath(glob));
 }
 
-bool ShouldKeepIncludeFor(const clang::FileEntry* file) {
+bool ShouldKeepIncludeFor(clang::OptionalFileEntryRef file) {
   if (GlobalFlags().keep.empty())
     return false;
   const string filepath = GetFilePath(file);

--- a/iwyu_globals.h
+++ b/iwyu_globals.h
@@ -138,12 +138,12 @@ FullUseCache* ClassMembersFullUseCache();
 // They are specified as glob file-patterns (which behave just as they
 // do in the shell).  TODO(csilvers): use a prefix instead? allow '...'?
 void AddGlobToReportIWYUViolationsFor(const string& glob);
-bool ShouldReportIWYUViolationsFor(const clang::FileEntry* file);
+bool ShouldReportIWYUViolationsFor(clang::OptionalFileEntryRef file);
 
 // For the commandline option --keep.
 // Similar to AddGlobToReportIWYUViolationsFor.
 void AddGlobToKeepIncludes(const string& glob);
-bool ShouldKeepIncludeFor(const clang::FileEntry* file);
+bool ShouldKeepIncludeFor(clang::OptionalFileEntryRef file);
 
 }  // namespace include_what_you_use
 

--- a/iwyu_include_picker.cc
+++ b/iwyu_include_picker.cc
@@ -1640,7 +1640,7 @@ bool IncludePicker::HasMapping(const string& map_from_filepath,
   return quoted_to == quoted_from;   // indentity mapping, why not?
 }
 
-bool IncludePicker::IsPublic(const clang::FileEntry* file) const {
+bool IncludePicker::IsPublic(clang::OptionalFileEntryRef file) const {
   CHECK_(file && "Need existing FileEntry");
   const string path = GetFilePath(file);
   const string quoted_file = ConvertToQuotedInclude(path);

--- a/iwyu_include_picker.h
+++ b/iwyu_include_picker.h
@@ -178,7 +178,7 @@ class IncludePicker {
   bool HasMapping(const string& map_from_filepath,
                   const string& map_to_filepath) const;
 
-  bool IsPublic(const clang::FileEntry* file) const;
+  bool IsPublic(clang::OptionalFileEntryRef file) const;
 
   // Parses a YAML/JSON file containing mapping directives of various types.
   void AddMappingsFromFile(const string& filename);

--- a/iwyu_verrs.cc
+++ b/iwyu_verrs.cc
@@ -15,7 +15,7 @@
 
 namespace include_what_you_use {
 
-using clang::FileEntry;
+using clang::OptionalFileEntryRef;
 
 namespace {
 int verbose_level = 1;
@@ -29,7 +29,7 @@ int GetVerboseLevel() {
   return verbose_level;
 }
 
-bool ShouldPrintSymbolFromFile(const FileEntry* file) {
+bool ShouldPrintSymbolFromFile(OptionalFileEntryRef file) {
   if (GetVerboseLevel() < 5) {
     return false;
   } else if (GetVerboseLevel() < 10) {

--- a/iwyu_verrs.h
+++ b/iwyu_verrs.h
@@ -30,7 +30,7 @@ inline bool ShouldPrint(int verbose_level) {
 // given file, at the current verbosity level.  For instance, at most
 // normal verbosities, we don't print information about symbols in
 // system header files.
-bool ShouldPrintSymbolFromFile(const clang::FileEntry* file);
+bool ShouldPrintSymbolFromFile(clang::OptionalFileEntryRef file);
 
 // VERRS(n) << blah;
 // prints blah to errs() if the verbose level is >= n.


### PR DESCRIPTION
This is the result of:

    sed -i -e 's/using clang::FileEntry;/using clang::OptionalFileEntryRef;/g' *.cc *.h
    sed -i -e 's/const FileEntry\*/OptionalFileEntryRef/g' *.cc *.h
    sed -i -e 's/const clang::FileEntry\*/clang::OptionalFileEntryRef/g' *.cc *.h
    sed -i -e 's/GetFileEntry(/GetFileEntryRef(/g' *.cc *.h
    sed -i -e 's/GetLocFileEntry(/GetLocFileEntryRef(/g' *.cc *.h

    git restore iwyu_location_util.*

followed by fixing up a small number of trivial type errors manually, and formatting.

No functional change.