### PR TITLE
Clean up FileEntry comments

### DIFF
--- a/iwyu_location_util.h
+++ b/iwyu_location_util.h
@@ -25,8 +25,10 @@
 // Clang uses the type FileEntry to identify a physical file in the
 // file system.  A FileEntry is created for each source file Clang
 // processes.  Clang never creates two FileEntry objects for the same
-// file.  Therefore we use const FileEntry* in IWYU as unique IDs for
-// files.
+// file, so FileEntry objects have pointer identity. Clang wraps
+// FileEntry in a couple of stronger types with similar semantics
+// (FileEntryRef and OptionalFileEntryRef). We use these wrappers
+// as file identities in IWYU.
 //
 // Clang's FileID type is a misnomer.  It's actually an ID of a
 // particular #include statement.  If a file is #included in two
@@ -139,7 +141,7 @@ inline int GetLineNumber(clang::SourceLocation loc) {
 }
 
 // The rest of this section of the file is for returning the
-// FileEntry* corresponding to a source location: the file that the
+// FileEntry corresponding to a source location: the file that the
 // location is in.  This is a surprising amount of work.
 
 // Tells which #include loc comes from.
@@ -149,7 +151,7 @@ inline clang::OptionalFileEntryRef GetLocFileEntry(clang::SourceLocation loc) {
   // clang uses the name FileID to mean 'a filename that was reached via
   // a particular series of #includes.'  (What one might think a FileID
   // might be -- a unique reference to a filesystem object -- is
-  // actually a FileEntry*.)
+  // actually a FileEntry.)
   const clang::SourceManager& source_manager = *GlobalSourceManager();
   return source_manager.getFileEntryRefForID(source_manager.getFileID(loc));
 }
@@ -196,7 +198,7 @@ clang::SourceLocation GetLocation(const clang::NestedNameSpecifierLoc* nnsloc);
 clang::SourceLocation GetLocation(const clang::TemplateArgumentLoc* argloc);
 
 // These define default implementations of GetFileEntry() and
-// GetPath() in terms of GetLocation().  As long as an object defines
+// GetFilePath() in terms of GetLocation().  As long as an object defines
 // its own GetLocation(), it will get these other two for free.
 template <typename T>
 clang::OptionalFileEntryRef GetFileEntry(const T& obj) {

--- a/iwyu_preprocessor.cc
+++ b/iwyu_preprocessor.cc
@@ -531,10 +531,10 @@ void IwyuPreprocessorInfo::FinalizeProtectedIncludes() {
 
 // Called when a #include is encountered.  i_n_a_t includes <> or "".
 // We keep track of this information in two places:
-// 1) iwyu_file_info_map_ maps the includer as a FileEntry* to the
-//    includee both as the literal name used and as a FileEntry*.
+// 1) iwyu_file_info_map_ maps the includer as a FileEntry to the
+//    includee both as the literal name used and as a FileEntry.
 // 2) include_to_fileentry_map_ maps the includee's literal name
-//    as written to the FileEntry* used.  This can be used (in a
+//    as written to the FileEntry used.  This can be used (in a
 //    limited way, due to non-uniqueness concerns) to map between
 //    names and FileEntries.
 // We also tell this #include to the include-picker, which may

--- a/iwyu_preprocessor.h
+++ b/iwyu_preprocessor.h
@@ -50,9 +50,9 @@
 // This class finishes its processing before the 'main' iwyu
 // processing is done, so other iwyu consumers can access the main
 // outputs of this class:
-//    * The map from include-name to FileEntry*.
-//    * The map from FileEntry* to its IwyuFileInfo object.
-//    * TODO(csilvers): Information about direct includes of a FileEntry*
+//    * The map from include-name to FileEntry.
+//    * The map from FileEntry to its IwyuFileInfo object.
+//    * TODO(csilvers): Information about direct includes of a FileEntry
 //    * The 'intends to provide' map, which encapsulates some
 //      of the information about public vs private headers.
 //    * Testing and reporting membership in the main compilation unit.
@@ -110,8 +110,8 @@ class IwyuPreprocessorInfo : public clang::PPCallbacks,
   }
 
   // Given a quoted include like '<vector>', or '"ads/base.h"',
-  // returns the FileEntry for that file, or nullptr if none is
-  // found.  If multiple files are included under the same
+  // returns the optional FileEntry for that file.
+  // If multiple files are included under the same
   // quoted-include name (which can happen via #include-next),
   // one is returned arbitrarily.  (But always the same one.)
   clang::OptionalFileEntryRef IncludeToFileEntry(
@@ -320,7 +320,7 @@ class IwyuPreprocessorInfo : public clang::PPCallbacks,
   // How many #include lines we've encountered from the given file.
   map<clang::OptionalFileEntryRef, int> num_includes_seen_;
 
-  // Maps from a FileEntry* to all files that this file "intends" to
+  // Maps from a FileEntry to all files that this file "intends" to
   // provide the symbols from.  For now, we say a file intentionally
   // provides a symbol if it defines it, or if any file it directly
   // #includes defines it.  However, if the header is a private header
@@ -332,16 +332,16 @@ class IwyuPreprocessorInfo : public clang::PPCallbacks,
   map<clang::OptionalFileEntryRef, set<clang::OptionalFileEntryRef>>
       intends_to_provide_map_;
 
-  // Maps from a FileEntry* to all the files that this file includes,
+  // Maps from a FileEntry to all the files that this file includes,
   // either directly or indirectly.
   map<clang::OptionalFileEntryRef, set<clang::OptionalFileEntryRef>>
       transitive_include_map_;
 
-  // Maps from a FileEntry* to the quoted names of files that its file
+  // Maps from a FileEntry to the quoted names of files that its file
   // is directed *not* to include via the "no_include" pragma.
   map<clang::OptionalFileEntryRef, set<string>> no_include_map_;
 
-  // Maps from a FileEntry* to the qualified names of symbols that its
+  // Maps from a FileEntry to the qualified names of symbols that its
   // file is directed *not* to forward-declare via the
   // "no_forward_declare" pragma.
   map<clang::OptionalFileEntryRef, set<string>> no_forward_declare_map_;

--- a/more_tests/iwyu_output_test.cc
+++ b/more_tests/iwyu_output_test.cc
@@ -87,7 +87,7 @@ string GetFilePath(const FakeNamedDecl* fake_decl) {
   return fake_decl->decl_filepath();
 }
 
-// Note these return a string, not a FileEntry*.
+// Note these return a string, not a FileEntry.
 string GetFileEntry(const FakeSourceLocation& fake_loc) {
   return fake_loc.filepath;
 }


### PR DESCRIPTION
There's quite a bit of commentary around FileEntry. Remove pointer asterisks to talk more about the concept of 'FileEntry' as opposed to the concrete type 'FileEntry*'.

While at it, fix a little typo.