### PR TITLE
Sort and group all #include lines in iwyu.cc

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -101,23 +101,6 @@
 #include <utility>                      // for pair, make_pair
 #include <vector>                       // for vector, swap
 
-#include "iwyu_ast_util.h"
-#include "iwyu_cache.h"
-#include "iwyu_driver.h"
-#include "iwyu_globals.h"
-#include "iwyu_lexer_utils.h"
-#include "iwyu_location_util.h"
-#include "iwyu_output.h"
-#include "iwyu_path_util.h"
-#include "iwyu_port.h"  // for CHECK_
-#include "iwyu_preprocessor.h"
-#include "iwyu_stl_util.h"
-#include "iwyu_string_util.h"
-#include "iwyu_use_flags.h"
-#include "iwyu_verrs.h"
-#include "llvm/Support/Casting.h"
-#include "llvm/Support/TargetSelect.h"
-#include "llvm/Support/raw_ostream.h"
 #include "clang/AST/ASTConsumer.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Decl.h"
@@ -139,6 +122,23 @@
 #include "clang/Lex/Preprocessor.h"
 #include "clang/Lex/PreprocessorOptions.h"
 #include "clang/Sema/Sema.h"
+#include "iwyu_ast_util.h"
+#include "iwyu_cache.h"
+#include "iwyu_driver.h"
+#include "iwyu_globals.h"
+#include "iwyu_lexer_utils.h"
+#include "iwyu_location_util.h"
+#include "iwyu_output.h"
+#include "iwyu_path_util.h"
+#include "iwyu_port.h"  // for CHECK_
+#include "iwyu_preprocessor.h"
+#include "iwyu_stl_util.h"
+#include "iwyu_string_util.h"
+#include "iwyu_use_flags.h"
+#include "iwyu_verrs.h"
+#include "llvm/Support/Casting.h"
+#include "llvm/Support/TargetSelect.h"
+#include "llvm/Support/raw_ostream.h"
 
 namespace clang {
 class PPCallbacks;


### PR DESCRIPTION
Oops. A pattern-matching snafu caused me to miss iwyu.cc in 4104b3fcf9aa5853ba30bab0aefbd18584384ce0.

Do the same sorting and grouping in iwyu.cc.