### PR TITLE
Add pragmas to suppress IWYU warnings in IWYU itself

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -140,9 +140,20 @@
 #include "llvm/Support/TargetSelect.h"
 #include "llvm/Support/raw_ostream.h"
 
+// TODO: Clean out pragmas as IWYU improves.
+// IWYU pragma: no_include "clang/AST/Redeclarable.h"
+// IWYU pragma: no_include "clang/AST/StmtIterator.h"
+// IWYU pragma: no_include "clang/AST/UnresolvedSet.h"
+// IWYU pragma: no_include "clang/Basic/CustomizableOptional.h"
+// IWYU pragma: no_include "clang/Lex/PPCallbacks.h"
+// IWYU pragma: no_include "llvm/ADT/iterator.h"
+// IWYU pragma: begin_keep
 namespace clang {
 class PPCallbacks;
+}  // namespace clang
+// IWYU pragma: end_keep
 
+namespace clang {
 namespace driver {
 class ToolChain;
 }

--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -46,6 +46,10 @@
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/raw_ostream.h"
 
+// TODO: Clean out pragmas as IWYU improves.
+// IWYU pragma: no_include "clang/AST/StmtIterator.h"
+// IWYU pragma: no_include "clang/Basic/CustomizableOptional.h"
+
 using clang::ASTDumper;
 using clang::ArrayType;
 using clang::BlockPointerType;

--- a/iwyu_cache.h
+++ b/iwyu_cache.h
@@ -22,6 +22,9 @@
 #include "iwyu_port.h"  // for CHECK_
 #include "iwyu_stl_util.h"
 
+// TODO: Clean out pragmas as IWYU improves.
+// IWYU pragma: no_include <iterator>
+
 namespace clang {
 class LangOptions;
 class NamedDecl;

--- a/iwyu_driver.cc
+++ b/iwyu_driver.cc
@@ -41,6 +41,10 @@
 #include "llvm/TargetParser/Host.h"
 #include "llvm/TargetParser/Triple.h"
 
+// TODO: Clean out pragmas as IWYU improves.
+// IWYU pragma: no_include "clang/Basic/LLVM.h"
+// IWYU pragma: no_include "llvm/ADT/iterator.h"
+
 namespace include_what_you_use {
 
 using clang::CompilerInstance;

--- a/iwyu_globals.cc
+++ b/iwyu_globals.cc
@@ -38,6 +38,10 @@
 #include "iwyu_version.h"
 #include "llvm/Support/raw_ostream.h"
 
+// TODO: Clean out pragmas as IWYU improves.
+// IWYU pragma: no_include <unistd.h>
+// IWYU pragma: no_include "llvm/ADT/iterator.h"
+
 using clang::CompilerInstance;
 using clang::HeaderSearch;
 using clang::LangOptions;

--- a/iwyu_include_picker.cc
+++ b/iwyu_include_picker.cc
@@ -11,8 +11,6 @@
 
 #include <algorithm>                    // for find
 #include <cstddef>                      // for size_t
-// TODO(wan): make sure IWYU doesn't suggest <iterator>.
-#include <iterator>                     // for find
 // not hash_map: it's not as portable and needs hash<string>.
 #include <map>                          // for map, map<>::mapped_type, etc
 #include <memory>
@@ -40,6 +38,9 @@
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/YAMLParser.h"
+
+// TODO: Clean out pragmas as IWYU improves.
+// IWYU pragma: no_include <iterator>
 
 using clang::OptionalFileEntryRef;
 using llvm::MemoryBuffer;

--- a/iwyu_include_picker.h
+++ b/iwyu_include_picker.h
@@ -52,6 +52,9 @@
 
 #include "clang/Basic/FileEntry.h"
 
+// TODO: Clean out pragmas as IWYU improves.
+// IWYU pragma: no_include <iterator>
+
 namespace include_what_you_use {
 
 using std::map;

--- a/iwyu_location_util.cc
+++ b/iwyu_location_util.cc
@@ -23,6 +23,9 @@
 #include "iwyu_ast_util.h"
 #include "iwyu_port.h"
 
+// TODO: Clean out pragmas as IWYU improves.
+// IWYU pragma: no_include "clang/Basic/CustomizableOptional.h"
+
 using clang::BinaryOperator;
 using clang::CXXDependentScopeMemberExpr;
 using clang::CXXMethodDecl;

--- a/iwyu_output.h
+++ b/iwyu_output.h
@@ -28,6 +28,9 @@
 #include "iwyu_stl_util.h"
 #include "iwyu_use_flags.h"
 
+// TODO: Clean out pragmas as IWYU improves.
+// IWYU pragma: no_include "clang/Basic/CustomizableOptional.h"
+
 namespace clang {
 class UsingDecl;
 class ElaboratedTypeLoc;

--- a/iwyu_preprocessor.cc
+++ b/iwyu_preprocessor.cc
@@ -32,6 +32,9 @@
 #include "iwyu_verrs.h"
 #include "llvm/Support/raw_ostream.h"
 
+// TODO: Clean out pragmas as IWYU improves.
+// IWYU pragma: no_include "clang/Basic/CustomizableOptional.h"
+
 using clang::CharSourceRange;
 using clang::FileEntryRef;
 using clang::FileID;

--- a/iwyu_stl_util.h
+++ b/iwyu_stl_util.h
@@ -12,7 +12,9 @@
 #ifndef INCLUDE_WHAT_YOU_USE_IWYU_STL_UTIL_H_
 #define INCLUDE_WHAT_YOU_USE_IWYU_STL_UTIL_H_
 
-#include <algorithm>                    // for find
+// TODO: IWYU can't see the use of std::find in uninstantiated template.
+#include <algorithm>  // IWYU pragma: keep
+
 #include <map>                          // for map, multimap
 #include <set>                          // for set
 #include <vector>                       // for vector

--- a/iwyu_verrs.h
+++ b/iwyu_verrs.h
@@ -13,7 +13,10 @@
 #define INCLUDE_WHAT_YOU_USE_IWYU_VERRS_H_
 
 #include "clang/Basic/FileEntry.h"
-#include "llvm/Support/raw_ostream.h"
+// IWYU can't see the use inside unexpanded macro VERRS(). All users of VERRS()
+// would need to include raw_ostream.h for operator<<() anyway, so export the
+// type for correctness and convenience.
+#include "llvm/Support/raw_ostream.h"  // IWYU pragma: export
 
 namespace include_what_you_use {
 


### PR DESCRIPTION
To run IWYU on IWYU, we can simply do:

* mkdir build && cd build
* cmake -DCMAKE_GENERATE_EXPORT_COMPILE_COMMANDS ...
* cd ..
* iwyu_tool.py -p build/ *.cc | ./fix_includes.py ...

I ran these steps and worked through the results. I found some recurring IWYU mistakes:

* Some headers are requested though they don't appear to be used. I think this is mostly due to "template spill", i.e. IWYU fails to identify whether a type should be provided by the template or covered by the instantiation (clang/AST/Redeclarable.h, clang/AST/StmtIterator.h, clang/AST/UnresolvedSet.h, clang/Basic/CustomizableOptional.h, llvm/ADT/iterator.h)
* PPCallbacks is thrown around in a std::unique_ptr, and IWYU fails to understand that a forward-declaration will suffice for that.
* std::pair appears to somehow confuse IWYU; it's attributed to both `<utility>` and `<iterator>`
* The getopt family is attributed to `<unistd.h>`. While that is correct according to the Linux manpage, it is not portable. We have a portable getopt in tree.
* Clang exposes a set of aliases for LLVM's Support library, and that appears to confuse IWYU so it suggests clang/Basic/LLVM.h even if better LLVM headers are already available.
* In iwyu_stl_util.h, we include <algorithm> for std::find. Unfortunately std::find is only used in a single, uninstantiated template, so IWYU can't see it (search issues for "UnresolvedLookupExpr" for more details).
* Similar, but different, in iwyu_verrs.h, the only use of raw_ostream is in an unexpanded macro.

Use IWYU pragmas to deal with these weaknesses:

* "pragma: no_include" to avoid pulling in implementation detail headers misdiagnosed by IWYU
* "pragma: keep" to force IWYU to retain misdiagnosed forward declarations and #includes
* "pragma: export" to let iwyu_verrs.h provide llvm::errs()

Once this is in place, we should be able to run a single IWYU pass over all IWYU's source files without any glaring mistakes.