### PR TITLE
Manually apply use-what-you-use policy

### DIFF
--- a/iwyu_driver.cc
+++ b/iwyu_driver.cc
@@ -47,7 +47,6 @@ namespace include_what_you_use {
 
 using clang::CompilerInstance;
 using clang::CompilerInvocation;
-using clang::DiagnosticIDs;
 using clang::DiagnosticOptions;
 using clang::DiagnosticsEngine;
 using clang::FrontendAction;

--- a/iwyu_include_picker.cc
+++ b/iwyu_include_picker.cc
@@ -50,6 +50,7 @@ using std::string;
 using std::unique_ptr;
 using std::vector;
 
+using clang::OptionalFileEntryRef;
 using llvm::MemoryBuffer;
 using llvm::SourceMgr;
 using llvm::yaml::KeyValueNode;
@@ -1686,7 +1687,7 @@ bool IncludePicker::HasMapping(const string& map_from_filepath,
   return quoted_to == quoted_from;   // indentity mapping, why not?
 }
 
-bool IncludePicker::IsPublic(clang::OptionalFileEntryRef file) const {
+bool IncludePicker::IsPublic(OptionalFileEntryRef file) const {
   CHECK_(file && "Need existing FileEntry");
   const string path = GetFilePath(file);
   const string quoted_file = ConvertToQuotedInclude(path);

--- a/iwyu_location_util.cc
+++ b/iwyu_location_util.cc
@@ -29,12 +29,17 @@ using clang::CXXMethodDecl;
 using clang::CXXOperatorCallExpr;
 using clang::ClassTemplateSpecializationDecl;
 using clang::ConditionalOperator;
+using clang::Decl;
 using clang::FileID;
 using clang::FunctionDecl;
 using clang::MemberExpr;
+using clang::NestedNameSpecifierLoc;
 using clang::OptionalFileEntryRef;
 using clang::SourceLocation;
 using clang::SourceManager;
+using clang::Stmt;
+using clang::TemplateArgumentLoc;
+using clang::TypeLoc;
 using clang::UnaryOperator;
 using clang::UnresolvedMemberExpr;
 
@@ -65,7 +70,7 @@ namespace include_what_you_use {
 // methods don't have their own location anyway.
 //    Note the two issues can both be present, if an implicit method's
 // parent is an implicit instantiation.
-SourceLocation GetLocation(const clang::Decl* decl) {
+SourceLocation GetLocation(const Decl* decl) {
   if (decl == nullptr)
     return SourceLocation();
 
@@ -122,7 +127,7 @@ static SourceLocation GetMemberExprLocation(const MemberExpr* member_expr) {
   return GetInstantiationLoc(member_start);
 }
 
-SourceLocation GetLocation(const clang::Stmt* stmt) {
+SourceLocation GetLocation(const Stmt* stmt) {
   if (stmt == nullptr)
     return SourceLocation();
   // For some expressions, we take the location to be the 'key' part
@@ -155,19 +160,19 @@ SourceLocation GetLocation(const clang::Stmt* stmt) {
   return stmt->getBeginLoc();
 }
 
-SourceLocation GetLocation(const clang::TypeLoc* typeloc) {
+SourceLocation GetLocation(const TypeLoc* typeloc) {
   if (typeloc == nullptr)
     return SourceLocation();
   return typeloc->getBeginLoc();
 }
 
-SourceLocation GetLocation(const clang::NestedNameSpecifierLoc* nnsloc) {
+SourceLocation GetLocation(const NestedNameSpecifierLoc* nnsloc) {
   if (nnsloc == nullptr)
     return SourceLocation();
   return nnsloc->getBeginLoc();
 }
 
-SourceLocation GetLocation(const clang::TemplateArgumentLoc* argloc) {
+SourceLocation GetLocation(const TemplateArgumentLoc* argloc) {
   if (argloc == nullptr)
     return SourceLocation();
   return argloc->getLocation();
@@ -177,7 +182,7 @@ bool IsInScratchSpace(SourceLocation loc) {
   return StartsWith(PrintableLoc(GetSpellingLoc(loc)), "<scratch space>");
 }
 
-bool IsInHeader(const clang::Decl* decl) {
+bool IsInHeader(const Decl* decl) {
   OptionalFileEntryRef containing_file = GetFileEntry(decl);
   if (!containing_file) {
     // This is a builtin, or something is terribly wrong.


### PR DESCRIPTION
Use-what-you-use is a half-joke policy that says every type we use from a namespace should have a corresponding using declaration.

Remove all "clang::" qualifications in source files except for:

* enumerator names
* nested namespaces

This makes the code easier to read, line-wrapping less excessive, and also helps IWYU understand type identity better when analyzing itself.

Also remove unused using declarations.

No functional change.