### PR TITLE
Sort and group all #include lines in the IWYU source tree

### DIFF
--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -15,15 +15,6 @@
 #include <string>                       // for string, operator+, etc
 #include <utility>                      // for pair
 
-#include "iwyu_globals.h"
-#include "iwyu_location_util.h"
-#include "iwyu_path_util.h"
-#include "iwyu_port.h"  // for CHECK_
-#include "iwyu_stl_util.h"
-#include "iwyu_verrs.h"
-#include "llvm/ADT/ArrayRef.h"
-#include "llvm/Support/Casting.h"
-#include "llvm/Support/raw_ostream.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/ASTDumper.h"
 #include "clang/AST/CanonicalType.h"
@@ -45,6 +36,15 @@
 #include "clang/Basic/SourceLocation.h"
 #include "clang/Basic/SourceManager.h"
 #include "clang/Basic/Specifiers.h"
+#include "iwyu_globals.h"
+#include "iwyu_location_util.h"
+#include "iwyu_path_util.h"
+#include "iwyu_port.h"  // for CHECK_
+#include "iwyu_stl_util.h"
+#include "iwyu_verrs.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/Support/Casting.h"
+#include "llvm/Support/raw_ostream.h"
 
 using clang::ASTDumper;
 using clang::ArrayType;

--- a/iwyu_ast_util.h
+++ b/iwyu_ast_util.h
@@ -17,9 +17,6 @@
 #include <set>                          // for set
 #include <string>                       // for string
 
-#include "iwyu_port.h"  // for CHECK_
-#include "iwyu_use_flags.h"
-#include "llvm/Support/Casting.h"
 #include "clang/AST/DeclBase.h"
 #include "clang/AST/NestedNameSpecifier.h"
 #include "clang/AST/Stmt.h"
@@ -27,6 +24,9 @@
 #include "clang/AST/Type.h"
 #include "clang/AST/TypeLoc.h"
 #include "clang/Basic/SourceLocation.h"
+#include "iwyu_port.h"  // for CHECK_
+#include "iwyu_use_flags.h"
+#include "llvm/Support/Casting.h"
 
 namespace clang {
 class CXXConstructExpr;

--- a/iwyu_cache.cc
+++ b/iwyu_cache.cc
@@ -12,12 +12,12 @@
 #include <set>
 #include <string>
 
-#include "iwyu_ast_util.h"
-#include "iwyu_stl_util.h"
 #include "clang/AST/DeclTemplate.h"
 #include "clang/AST/TemplateBase.h"
 #include "clang/AST/Type.h"
 #include "clang/Basic/LangOptions.h"
+#include "iwyu_ast_util.h"
+#include "iwyu_stl_util.h"
 
 using clang::ClassTemplateSpecializationDecl;
 using clang::LangOptions;

--- a/iwyu_driver.cc
+++ b/iwyu_driver.cc
@@ -22,17 +22,8 @@
 
 #include "iwyu_verrs.h"
 
-#include "llvm/ADT/ArrayRef.h"
-#include "llvm/ADT/SmallString.h"
-#include "llvm/ADT/STLExtras.h"
-#include "llvm/Option/ArgList.h"
-#include "llvm/Support/ErrorOr.h"
-#include "llvm/Support/FileSystem.h"
-#include "llvm/Support/MemoryBuffer.h"
-#include "llvm/TargetParser/Host.h"
-#include "llvm/TargetParser/Triple.h"
-#include "clang/Basic/DiagnosticOptions.h"
 #include "clang/Basic/DiagnosticFrontend.h"
+#include "clang/Basic/DiagnosticOptions.h"
 #include "clang/Driver/Action.h"
 #include "clang/Driver/Compilation.h"
 #include "clang/Driver/Driver.h"
@@ -42,6 +33,15 @@
 #include "clang/Frontend/FrontendAction.h"
 #include "clang/Frontend/TextDiagnosticPrinter.h"
 #include "clang/FrontendTool/Utils.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallString.h"
+#include "llvm/Option/ArgList.h"
+#include "llvm/Support/ErrorOr.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/TargetParser/Host.h"
+#include "llvm/TargetParser/Triple.h"
 
 namespace include_what_you_use {
 

--- a/iwyu_globals.cc
+++ b/iwyu_globals.cc
@@ -17,9 +17,16 @@
 #include <string>                       // for string, operator<, etc
 #include <utility>                      // for make_pair, pair
 
+#include "clang/AST/PrettyPrinter.h"
+#include "clang/Basic/FileManager.h"
+#include "clang/Basic/Version.h"
+#include "clang/Driver/ToolChain.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Lex/HeaderSearch.h"
+#include "clang/Lex/Preprocessor.h"
 #include "iwyu_cache.h"
-#include "iwyu_include_picker.h"
 #include "iwyu_getopt.h"
+#include "iwyu_include_picker.h"
 #include "iwyu_lexer_utils.h"
 #include "iwyu_location_util.h"
 #include "iwyu_path_util.h"
@@ -30,13 +37,6 @@
 #include "iwyu_verrs.h"
 #include "iwyu_version.h"
 #include "llvm/Support/raw_ostream.h"
-#include "clang/AST/PrettyPrinter.h"
-#include "clang/Basic/FileManager.h"
-#include "clang/Basic/Version.h"
-#include "clang/Driver/ToolChain.h"
-#include "clang/Frontend/CompilerInstance.h"
-#include "clang/Lex/HeaderSearch.h"
-#include "clang/Lex/Preprocessor.h"
 
 using clang::CompilerInstance;
 using clang::HeaderSearch;

--- a/iwyu_include_picker.cc
+++ b/iwyu_include_picker.cc
@@ -22,6 +22,8 @@
 #include <utility>                      // for pair, make_pair
 #include <vector>                       // for vector, vector<>::iterator
 
+#include "clang/Basic/FileManager.h"
+#include "clang/Tooling/Inclusions/StandardLibrary.h"
 #include "iwyu_location_util.h"
 #include "iwyu_path_util.h"
 #include "iwyu_port.h"
@@ -29,7 +31,6 @@
 #include "iwyu_stl_util.h"
 #include "iwyu_string_util.h"
 #include "iwyu_verrs.h"
-
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Casting.h"
@@ -39,8 +40,6 @@
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/YAMLParser.h"
-#include "clang/Basic/FileManager.h"
-#include "clang/Tooling/Inclusions/StandardLibrary.h"
 
 using clang::OptionalFileEntryRef;
 using llvm::MemoryBuffer;

--- a/iwyu_location_util.cc
+++ b/iwyu_location_util.cc
@@ -9,8 +9,6 @@
 
 #include "iwyu_location_util.h"
 
-#include "iwyu_ast_util.h"
-#include "iwyu_port.h"
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclBase.h"
 #include "clang/AST/DeclCXX.h"
@@ -22,6 +20,8 @@
 #include "clang/AST/TemplateBase.h"
 #include "clang/AST/TypeLoc.h"
 #include "clang/Basic/SourceLocation.h"
+#include "iwyu_ast_util.h"
+#include "iwyu_port.h"
 
 using clang::BinaryOperator;
 using clang::CXXDependentScopeMemberExpr;

--- a/iwyu_location_util.h
+++ b/iwyu_location_util.h
@@ -44,13 +44,13 @@
 
 #include <string>                       // for string
 
-#include "iwyu_globals.h"
-#include "iwyu_path_util.h"
 #include "clang/Basic/FileEntry.h"
 #include "clang/Basic/FileManager.h"
 #include "clang/Basic/SourceLocation.h"
 #include "clang/Basic/SourceManager.h"
 #include "clang/Lex/Token.h"
+#include "iwyu_globals.h"
+#include "iwyu_path_util.h"
 
 namespace clang {
 class Decl;

--- a/iwyu_output.cc
+++ b/iwyu_output.cc
@@ -16,6 +16,12 @@
 #include <utility>                      // for pair, make_pair, operator>
 #include <vector>                       // for vector, vector<>::iterator, etc
 
+#include "clang/AST/ASTContext.h"
+#include "clang/AST/Decl.h"
+#include "clang/AST/DeclBase.h"
+#include "clang/AST/DeclTemplate.h"
+#include "clang/AST/Type.h"
+#include "clang/Basic/SourceLocation.h"
 #include "iwyu_ast_util.h"
 #include "iwyu_globals.h"
 #include "iwyu_include_picker.h"
@@ -27,12 +33,6 @@
 #include "iwyu_verrs.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/raw_ostream.h"
-#include "clang/AST/ASTContext.h"
-#include "clang/AST/Decl.h"
-#include "clang/AST/DeclBase.h"
-#include "clang/AST/DeclTemplate.h"
-#include "clang/AST/Type.h"
-#include "clang/Basic/SourceLocation.h"
 
 namespace include_what_you_use {
 

--- a/iwyu_output.h
+++ b/iwyu_output.h
@@ -21,12 +21,12 @@
 #include <string>                       // for string, operator<
 #include <vector>                       // for vector
 
-#include "iwyu_port.h"  // for CHECK_
-#include "iwyu_stl_util.h"
-#include "iwyu_use_flags.h"
 #include "clang/AST/Decl.h"
 #include "clang/Basic/FileEntry.h"
 #include "clang/Basic/SourceLocation.h"
+#include "iwyu_port.h"  // for CHECK_
+#include "iwyu_stl_util.h"
+#include "iwyu_use_flags.h"
 
 namespace clang {
 class UsingDecl;

--- a/iwyu_path_util.cc
+++ b/iwyu_path_util.cc
@@ -15,10 +15,9 @@
 #include <system_error>
 
 #include "iwyu_stl_util.h"
-
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringRef.h"
-#include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Path.h"
 

--- a/iwyu_port.h
+++ b/iwyu_port.h
@@ -12,6 +12,7 @@
 #define INCLUDE_WHAT_YOU_USE_PORT_H_
 
 #include <cstdlib>   // for abort
+
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/raw_ostream.h"
 

--- a/iwyu_preprocessor.cc
+++ b/iwyu_preprocessor.cc
@@ -9,13 +9,16 @@
 
 #include "iwyu_preprocessor.h"
 
+#include <algorithm>
 #include <cstddef>                      // for size_t
 #include <cstring>
-#include <algorithm>
 #include <iterator>
 #include <string>                       // for string, basic_string, etc
 #include <utility>                      // for pair, make_pair
 
+#include "clang/AST/Decl.h"
+#include "clang/Basic/IdentifierTable.h"
+#include "clang/Lex/MacroInfo.h"
 #include "iwyu_ast_util.h"
 #include "iwyu_globals.h"
 #include "iwyu_include_picker.h"
@@ -28,9 +31,6 @@
 #include "iwyu_string_util.h"
 #include "iwyu_verrs.h"
 #include "llvm/Support/raw_ostream.h"
-#include "clang/AST/Decl.h"
-#include "clang/Basic/IdentifierTable.h"
-#include "clang/Lex/MacroInfo.h"
 
 using clang::CharSourceRange;
 using clang::FileEntryRef;

--- a/iwyu_preprocessor.h
+++ b/iwyu_preprocessor.h
@@ -67,15 +67,14 @@
 #include <utility>                      // for pair
 #include <vector>                       // for vector
 
-#include "iwyu_output.h"
-#include "iwyu_port.h"  // for CHECK_
-
 #include "clang/Basic/FileEntry.h"
 #include "clang/Basic/SourceLocation.h"
 #include "clang/Basic/SourceManager.h"
-#include "clang/Lex/Preprocessor.h"
 #include "clang/Lex/PPCallbacks.h"
+#include "clang/Lex/Preprocessor.h"
 #include "clang/Lex/Token.h"
+#include "iwyu_output.h"
+#include "iwyu_port.h"  // for CHECK_
 
 namespace clang {
 class MacroInfo;

--- a/iwyu_regex.cc
+++ b/iwyu_regex.cc
@@ -10,10 +10,10 @@
 #include "iwyu_regex.h"
 
 #include <regex>
-#include "llvm/Support/Regex.h"
 
 #include "iwyu_port.h"
 #include "iwyu_string_util.h"
+#include "llvm/Support/Regex.h"
 
 namespace include_what_you_use {
 

--- a/iwyu_verrs.h
+++ b/iwyu_verrs.h
@@ -13,7 +13,6 @@
 #define INCLUDE_WHAT_YOU_USE_IWYU_VERRS_H_
 
 #include "clang/Basic/FileEntry.h"
-
 #include "llvm/Support/raw_ostream.h"
 
 namespace include_what_you_use {


### PR DESCRIPTION
All #include lines are now grouped like IWYU would do it:

* Associated header
* C standard library
* C++ standard library
* Quoted project headers

Each group is now sorted case-sensitively.

Put IWYU, Clang and LLVM together in the quoted-project-headers group, because from IWYU's perspective, they are all the same.

No functional change.