### PR TITLE
Clean out some more unused using decls

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -98,7 +98,7 @@
 #include <memory>                       // for unique_ptr
 #include <set>                          // for set, set<>::iterator, swap
 #include <string>                       // for string, operator+, etc
-#include <utility>                      // for pair, make_pair
+#include <utility>                      // for pair
 #include <vector>                       // for vector, swap
 
 #include "clang/AST/ASTConsumer.h"
@@ -248,7 +248,6 @@ using llvm::dyn_cast;
 using llvm::dyn_cast_or_null;
 using llvm::errs;
 using llvm::isa;
-using std::make_pair;
 using std::map;
 using std::set;
 using std::string;

--- a/iwyu_driver.cc
+++ b/iwyu_driver.cc
@@ -31,11 +31,9 @@
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Frontend/CompilerInvocation.h"
 #include "clang/Frontend/FrontendAction.h"
-#include "clang/Frontend/TextDiagnosticPrinter.h"
 #include "clang/FrontendTool/Utils.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/STLExtras.h"
-#include "llvm/ADT/SmallString.h"
 #include "llvm/Option/ArgList.h"
 #include "llvm/Support/ErrorOr.h"
 #include "llvm/Support/FileSystem.h"
@@ -50,7 +48,6 @@ using clang::CompilerInvocation;
 using clang::DiagnosticOptions;
 using clang::DiagnosticsEngine;
 using clang::FrontendAction;
-using clang::TextDiagnosticPrinter;
 using clang::driver::Action;
 using clang::driver::Command;
 using clang::driver::Compilation;
@@ -60,13 +57,10 @@ using llvm::ArrayRef;
 using llvm::ErrorOr;
 using llvm::IntrusiveRefCntPtr;
 using llvm::MemoryBuffer;
-using llvm::SmallString;
 using llvm::SmallVector;
 using llvm::SmallVectorImpl;
 using llvm::StringRef;
-using llvm::cast;
 using llvm::errs;
-using llvm::isa;
 using llvm::opt::ArgStringList;
 using llvm::raw_ostream;
 using llvm::raw_string_ostream;


### PR DESCRIPTION
... and where possible, the providing #includes.

These were discovered by a refinement (cough) of the pipeline in iwyu.cc:

    file=$1
    echo "$file:"

    qualifieds=$(grep -E "^using [^;=]+;" $file | sed -e 's/using //' | tr -d ';')
    for qualified in $qualifieds; do
      symbol=$(echo "$qualified" | rev | cut -d":" -f1 | rev)
      grep -P "[^:/]$symbol\b" $file | grep -vq "//.*$symbol\b" || echo " $qualified"
    done

No functional change.