### PR TITLE
Handle function template default type arguments

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -122,6 +122,7 @@
 #include "clang/AST/DeclBase.h"
 #include "clang/AST/DeclCXX.h"
 #include "clang/AST/DeclTemplate.h"
+#include "clang/AST/Expr.h"
 #include "clang/AST/ExprConcepts.h"
 #include "clang/AST/NestedNameSpecifier.h"
 #include "clang/AST/OperationKinds.h"
@@ -798,6 +799,11 @@ class BaseAstVisitor : public RecursiveASTVisitor<Derived> {
     if (FunctionDecl* fn_decl = DynCastFrom(expr->getDecl())) {
       if (!IsImplicitlyInstantiatedDfn(fn_decl))
         return true;
+      if (const auto* call_expr =  // Skip intermediate ImplicitCastExpr node.
+          current_ast_node_->GetAncestorAs<CallExpr>(2)) {
+        if (call_expr->getDirectCallee() == fn_decl)
+          return true;
+      }
       // If fn_decl has a class-name before it -- 'MyClass::method' --
       // it's a method pointer.
       const Type* parent_type = nullptr;

--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -76,6 +76,7 @@ using clang::Expr;
 using clang::ExprWithCleanups;
 using clang::FullSourceLoc;
 using clang::FunctionDecl;
+using clang::FunctionTemplateDecl;
 using clang::FunctionTemplateSpecializationInfo;
 using clang::FunctionType;
 using clang::ImplicitCastExpr;
@@ -109,6 +110,7 @@ using clang::TemplateName;
 using clang::TemplateParameterList;
 using clang::TemplateSpecializationKind;
 using clang::TemplateSpecializationType;
+using clang::TemplateTypeParmDecl;
 using clang::TranslationUnitDecl;
 using clang::Type;
 using clang::TypeAliasTemplateDecl;
@@ -888,6 +890,29 @@ static const Type* GetSugaredTypeOf(const Expr* expr) {
   return v.sugared.getTypePtr();
 }
 
+static map<const Type*, const Type*> GetDefaultedArgResugarMap(
+    const FunctionDecl* decl) {
+  map<const Type*, const Type*> res;
+  const FunctionTemplateDecl* template_decl = decl->getPrimaryTemplate();
+  if (!template_decl)
+    return res;
+  const TemplateParameterList* params = template_decl->getTemplateParameters();
+  const TemplateArgumentList* args = decl->getTemplateSpecializationArgs();
+  const unsigned count = params->size();
+  CHECK_(args->size() == count);
+  for (unsigned i = 0; i < count; ++i) {
+    if (const auto* param_decl =
+            dyn_cast<TemplateTypeParmDecl>(params->getParam(i))) {
+      const QualType type = args->get(i).getAsType().getCanonicalType();
+      if (param_decl->hasDefaultArgument() &&
+          param_decl->getDefaultArgument().getCanonicalType() == type) {
+        res.emplace(type.getTypePtr(), nullptr);
+      }
+    }
+  }
+  return res;
+}
+
 TemplateInstantiationData GetTplInstDataForFunction(
     const FunctionDecl* decl, const Expr* calling_expr,
     function<set<const Type*>(const Type*)> provided_getter) {
@@ -940,6 +965,7 @@ TemplateInstantiationData GetTplInstDataForFunction(
       for (const auto [_, sugared_type] : resugar_map)
         InsertAllInto(provided_getter(sugared_type), &provided_types);
     }
+    InsertAllInto(GetDefaultedArgResugarMap(decl), &resugar_map);
     return TemplateInstantiationData{resugar_map, provided_types};
   }
 
@@ -986,6 +1012,8 @@ TemplateInstantiationData GetTplInstDataForFunction(
     // argument.
     InsertAllInto(provided_getter(type), &provided_types);
   }
+
+  InsertAllInto(GetDefaultedArgResugarMap(decl), &resugar_map);
 
   // Log the types we never mapped.
   for (const auto& types : desugared_types) {

--- a/tests/cxx/default_tpl_arg-d2.h
+++ b/tests/cxx/default_tpl_arg-d2.h
@@ -16,3 +16,12 @@ template <typename T = IndirectClass>
 void FnWithProvidedDefaultTplArg() {
   T t;
 }
+
+// Use of this function template instantiated with the default argument and
+// called **without explicit ordinary argument** doesn't require complete
+// 'IndirectClass' type because this header '#include's it directly and hence
+// provides.
+template <typename T = IndirectClass>
+void FnWithProvidedDefaultTplArgAndDefaultCallArg(T* = nullptr) {
+  T t;
+}

--- a/tests/cxx/default_tpl_arg-d2.h
+++ b/tests/cxx/default_tpl_arg-d2.h
@@ -1,0 +1,18 @@
+//===--- default_tpl_arg-d2.h - test input file for iwyu ------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/indirect.h"
+
+// Use of this function template instantiated with the default argument doesn't
+// require complete 'IndirectClass' type because this header '#include's it
+// directly and hence provides.
+template <typename T = IndirectClass>
+void FnWithProvidedDefaultTplArg() {
+  T t;
+}

--- a/tests/cxx/default_tpl_arg-i1.h
+++ b/tests/cxx/default_tpl_arg-i1.h
@@ -20,3 +20,13 @@ template <typename T = IndirectClass>
 void FnWithNonProvidedDefaultTplArg() {
   T t;
 }
+
+// Use of this function template instantiated with the default argument and
+// called **without explicit ordinary argument** requires complete
+// 'IndirectClass' type info because this header doesn't provide it.
+template <typename T = IndirectClass>
+void FnWithNonProvidedDefaultTplArgAndDefaultCallArg(T* = nullptr) {
+  T t;
+}
+
+using NonProvidingAlias = IndirectClass;

--- a/tests/cxx/default_tpl_arg-i1.h
+++ b/tests/cxx/default_tpl_arg-i1.h
@@ -11,3 +11,12 @@ template <typename T>
 struct UninstantiatedTpl {
   T t;
 };
+
+class IndirectClass;
+
+// Use of this function template instantiated with the default argument requires
+// complete 'IndirectClass' type info because this header doesn't provide it.
+template <typename T = IndirectClass>
+void FnWithNonProvidedDefaultTplArg() {
+  T t;
+}

--- a/tests/cxx/default_tpl_arg.cc
+++ b/tests/cxx/default_tpl_arg.cc
@@ -13,6 +13,7 @@
 // doesn't crash when they refer to uninstantiated template specializations.
 
 #include "tests/cxx/default_tpl_arg-d1.h"
+#include "tests/cxx/default_tpl_arg-d2.h"
 #include "tests/cxx/direct.h"
 
 // IWYU: UninstantiatedTpl needs a declaration
@@ -43,6 +44,18 @@ struct Outer2 {
 // IWYU: IndirectTemplate needs a declaration
 Outer2<int, IndirectTemplate<int>> o2;
 
+void Fn() {
+  // IWYU: FnWithNonProvidedDefaultTplArg is...*default_tpl_arg-i1.h
+  // IWYU: IndirectClass is...*indirect.h
+  (void)&FnWithNonProvidedDefaultTplArg<>;
+  // IWYU: FnWithNonProvidedDefaultTplArg is...*default_tpl_arg-i1.h
+  // IWYU: IndirectClass is...*indirect.h
+  FnWithNonProvidedDefaultTplArg();
+
+  (void)&FnWithProvidedDefaultTplArg<>;
+  FnWithProvidedDefaultTplArg();
+}
+
 /**** IWYU_SUMMARY
 
 tests/cxx/default_tpl_arg.cc should add these lines:
@@ -54,7 +67,8 @@ tests/cxx/default_tpl_arg.cc should remove these lines:
 - #include "tests/cxx/direct.h"  // lines XX-XX
 
 The full include-list for tests/cxx/default_tpl_arg.cc:
-#include "tests/cxx/default_tpl_arg-i1.h"  // for UninstantiatedTpl
-#include "tests/cxx/indirect.h"  // for IndirectTemplate
+#include "tests/cxx/default_tpl_arg-d2.h"  // for FnWithProvidedDefaultTplArg
+#include "tests/cxx/default_tpl_arg-i1.h"  // for FnWithNonProvidedDefaultTplArg, UninstantiatedTpl
+#include "tests/cxx/indirect.h"  // for IndirectClass, IndirectTemplate
 
 ***** IWYU_SUMMARY */

--- a/tests/cxx/default_tpl_arg.cc
+++ b/tests/cxx/default_tpl_arg.cc
@@ -54,6 +54,29 @@ void Fn() {
 
   (void)&FnWithProvidedDefaultTplArg<>;
   FnWithProvidedDefaultTplArg();
+
+  // IWYU: IndirectClass is...*indirect.h
+  using ProvidingAlias = IndirectClass;
+  ProvidingAlias* p = 0;
+  // IWYU: NonProvidingAlias is...*default_tpl_arg-i1.h
+  NonProvidingAlias* n = 0;
+
+  // IWYU: FnWithNonProvidedDefaultTplArgAndDefaultCallArg is...*default_tpl_arg-i1.h
+  // IWYU: IndirectClass is...*indirect.h
+  FnWithNonProvidedDefaultTplArgAndDefaultCallArg();
+  // TODO: should not report here.
+  // IWYU: IndirectClass is...*indirect.h
+  FnWithProvidedDefaultTplArgAndDefaultCallArg();
+
+  // IWYU: FnWithNonProvidedDefaultTplArgAndDefaultCallArg is...*default_tpl_arg-i1.h
+  FnWithNonProvidedDefaultTplArgAndDefaultCallArg(p);
+  FnWithProvidedDefaultTplArgAndDefaultCallArg(p);
+
+  // IWYU: FnWithNonProvidedDefaultTplArgAndDefaultCallArg is...*default_tpl_arg-i1.h
+  // IWYU: IndirectClass is...*indirect.h
+  FnWithNonProvidedDefaultTplArgAndDefaultCallArg(n);
+  // IWYU: IndirectClass is...*indirect.h
+  FnWithProvidedDefaultTplArgAndDefaultCallArg(n);
 }
 
 /**** IWYU_SUMMARY
@@ -67,8 +90,8 @@ tests/cxx/default_tpl_arg.cc should remove these lines:
 - #include "tests/cxx/direct.h"  // lines XX-XX
 
 The full include-list for tests/cxx/default_tpl_arg.cc:
-#include "tests/cxx/default_tpl_arg-d2.h"  // for FnWithProvidedDefaultTplArg
-#include "tests/cxx/default_tpl_arg-i1.h"  // for FnWithNonProvidedDefaultTplArg, UninstantiatedTpl
+#include "tests/cxx/default_tpl_arg-d2.h"  // for FnWithProvidedDefaultTplArg, FnWithProvidedDefaultTplArgAndDefaultCallArg
+#include "tests/cxx/default_tpl_arg-i1.h"  // for FnWithNonProvidedDefaultTplArg, FnWithNonProvidedDefaultTplArgAndDefaultCallArg, NonProvidingAlias, UninstantiatedTpl
 #include "tests/cxx/indirect.h"  // for IndirectClass, IndirectTemplate
 
 ***** IWYU_SUMMARY */


### PR DESCRIPTION
Besides adding default type arguments of function templates into `resugar_map`, this PR introduces short-circuiting of handling a function reference when such a reference occur due to calling that function. Previously, that handling was just redundant. But after turning default argument analysis on, it started causing a bug with unwanted default type template argument reporting when it is actually overridden by the deduced one.

The problem arises because there is a lack of the full context for `resugar_map` and provided type set determination: actual function call arguments are not considered on function reference analyzing. Hence, a default type argument of a function template may be placed into `resugar_map` as defaulted despite being overridden by some of function call argument types.
