### PR TITLE
Allow not to provide default type tpl arguments

### DIFF
--- a/tests/cxx/default_tpl_arg.cc
+++ b/tests/cxx/default_tpl_arg.cc
@@ -13,29 +13,48 @@
 // doesn't crash when they refer to uninstantiated template specializations.
 
 #include "tests/cxx/default_tpl_arg-d1.h"
+#include "tests/cxx/direct.h"
 
+// IWYU: UninstantiatedTpl needs a declaration
 // IWYU: UninstantiatedTpl is...*default_tpl_arg-i1.h
 template <typename = UninstantiatedTpl<int>>
 struct Tpl {};
 
 template <typename T>
-struct Outer {
+struct Outer1 {
+  // IWYU: UninstantiatedTpl needs a declaration
   // IWYU: UninstantiatedTpl is...*default_tpl_arg-i1.h
   template <typename = UninstantiatedTpl<T>>
   struct Inner {};
 };
 
-Outer<int> o;
+Outer1<int> o1;
+
+template <typename T1, typename T2>
+struct Outer2 {
+  // IWYU: IndirectTemplate needs a declaration
+  // IWYU: IndirectTemplate is...*indirect.h
+  template <typename = IndirectTemplate<T1>>
+  struct Inner {};
+};
+
+// Test that IWYU should not suggest to provide default template argument
+// of an internal template on instantiation side.
+// IWYU: IndirectTemplate needs a declaration
+Outer2<int, IndirectTemplate<int>> o2;
 
 /**** IWYU_SUMMARY
 
 tests/cxx/default_tpl_arg.cc should add these lines:
 #include "tests/cxx/default_tpl_arg-i1.h"
+#include "tests/cxx/indirect.h"
 
 tests/cxx/default_tpl_arg.cc should remove these lines:
 - #include "tests/cxx/default_tpl_arg-d1.h"  // lines XX-XX
+- #include "tests/cxx/direct.h"  // lines XX-XX
 
 The full include-list for tests/cxx/default_tpl_arg.cc:
 #include "tests/cxx/default_tpl_arg-i1.h"  // for UninstantiatedTpl
+#include "tests/cxx/indirect.h"  // for IndirectTemplate
 
 ***** IWYU_SUMMARY */

--- a/tests/cxx/iwyu_stricter_than_cpp-d3.h
+++ b/tests/cxx/iwyu_stricter_than_cpp-d3.h
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef IWYU_STRICTER_THAN_CPP_D3_H_
+#define IWYU_STRICTER_THAN_CPP_D3_H_
+
 #include "tests/cxx/iwyu_stricter_than_cpp-i3.h"
 #include "tests/cxx/iwyu_stricter_than_cpp-i4.h"
 
@@ -15,3 +18,5 @@ typedef IndirectStruct4 IndirectStruct4ProvidingTypedef;
 
 using IndirectStruct3ProvidingAl = IndirectStruct3;
 using IndirectStruct4ProvidingAl = IndirectStruct4;
+
+#endif

--- a/tests/cxx/iwyu_stricter_than_cpp-def_tpl_arg.h
+++ b/tests/cxx/iwyu_stricter_than_cpp-def_tpl_arg.h
@@ -1,0 +1,57 @@
+//===--- iwyu_stricter_than_cpp-def_tpl_arg.h - test input file for iwyu --===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// The two rules the author has to follow to disable iwyu's
+// stricter-than-C++ rule and force it to fall back on the c++
+// requirement (forward-declare ok):
+// (1) forward-declare the relevant type
+// (2) do not directly #include the definition of the relevant type.
+
+#include "tests/cxx/iwyu_stricter_than_cpp-d1.h"
+#include "tests/cxx/iwyu_stricter_than_cpp-d3.h"
+
+struct DirectStruct1;
+struct IndirectStruct2;
+
+// --- Default type template arguments.
+
+template <
+    // Requires the full type because it does not obey rule (1)
+    // IWYU: IndirectStruct3 is...*iwyu_stricter_than_cpp-i3.h
+    typename DoesNotForwardDeclare = IndirectStruct3,
+    // Requires the full type because it does not obey rule (2)
+    typename Includes = DirectStruct1,
+    // Requires the full type because it does not obey rules (1) *or* (2)
+    typename DoesNotForwardDeclareAndIncludes = DirectStruct2,
+    // Does not require full type because it obeys all the rules.
+    typename DoesEverythingRight = IndirectStruct2>
+struct TplWithDefaultArgs {
+  TplWithDefaultArgs();
+
+  DoesNotForwardDeclare a;
+  Includes b;
+  DoesNotForwardDeclareAndIncludes c;
+  DoesEverythingRight d;
+};
+
+/**** IWYU_SUMMARY
+
+tests/cxx/iwyu_stricter_than_cpp-def_tpl_arg.h should add these lines:
+#include "tests/cxx/iwyu_stricter_than_cpp-i3.h"
+
+tests/cxx/iwyu_stricter_than_cpp-def_tpl_arg.h should remove these lines:
+- #include "tests/cxx/iwyu_stricter_than_cpp-d3.h"  // lines XX-XX
+- struct DirectStruct1;  // lines XX-XX
+
+The full include-list for tests/cxx/iwyu_stricter_than_cpp-def_tpl_arg.h:
+#include "tests/cxx/iwyu_stricter_than_cpp-d1.h"  // for DirectStruct1, DirectStruct2
+#include "tests/cxx/iwyu_stricter_than_cpp-i3.h"  // for IndirectStruct3
+struct IndirectStruct2;  // lines XX-XX
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/iwyu_stricter_than_cpp.cc
+++ b/tests/cxx/iwyu_stricter_than_cpp.cc
@@ -11,6 +11,7 @@
 //            -Xiwyu --check_also="tests/cxx/*-fnreturn.h" \
 //            -Xiwyu --check_also="tests/cxx/*-typedefs.h" \
 //            -Xiwyu --check_also="tests/cxx/*-type_alias.h" \
+//            -Xiwyu --check_also="tests/cxx/*-def_tpl_arg.h" \
 //            -Xiwyu --check_also="tests/cxx/*-d2.h" \
 //            -I .
 
@@ -37,6 +38,7 @@
 // when these two conditions are met, and not otherwise.
 
 #include "tests/cxx/direct.h"
+#include "tests/cxx/iwyu_stricter_than_cpp-def_tpl_arg.h"
 #include "tests/cxx/iwyu_stricter_than_cpp-typedefs.h"
 #include "tests/cxx/iwyu_stricter_than_cpp-type_alias.h"
 #include "tests/cxx/iwyu_stricter_than_cpp-autocast.h"
@@ -419,6 +421,21 @@ void TestFunctionReturn() {
   Call<Alias, TplAllForwardDeclaredFn>();
 }
 
+void TestDefaultTplArgs() {
+  // There is currently some difference between default type template arguments
+  // and the other cases: on the user's side, IWYU requires complete type info
+  // when the template defining file doesn't provide the corresponding header
+  // (for user-defined templates, it usually means "doesn't include directly")
+  // regardless of fwd-decl presence or absence. Hence, 'IndirectStruct3' (which
+  // is neither directly included nor fwd-declared in the template defn header)
+  // is required both here and at the template definition side.
+  // 'IndirectStruct2' is required here because it is fwd-declared and not
+  // included directly in the template defining header.
+  // IWYU: IndirectStruct3 is...*iwyu_stricter_than_cpp-i3.h
+  // IWYU: IndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
+  TplWithDefaultArgs<> t;
+}
+
 /**** IWYU_SUMMARY
 
 tests/cxx/iwyu_stricter_than_cpp.cc should add these lines:
@@ -446,6 +463,7 @@ The full include-list for tests/cxx/iwyu_stricter_than_cpp.cc:
 #include "tests/cxx/indirect.h"  // for IndirectClass
 #include "tests/cxx/iwyu_stricter_than_cpp-autocast.h"  // for FnRefs, FnValues, HeaderDefinedFnRefs, HeaderDefinedTplFnRefs, TplFnRefs, TplFnValues
 #include "tests/cxx/iwyu_stricter_than_cpp-d3.h"  // for IndirectStruct3ProvidingAl, IndirectStruct3ProvidingTypedef, IndirectStruct4ProvidingAl, IndirectStruct4ProvidingTypedef
+#include "tests/cxx/iwyu_stricter_than_cpp-def_tpl_arg.h"  // for TplWithDefaultArgs
 #include "tests/cxx/iwyu_stricter_than_cpp-fnreturn.h"  // for DoesEverythingRightFn, DoesNotForwardDeclareAndIncludesFn, DoesNotForwardDeclareFn, DoesNotForwardDeclareProperlyFn, IncludesFn, TplAllForwardDeclaredFn, TplAllNeededTypesProvidedFn, TplDoesEverythingRightAgainFn, TplDoesEverythingRightFn, TplDoesNotForwardDeclareAndIncludesFn, TplDoesNotForwardDeclareFn, TplDoesNotForwardDeclareProperlyFn, TplIncludesFn, TplOnlyArgumentTypeProvidedFn, TplOnlyTemplateProvidedFn
 #include "tests/cxx/iwyu_stricter_than_cpp-i2.h"  // for IndirectStruct2, TplIndirectStruct2
 #include "tests/cxx/iwyu_stricter_than_cpp-i3.h"  // for IndirectStruct3


### PR DESCRIPTION
Prior to this, IWYU always required complete default template argument type info at template definition side. However, as discussed in #1333, a template author should be able to decide whether to provide it or not, because they are forward-declarable in principle. Hence, they are now handled similarly to typedef-fnreturn-autocast triad, but only at the template definition side. At the template instantiation side, there already is some logic to detect their provision status (see `InstantiatedTemplateVisitor::CanIgnoreType`). Hence, there is some redundancy when IWYU requires complete type info both at the template definition and instantiation sides at the first pass, but this behavior was already present on the master branch, and this PR should not make it worse.

Besides, this changeset fixes a subtle bug similar to the one fixed in #1363, when IWYU suggested complete type info for an inner template default type argument at the outer template instantiation site. The corresponding test case added to `default_tpl_arg` test.