### PR TITLE
Improve provided deduced type determination

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -3321,7 +3321,7 @@ class InstantiatedTemplateVisitor
     // TODO(csilvers): do better here.
     if (type->isDependentType()) {
       // TODO(csilvers): This is currently always a noop; need to fix
-      // GetTplTypeResugarMapForClassNoComponentTypes to do something
+      // GetTplInstDataForClassNoComponentTypes to do something
       // useful for dependent types.
       ReplayClassMemberUsesFromPrecomputedList(type);   // best-effort
       return true;
@@ -3888,14 +3888,15 @@ class IwyuAstConsumer
       // spec type location (as written) so that reportings from
       // 'InstantiatedTemplateVisitor' are attributed to the correct location.
       const ASTNode type_loc_node(&type_loc);
-      const map<const Type*, const Type*> resugar_map =
-          GetTplTypeResugarMapForClass(type_loc.getTypePtr());
+      const TemplateInstantiationData data = GetTplInstDataForClass(
+          type_loc.getTypePtr(),
+          [this](const Type* type) { return GetProvidedTypeComponents(type); });
       // Clang instantiates methods in the first ("canonical") spec decl context
       // (which may correspond to instantiation declaration, not to definition).
       for (const CXXMethodDecl* member : decl->getCanonicalDecl()->methods()) {
         instantiated_template_visitor_.ScanInstantiatedFunction(
-            member, type_loc.getTypePtr(), &type_loc_node, resugar_map,
-            ExtractProvidedTypeComponents(resugar_map));
+            member, type_loc.getTypePtr(), &type_loc_node, data.resugar_map,
+            data.provided_types);
       }
     }
 
@@ -4085,12 +4086,12 @@ class IwyuAstConsumer
     // If we're not in a forward-declare context, use of a template
     // specialization requires having the full type information.
     if (!CanForwardDeclareType(current_ast_node())) {
-      const map<const Type*, const Type*> resugar_map =
-          GetTplTypeResugarMapForClass(type);
+      const TemplateInstantiationData data = GetTplInstDataForClass(
+          type,
+          [this](const Type* type) { return GetProvidedTypeComponents(type); });
 
       instantiated_template_visitor_.ScanInstantiatedType(
-          current_ast_node(), resugar_map,
-          ExtractProvidedTypeComponents(resugar_map));
+          current_ast_node(), data.resugar_map, data.provided_types);
     }
 
     const auto [is_provided, comment] =
@@ -4166,23 +4167,28 @@ class IwyuAstConsumer
     if (!IsTemplatizedFunctionDecl(callee) && !IsTemplatizedType(parent_type))
       return true;
 
-    map<const Type*, const Type*> resugar_map =
-        GetTplTypeResugarMapForFunction(callee, calling_expr);
+    auto provided_getter = [this](const Type* type) {
+      return GetProvidedTypeComponents(type);
+    };
+    TemplateInstantiationData data =
+        GetTplInstDataForFunction(callee, calling_expr, provided_getter);
 
     if (parent_type) {    // means we're a method of a class
-      InsertAllInto(GetTplTypeResugarMapForClass(parent_type), &resugar_map);
+      const TemplateInstantiationData class_data =
+          GetTplInstDataForClass(parent_type, provided_getter);
+      InsertAllInto(class_data.resugar_map, &data.resugar_map);
+      InsertAllInto(class_data.provided_types, &data.provided_types);
     }
 
-    set<const Type*> provided_types =
-        ExtractProvidedTypeComponents(resugar_map);
     if (IsAutocastExpr(current_ast_node())) {
       const set<const Type*> provided_for_autocast =
           GetProvidedTypesForAutocast(current_ast_node());
-      provided_types.insert(provided_for_autocast.begin(),
-                            provided_for_autocast.end());
+      data.provided_types.insert(provided_for_autocast.begin(),
+                                 provided_for_autocast.end());
     }
     instantiated_template_visitor_.ScanInstantiatedFunction(
-        callee, parent_type, current_ast_node(), resugar_map, provided_types);
+        callee, parent_type, current_ast_node(), data.resugar_map,
+        data.provided_types);
     return true;
   }
 
@@ -4190,32 +4196,24 @@ class IwyuAstConsumer
 
   void ReportTplSpecComponentTypes(const TemplateSpecializationType* type,
                                    const set<const Type*>& blocked_types) {
-    const map<const Type*, const Type*> resugar_map =
-        GetTplTypeResugarMapForClass(type);
+    TemplateInstantiationData data = GetTplInstDataForClass(
+        type,
+        [this](const Type* type) { return GetProvidedTypeComponents(type); });
     ASTNode node(type);
     node.SetParent(current_ast_node());
-    set<const Type*> merged_blocked =
-        ExtractProvidedTypeComponents(resugar_map);
-    merged_blocked.insert(blocked_types.begin(), blocked_types.end());
-    instantiated_template_visitor_.ScanInstantiatedType(&node, resugar_map,
-                                                        merged_blocked);
+    data.provided_types.insert(blocked_types.begin(), blocked_types.end());
+    instantiated_template_visitor_.ScanInstantiatedType(&node, data.resugar_map,
+                                                        data.provided_types);
   }
 
  private:
-  set<const Type*> ExtractProvidedTypeComponents(
-      const map<const Type*, const Type*>& resugar_map) const {
-    set<const Type*> result;
-    for (const auto& canonical_sugared_pair : resugar_map) {
-      const Type* desugared_until_typedef =
-          Desugar(canonical_sugared_pair.second);
-      if (const auto* typedef_type =
-              dyn_cast_or_null<TypedefType>(desugared_until_typedef)) {
-        set<const Type*> provided =
-            GetProvidedTypesForTypedef(typedef_type->getDecl());
-        result.insert(provided.begin(), provided.end());
-      }
+  set<const Type*> GetProvidedTypeComponents(const Type* type) const {
+    const Type* desugared_until_typedef = Desugar(type);
+    if (const auto* typedef_type =
+            dyn_cast_or_null<TypedefType>(desugared_until_typedef)) {
+      return GetProvidedTypesForTypedef(typedef_type->getDecl());
     }
-    return result;
+    return set<const Type*>();
   }
 
   pair<bool, const char*> CanBeProvidedTypeComponent(

--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -837,7 +837,6 @@ static map<const Type*, const Type*> GetTplTypeResugarMapForFunctionNoCallExpr(
 
 static map<const Type*, const Type*>
 GetTplTypeResugarMapForFunctionExplicitTplArgs(
-    const FunctionDecl* decl,
     const TemplateArgumentListInfo& explicit_tpl_list) {
   map<const Type*, const Type*> retval;
   for (const TemplateArgumentLoc& loc : explicit_tpl_list.arguments()) {
@@ -922,8 +921,8 @@ map<const Type*, const Type*> GetTplTypeResugarMapForFunction(
     const TemplateArgumentListInfo& explicit_tpl_args =
         GetExplicitTplArgs(callee_expr);
     if (explicit_tpl_args.size() > 0) {
-      retval = GetTplTypeResugarMapForFunctionExplicitTplArgs(
-          decl, explicit_tpl_args);
+      retval =
+          GetTplTypeResugarMapForFunctionExplicitTplArgs(explicit_tpl_args);
       start_of_implicit_args = explicit_tpl_args.size();
     }
   } else {
@@ -931,8 +930,8 @@ map<const Type*, const Type*> GetTplTypeResugarMapForFunction(
     const TemplateArgumentListInfo& explicit_tpl_args =
         GetExplicitTplArgs(calling_expr);
     if (explicit_tpl_args.size() > 0) {
-      retval = GetTplTypeResugarMapForFunctionExplicitTplArgs(
-          decl, explicit_tpl_args);
+      retval =
+          GetTplTypeResugarMapForFunctionExplicitTplArgs(explicit_tpl_args);
       retval = ResugarTypeComponents(retval);
     }
     return retval;

--- a/iwyu_cache.cc
+++ b/iwyu_cache.cc
@@ -90,7 +90,9 @@ map<const Type*, const Type*> FullUseCache::GetPrecomputedResugarMap(
   // design): we fully use all template types.  (Note: we'll have to
   // do something more clever here if any types in kFullUseTypes start
   // accepting template-template types.)
-  return GetTplTypeResugarMapForClassNoComponentTypes(tpl_type);
+  return GetTplInstDataForClassNoComponentTypes(
+             tpl_type, [](const Type* type) { return set<const Type*>(); })
+      .resugar_map;
 }
 
 }  // namespace include_what_you_use

--- a/tests/cxx/derived_function_tpl_args.cc
+++ b/tests/cxx/derived_function_tpl_args.cc
@@ -65,11 +65,15 @@ int main() {
   // Now try again, but with a typedef.
   // IWYU: IndirectClass is...*derived_function_tpl_args-i1.h
   typedef IndirectClass LocalClass;
+  // IWYU: IndirectClass is...*derived_function_tpl_args-i1.h
+  typedef IndirectClass* LocalClassPtr;
   LocalClass lc;
   LocalClass* lc_ptr = 0;
+  LocalClassPtr lc_ptr2 = 0;
   Fn(lc);
   Fn(lc_ptr);
   FnWithPtr(lc_ptr);
+  FnWithPtr(lc_ptr2);
   FnWithReference(lc);
   FnWithReference(lc_ptr);
 

--- a/tests/cxx/template_args-d2.h
+++ b/tests/cxx/template_args-d2.h
@@ -26,3 +26,6 @@ using ::NonProvidingTypedef;
 
 template <int>
 using NonProvidingAlias = ns_in_d2::NonProvidingTypedef;
+
+using NonProvidingFunctionAlias1 = int(IndirectClass&);
+using NonProvidingFunctionAlias2 = IndirectClass(int);

--- a/tests/cxx/template_args.cc
+++ b/tests/cxx/template_args.cc
@@ -37,6 +37,14 @@ void FunctionProtoClassArguments() {
   // IWYU: IndirectClass is...*indirect.h
   FunctionStruct<IndirectClass(char)> f2;
   (void)f2;
+
+  // IWYU: IndirectClass is...*indirect.h
+  using ProvidingFunctionAlias = IndirectClass(IndirectClass);
+  FunctionStruct<ProvidingFunctionAlias> f3;
+  // IWYU: IndirectClass is...*indirect.h
+  FunctionStruct<NonProvidingFunctionAlias1> f4;
+  // IWYU: IndirectClass is...*indirect.h
+  FunctionStruct<NonProvidingFunctionAlias2> f5;
 }
 
 // ---------------------------------------------------------------
@@ -241,7 +249,7 @@ tests/cxx/template_args.cc should remove these lines:
 The full include-list for tests/cxx/template_args.cc:
 #include "tests/cxx/indirect.h"  // for IndirectClass
 #include "tests/cxx/template_args-d1.h"  // for ProvidingAlias
-#include "tests/cxx/template_args-d2.h"  // for NonProvidingAlias
+#include "tests/cxx/template_args-d2.h"  // for NonProvidingAlias, NonProvidingFunctionAlias1, NonProvidingFunctionAlias2
 #include "tests/cxx/template_args-i1.h"  // for TplInI1
 template <typename F> struct FunctionStruct;  // lines XX-XX
 


### PR DESCRIPTION
It turns out that extracting provided types from `resugar_map` doesn't always work when type template arguments are deduced (e. g. with partial class template specializations and function template argument deduction). Consider this code:
```cpp
template <typename T> class Tpl;
template <typename T> class Tpl<T*> {};

using ProvidingPtrAlias = Class*;

Tpl<ProvidingPtrAlias> t;
```
The resulting `resugar_map` would contain only `Class -> Class` mapping and not `Class* -> ProvidingPtrAlias`. Because it wouldn't contain `ProvidingPtrAlias`, there is no way to determine from it that `Class` is provided actually. To solve this problem, provided type set determination is moved inside `resugar_map`-getting algorithms, where full sets of type template or function argument type components are available.

The solution may look ugly, but I hope to rewrite the code soon because I want to remove `resugar_map` completely as proposed in [that discussion](https://github.com/include-what-you-use/include-what-you-use/pull/1182#issuecomment-1385818682). Nevertheless, better design suggestions are welcome! An alternative could be to insert components interesting for provided type determination into `resugar_map`. Another one could be to separate `resugar_map`- and `provided_types`-getting functions.