### PR TITLE
Remove legacy FileEntry* functions

### DIFF
--- a/iwyu_location_util.cc
+++ b/iwyu_location_util.cc
@@ -188,13 +188,6 @@ bool IsInHeader(const clang::Decl* decl) {
   return !GlobalSourceManager()->isMainFile(containing_file->getFileEntry());
 }
 
-bool IsSystemHeader(const clang::FileEntry* file) {
-  const SourceManager* sm = GlobalSourceManager();
-  FileID file_id = sm->translateFile(file);
-  SourceLocation loc = sm->getLocForStartOfFile(file_id);
-  return sm->isInSystemHeader(loc);
-}
-
 bool IsSystemHeader(OptionalFileEntryRef file) {
   const SourceManager* sm = GlobalSourceManager();
   FileID file_id = sm->translateFile(*file);

--- a/iwyu_location_util.h
+++ b/iwyu_location_util.h
@@ -50,8 +50,6 @@
 #include "clang/Basic/SourceManager.h"
 #include "clang/Lex/Token.h"
 
-#include "llvm/Support/Compiler.h"
-
 namespace clang {
 class Decl;
 class NestedNameSpecifierLoc;
@@ -76,10 +74,6 @@ inline const clang::FileEntry* RawFileEntry(clang::OptionalFileEntryRef file) {
 
 // Some symbols are directly defined by the compiler.  For them, the
 // definition location points to the "<built-in>" file.
-inline bool IsBuiltinFile(const clang::FileEntry* file) {
-  return file == nullptr;
-}
-
 inline bool IsBuiltinFile(clang::OptionalFileEntryRef file) {
   return !file;
 }
@@ -91,12 +85,6 @@ inline bool IsBuiltinFile(clang::OptionalFileEntryRef file) {
 // "<built-in>" in the first case, and "<command line>" in the second.
 // IsBuiltinOrCommandLineFile(file) returns true if it's either of the
 // two cases.
-LLVM_SUPPRESS_DEPRECATED_DECLARATIONS_PUSH
-inline bool IsBuiltinOrCommandLineFile(const clang::FileEntry* file) {
-  return IsBuiltinFile(file) || file->getName().equals("<command line>");
-}
-LLVM_SUPPRESS_DEPRECATED_DECLARATIONS_POP
-
 inline bool IsBuiltinOrCommandLineFile(clang::OptionalFileEntryRef file) {
   return IsBuiltinFile(file) || file->getName().equals("<command line>");
 }
@@ -108,13 +96,6 @@ inline bool IsBuiltinOrCommandLineFile(clang::OptionalFileEntryRef file) {
 bool IsInScratchSpace(clang::SourceLocation loc);
 
 // Resolve canonical file path from various file entry types.
-LLVM_SUPPRESS_DEPRECATED_DECLARATIONS_PUSH
-inline string GetFilePath(const clang::FileEntry* file) {
-  return (IsBuiltinFile(file) ? "<built-in>" :
-          NormalizeFilePath(file->getName().str()));
-}
-LLVM_SUPPRESS_DEPRECATED_DECLARATIONS_POP
-
 inline string GetFilePath(clang::OptionalFileEntryRef file) {
   return (IsBuiltinFile(file) ? "<built-in>"
                               : NormalizeFilePath(file->getName().str()));
@@ -164,15 +145,6 @@ inline int GetLineNumber(clang::SourceLocation loc) {
 // Tells which #include loc comes from.
 // This is the most basic FileEntry getter, it only does a simple lookup in
 // SourceManager to determine which file the location is associated with.
-inline const clang::FileEntry* GetLocFileEntry(clang::SourceLocation loc) {
-  // clang uses the name FileID to mean 'a filename that was reached via
-  // a particular series of #includes.'  (What one might think a FileID
-  // might be -- a unique reference to a filesystem object -- is
-  // actually a FileEntry*.)
-  const clang::SourceManager& source_manager = *GlobalSourceManager();
-  return source_manager.getFileEntryForID(source_manager.getFileID(loc));
-}
-
 inline clang::OptionalFileEntryRef GetLocFileEntryRef(
     clang::SourceLocation loc) {
   // clang uses the name FileID to mean 'a filename that was reached via
@@ -181,31 +153,6 @@ inline clang::OptionalFileEntryRef GetLocFileEntryRef(
   // actually a FileEntry*.)
   const clang::SourceManager& source_manager = *GlobalSourceManager();
   return source_manager.getFileEntryRefForID(source_manager.getFileID(loc));
-}
-
-inline const clang::FileEntry* GetFileEntry(clang::SourceLocation loc) {
-  if (!loc.isValid())
-    return nullptr;
-
-  // We want where the user actually writes the token, instead of
-  // where it appears as part of a macro expansion.  For example, in:
-  //
-  //  file foo.h,  line 5:  #define FOO(x) x + y
-  //  file bar.cc, line 10: FOO(z)
-  //
-  // FOO(z) will expand to 'z + y', where symbol z's location is
-  // foo.h, line 5, and its spelling location is bar.cc, line 10.
-  const clang::FileEntry* retval = GetLocFileEntry(GetSpellingLoc(loc));
-
-  // Sometimes the spelling location is NULL, because the symbol is
-  // 'spelled' via macro concatenation.  For instance, all the
-  // __gthrw3 symbols in
-  // /usr/include/c++/4.2/x86_64-linux-gnu/bits/gthr-default.h.
-  // In that case, fall back on the instantiation location.
-  if (!retval) {
-    retval = GetLocFileEntry(GetInstantiationLoc(loc));
-  }
-  return retval;
 }
 
 inline clang::OptionalFileEntryRef GetFileEntryRef(clang::SourceLocation loc) {
@@ -252,11 +199,6 @@ clang::SourceLocation GetLocation(const clang::TemplateArgumentLoc* argloc);
 // These define default implementations of GetFileEntry() and
 // GetPath() in terms of GetLocation().  As long as an object defines
 // its own GetLocation(), it will get these other two for free.
-template <typename T>
-const clang::FileEntry* GetFileEntry(const T& obj) {
-  return GetFileEntry(GetLocation(obj));
-}
-
 template <typename T>
 clang::OptionalFileEntryRef GetFileEntryRef(const T& obj) {
   return GetFileEntryRef(GetLocation(obj));
@@ -307,7 +249,6 @@ inline bool IsBeforeInSameFile(const T& a, const U& b) {
 bool IsInHeader(const clang::Decl*);
 
 // Returns true if file is a system header.
-bool IsSystemHeader(const clang::FileEntry* file);
 bool IsSystemHeader(clang::OptionalFileEntryRef file);
 
 }  // namespace include_what_you_use


### PR DESCRIPTION
Now that all code is ported over to use the (Optional)FileEntryRef overloads, remove the legacy functions.

Building and testing this step change proves they weren't used in any meaningful way after the rewrite.

No functional change intended.