### PR TITLE
Run IWYU on IWYU (with why-comments)

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -87,58 +87,63 @@
 //     already get it via foo.h, IWYU won't recommend foo.cc to
 //     #include bar.h, unless it already does so.
 
-#include <algorithm>                    // for swap, find, make_pair
-#include <cstddef>                      // for size_t
-#include <cstdlib>                      // for atoi, exit
-#include <cstring>
-#include <deque>                        // for swap
-#include <iterator>                     // for find
-#include <list>                         // for swap
-#include <map>                          // for map, swap, etc
-#include <memory>                       // for unique_ptr
-#include <set>                          // for set, set<>::iterator, swap
-#include <string>                       // for string, operator+, etc
-#include <utility>                      // for pair
-#include <vector>                       // for vector, swap
+#include <stdio.h>                              // for snprintf
+#include <cstdlib>                              // for exit, size_t, EXIT_FA...
+#include <functional>                           // for function
+#include <map>                                  // for map, operator!=, _Rb_...
+#include <memory>                               // for unique_ptr, allocator
+#include <set>                                  // for set
+#include <string>                               // for basic_string, operator+
+#include <utility>                              // for pair, swap
+#include <vector>                               // for vector
 
-#include "clang/AST/ASTConsumer.h"
-#include "clang/AST/ASTContext.h"
-#include "clang/AST/Decl.h"
-#include "clang/AST/DeclBase.h"
-#include "clang/AST/DeclCXX.h"
-#include "clang/AST/DeclTemplate.h"
-#include "clang/AST/ExprConcepts.h"
-#include "clang/AST/NestedNameSpecifier.h"
-#include "clang/AST/OperationKinds.h"
-#include "clang/AST/RecursiveASTVisitor.h"
-#include "clang/AST/TemplateBase.h"
-#include "clang/AST/Type.h"
-#include "clang/AST/TypeLoc.h"
-#include "clang/Basic/FileEntry.h"
-#include "clang/Basic/SourceLocation.h"
-#include "clang/Basic/TypeTraits.h"
-#include "clang/Frontend/CompilerInstance.h"
-#include "clang/Frontend/FrontendAction.h"
-#include "clang/Lex/Preprocessor.h"
-#include "clang/Lex/PreprocessorOptions.h"
-#include "clang/Sema/Sema.h"
-#include "iwyu_ast_util.h"
-#include "iwyu_cache.h"
-#include "iwyu_driver.h"
-#include "iwyu_globals.h"
-#include "iwyu_lexer_utils.h"
-#include "iwyu_location_util.h"
-#include "iwyu_output.h"
-#include "iwyu_path_util.h"
-#include "iwyu_port.h"  // for CHECK_
-#include "iwyu_preprocessor.h"
-#include "iwyu_stl_util.h"
-#include "iwyu_string_util.h"
-#include "iwyu_use_flags.h"
-#include "iwyu_verrs.h"
-#include "llvm/Support/Casting.h"
-#include "llvm/Support/TargetSelect.h"
-#include "llvm/Support/raw_ostream.h"
+#include "clang/AST/ASTConsumer.h"              // for ASTConsumer
+#include "clang/AST/ASTContext.h"               // for ASTContext
+#include "clang/AST/Attr.h"                     // for Attr
+#include "clang/AST/Decl.h"                     // for FunctionDecl, NamedDecl
+#include "clang/AST/DeclBase.h"                 // for operator!=, Decl, Dec...
+#include "clang/AST/DeclCXX.h"                  // for CXXRecordDecl, CXXMet...
+#include "clang/AST/DeclTemplate.h"             // for ClassTemplateSpeciali...
+#include "clang/AST/Expr.h"                     // for CallExpr, Expr, DeclR...
+#include "clang/AST/ExprCXX.h"                  // for CXXConstructExpr, Ove...
+#include "clang/AST/ExprConcepts.h"             // for ConceptSpecialization...
+#include "clang/AST/NestedNameSpecifier.h"      // for NestedNameSpecifierLoc
+#include "clang/AST/OperationKinds.h"           // for CastKind, BinaryOpera...
+#include "clang/AST/RecursiveASTVisitor.h"      // for RecursiveASTVisitor
+#include "clang/AST/StmtCXX.h"                  // for CXXCatchStmt, CXXForR...
+#include "clang/AST/TemplateBase.h"             // for TemplateArgument, Tem...
+#include "clang/AST/TemplateName.h"             // for TemplateName
+#include "clang/AST/Type.h"                     // for Type, QualType, Templ...
+#include "clang/AST/TypeLoc.h"                  // for TypeLoc, QualifiedTyp...
+#include "clang/Basic/Diagnostic.h"             // for DiagnosticsEngine
+#include "clang/Basic/FileEntry.h"              // for OptionalFileEntryRef
+#include "clang/Basic/LangOptions.h"            // for LangOptions
+#include "clang/Basic/SourceLocation.h"         // for SourceLocation, opera...
+#include "clang/Basic/SourceManager.h"          // for SourceManager
+#include "clang/Basic/Specifiers.h"             // for ExprValueKind, Templa...
+#include "clang/Basic/TypeTraits.h"             // for TypeTrait
+#include "clang/Frontend/CompilerInstance.h"    // for CompilerInstance
+#include "clang/Frontend/CompilerInvocation.h"  // for CompilerInvocation
+#include "clang/Frontend/FrontendAction.h"      // for ASTFrontendAction
+#include "clang/Lex/Preprocessor.h"             // for Preprocessor
+#include "clang/Lex/PreprocessorOptions.h"      // for PreprocessorOptions
+#include "clang/Sema/Sema.h"                    // for Sema, LateParsedTempl...
+#include "iwyu_ast_util.h"                      // for ASTNode, DynCastFrom
+#include "iwyu_cache.h"                         // for CacheStoringScope
+#include "iwyu_driver.h"                        // for ExecuteAction
+#include "iwyu_globals.h"                       // for GlobalFlags, ClassMem...
+#include "iwyu_location_util.h"                 // for GetFileEntry, GetLoca...
+#include "iwyu_output.h"                        // for IwyuFileInfo
+#include "iwyu_port.h"                          // for CHECK_, CHECK_UNREACH...
+#include "iwyu_preprocessor.h"                  // for IwyuPreprocessorInfo
+#include "iwyu_stl_util.h"                      // for ContainsKey, Extend
+#include "iwyu_use_flags.h"                     // for UseFlags, UF_Explicit...
+#include "iwyu_verrs.h"                         // for raw_ostream, VERRS, errs
+#include "llvm/ADT/ArrayRef.h"                  // for ArrayRef
+#include "llvm/ADT/StringRef.h"                 // for StringRef
+#include "llvm/Support/Casting.h"               // for dyn_cast, isa, cast
+#include "llvm/Support/ManagedStatic.h"         // for llvm_shutdown_obj
+#include "llvm/Support/TargetSelect.h"          // for InitializeAllAsmParsers
 
 // TODO: Clean out pragmas as IWYU improves.
 // IWYU pragma: no_include "clang/AST/Redeclarable.h"
@@ -154,6 +159,9 @@ class PPCallbacks;
 // IWYU pragma: end_keep
 
 namespace clang {
+class FriendDecl;
+class Stmt;
+
 namespace driver {
 class ToolChain;
 }

--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -11,40 +11,45 @@
 
 #include "iwyu_ast_util.h"
 
-#include <set>                          // for set
-#include <string>                       // for string, operator+, etc
-#include <utility>                      // for pair
+#include <set>                              // for set
+#include <string>                           // for basic_string, allocator
+#include <utility>                          // for pair
 
-#include "clang/AST/ASTContext.h"
-#include "clang/AST/ASTDumper.h"
-#include "clang/AST/CanonicalType.h"
-#include "clang/AST/Decl.h"
-#include "clang/AST/DeclBase.h"
-#include "clang/AST/DeclCXX.h"
-#include "clang/AST/DeclTemplate.h"
-#include "clang/AST/Expr.h"
-#include "clang/AST/ExprCXX.h"
-#include "clang/AST/NestedNameSpecifier.h"
-#include "clang/AST/RecursiveASTVisitor.h"
-#include "clang/AST/Stmt.h"
-#include "clang/AST/TemplateBase.h"
-#include "clang/AST/TemplateName.h"
-#include "clang/AST/Type.h"
-#include "clang/AST/TypeLoc.h"
-#include "clang/Basic/Builtins.h"
-#include "clang/Basic/FileEntry.h"
-#include "clang/Basic/SourceLocation.h"
-#include "clang/Basic/SourceManager.h"
-#include "clang/Basic/Specifiers.h"
-#include "iwyu_globals.h"
-#include "iwyu_location_util.h"
-#include "iwyu_path_util.h"
-#include "iwyu_port.h"  // for CHECK_
-#include "iwyu_stl_util.h"
-#include "iwyu_verrs.h"
-#include "llvm/ADT/ArrayRef.h"
-#include "llvm/Support/Casting.h"
-#include "llvm/Support/raw_ostream.h"
+#include "clang/AST/ASTContext.h"           // for LazyGenerationalUpdatePtr...
+#include "clang/AST/ASTDumper.h"            // for ASTDumper
+#include "clang/AST/CanonicalType.h"        // for Type::getCanonicalTypeUnq...
+#include "clang/AST/Decl.h"                 // for FunctionDecl, TagDecl
+#include "clang/AST/DeclBase.h"             // for Decl, DeclContext, Recurs...
+#include "clang/AST/DeclCXX.h"              // for CXXRecordDecl, CXXConstru...
+#include "clang/AST/DeclTemplate.h"         // for ClassTemplateDecl, ClassT...
+#include "clang/AST/Expr.h"                 // for CallExpr, DeclRefExpr, Expr
+#include "clang/AST/ExprCXX.h"              // for CXXConstructExpr, Depende...
+#include "clang/AST/NestedNameSpecifier.h"  // for NestedNameSpecifier
+#include "clang/AST/OperationKinds.h"       // for UnaryOperatorKind
+#include "clang/AST/PrettyPrinter.h"        // for PrintingPolicy
+#include "clang/AST/RecursiveASTVisitor.h"  // for RecursiveASTVisitor
+#include "clang/AST/Redeclarable.h"         // for operator!=, Redeclarable ...
+#include "clang/AST/Stmt.h"                 // for RecursiveASTVisitor::Visi...
+#include "clang/AST/TemplateBase.h"         // for TemplateArgumentListInfo
+#include "clang/AST/TemplateName.h"         // for TemplateName, DependentTe...
+#include "clang/AST/Type.h"                 // for Type, QualType, Elaborate...
+#include "clang/AST/TypeLoc.h"              // for TypeLoc
+#include "clang/Basic/Builtins.h"           // for Context
+#include "clang/Basic/FileEntry.h"          // for OptionalFileEntryRef, ope...
+#include "clang/Basic/IdentifierTable.h"    // for IdentifierInfo
+#include "clang/Basic/SourceLocation.h"     // for SourceLocation, FullSourc...
+#include "clang/Basic/SourceManager.h"      // for SourceManager
+#include "clang/Basic/Specifiers.h"         // for TemplateSpecializationKind
+#include "iwyu_globals.h"                   // for DefaultPrintPolicy, Globa...
+#include "iwyu_location_util.h"             // for string, GetLocation
+#include "iwyu_path_util.h"                 // for NormalizeFilePath
+#include "iwyu_port.h"                      // for CHECK_, CHECK_UNREACHABLE_
+#include "iwyu_stl_util.h"                  // for InsertAllInto, ContainsKey
+#include "iwyu_verrs.h"                     // for raw_ostream, raw_string_o...
+#include "llvm/ADT/ArrayRef.h"              // for ArrayRef
+#include "llvm/ADT/PointerUnion.h"          // for PointerUnion
+#include "llvm/ADT/StringRef.h"             // for StringRef
+#include "llvm/Support/Casting.h"           // for cast, isa, dyn_cast, dyn_...
 
 // TODO: Clean out pragmas as IWYU improves.
 // IWYU pragma: no_include "clang/AST/StmtIterator.h"

--- a/iwyu_ast_util.h
+++ b/iwyu_ast_util.h
@@ -12,21 +12,19 @@
 #ifndef INCLUDE_WHAT_YOU_USE_IWYU_AST_UTIL_H_
 #define INCLUDE_WHAT_YOU_USE_IWYU_AST_UTIL_H_
 
-#include <functional>                   // for function
-#include <map>                          // for map
-#include <set>                          // for set
-#include <string>                       // for string
+#include <functional>                       // for function
+#include <map>                              // for map
+#include <set>                              // for set
+#include <string>                           // for string
 
-#include "clang/AST/DeclBase.h"
-#include "clang/AST/NestedNameSpecifier.h"
-#include "clang/AST/Stmt.h"
-#include "clang/AST/TemplateBase.h"
-#include "clang/AST/Type.h"
-#include "clang/AST/TypeLoc.h"
-#include "clang/Basic/SourceLocation.h"
-#include "iwyu_port.h"  // for CHECK_
-#include "iwyu_use_flags.h"
-#include "llvm/Support/Casting.h"
+#include "clang/AST/NestedNameSpecifier.h"  // for NestedNameSpecifier (ptr ...
+#include "clang/AST/TemplateBase.h"         // for TemplateArgument (ptr only)
+#include "clang/AST/Type.h"                 // for Type, EnumType (ptr only)
+#include "clang/AST/TypeLoc.h"              // for TypeLoc, operator==
+#include "clang/Basic/SourceLocation.h"     // for SourceLocation, SourceRange
+#include "iwyu_port.h"                      // for CHECK_UNREACHABLE_
+#include "iwyu_use_flags.h"                 // for UseFlags
+#include "llvm/Support/Casting.h"           // for dyn_cast, dyn_cast_or_null
 
 namespace clang {
 class CXXConstructExpr;
@@ -36,20 +34,21 @@ class CXXDestructorDecl;
 class CXXMethodDecl;
 class CXXRecordDecl;
 class CallExpr;
-class CastExpr;
 class ClassTemplateDecl;
 class ClassTemplateSpecializationDecl;
+class Decl;
+class DeclContext;
 class Expr;
 class FunctionDecl;
 class NamedDecl;
 class NamespaceDecl;
+class Stmt;
 class TagDecl;
 class TemplateDecl;
 class TemplateName;
 class TranslationUnitDecl;
 class TypeDecl;
 class ValueDecl;
-struct ASTTemplateArgumentListInfo;
 }  // namespace clang
 
 namespace include_what_you_use {

--- a/iwyu_cache.cc
+++ b/iwyu_cache.cc
@@ -9,15 +9,16 @@
 
 #include "iwyu_cache.h"
 
-#include <set>
-#include <string>
+#include <functional>                 // for function
+#include <set>                        // for set
+#include <string>                     // for basic_string, operator<, string
 
-#include "clang/AST/DeclTemplate.h"
-#include "clang/AST/TemplateBase.h"
-#include "clang/AST/Type.h"
-#include "clang/Basic/LangOptions.h"
-#include "iwyu_ast_util.h"
-#include "iwyu_stl_util.h"
+#include "clang/AST/DeclTemplate.h"   // for TemplateArgumentList, ClassTemp...
+#include "clang/AST/TemplateBase.h"   // for TemplateArgument
+#include "clang/AST/Type.h"           // for Type (ptr only), TemplateSpecia...
+#include "clang/Basic/LangOptions.h"  // for LangOptions
+#include "iwyu_ast_util.h"            // for DynCastFrom, DynCastPtr, GetTpl...
+#include "iwyu_stl_util.h"            // for ContainsKey
 
 using clang::ClassTemplateSpecializationDecl;
 using clang::LangOptions;

--- a/iwyu_cache.h
+++ b/iwyu_cache.h
@@ -15,12 +15,13 @@
 #ifndef INCLUDE_WHAT_YOU_USE_IWYU_CACHE_H_
 #define INCLUDE_WHAT_YOU_USE_IWYU_CACHE_H_
 
-#include <map>                          // for map
-#include <set>                          // for set
-#include <utility>                      // for pair
+#include <map>               // for map
+#include <set>               // for set
+#include <utility>           // for pair
 
-#include "iwyu_port.h"  // for CHECK_
-#include "iwyu_stl_util.h"
+#include "clang/AST/Type.h"  // for Type, TemplateSpecializationType (ptr only)
+#include "iwyu_port.h"       // for CHECK_
+#include "iwyu_stl_util.h"   // for FindInMap, ContainsKey
 
 // TODO: Clean out pragmas as IWYU improves.
 // IWYU pragma: no_include <iterator>
@@ -28,8 +29,6 @@
 namespace clang {
 class LangOptions;
 class NamedDecl;
-class TemplateSpecializationType;
-class Type;
 }
 
 namespace include_what_you_use {

--- a/iwyu_driver.cc
+++ b/iwyu_driver.cc
@@ -13,33 +13,39 @@
 // Everything below is adapted from clang/examples/clang-interpreter/main.cpp.
 #include "iwyu_driver.h"
 
-#include <cctype>
-#include <cstdint>
-#include <memory>
-#include <set>
-#include <string>
-#include <utility>
+#include <cctype>                               // for isspace
+#include <cstdint>                              // for intptr_t
+#include <memory>                               // for unique_ptr, allocator
+#include <set>                                  // for set, _Rb_tree_const_i...
+#include <string>                               // for basic_string, string
+#include <utility>                              // for pair
+#include <vector>                               // for vector
 
-#include "iwyu_verrs.h"
-
-#include "clang/Basic/DiagnosticFrontend.h"
-#include "clang/Basic/DiagnosticOptions.h"
-#include "clang/Driver/Action.h"
-#include "clang/Driver/Compilation.h"
-#include "clang/Driver/Driver.h"
-#include "clang/Driver/Tool.h"
-#include "clang/Frontend/CompilerInstance.h"
-#include "clang/Frontend/CompilerInvocation.h"
-#include "clang/Frontend/FrontendAction.h"
-#include "clang/FrontendTool/Utils.h"
-#include "llvm/ADT/ArrayRef.h"
-#include "llvm/ADT/STLExtras.h"
-#include "llvm/Option/ArgList.h"
-#include "llvm/Support/ErrorOr.h"
-#include "llvm/Support/FileSystem.h"
-#include "llvm/Support/MemoryBuffer.h"
-#include "llvm/TargetParser/Host.h"
-#include "llvm/TargetParser/Triple.h"
+#include "clang/Basic/Diagnostic.h"             // for DiagnosticBuilder
+#include "clang/Basic/DiagnosticFrontend.h"     // for err_fe_expected_compi...
+#include "clang/Basic/DiagnosticOptions.h"      // for DiagnosticOptions
+#include "clang/Driver/Action.h"                // for Action
+#include "clang/Driver/Compilation.h"           // for Compilation
+#include "clang/Driver/Driver.h"                // for Driver
+#include "clang/Driver/Job.h"                   // for Command, JobList
+#include "clang/Driver/Tool.h"                  // for Tool
+#include "clang/Frontend/CompilerInstance.h"    // for CompilerInstance
+#include "clang/Frontend/CompilerInvocation.h"  // for CompilerInvocation
+#include "clang/Frontend/FrontendAction.h"      // for FrontendAction
+#include "clang/Frontend/FrontendOptions.h"     // for FrontendOptions
+#include "clang/FrontendTool/Utils.h"           // for CreateFrontendAction
+#include "clang/Lex/HeaderSearchOptions.h"      // for HeaderSearchOptions
+#include "iwyu_verrs.h"                         // for raw_ostream, errs
+#include "llvm/ADT/ArrayRef.h"                  // for ArrayRef
+#include "llvm/ADT/IntrusiveRefCntPtr.h"        // for IntrusiveRefCntPtr
+#include "llvm/ADT/STLExtras.h"                 // for any_of, erase_if
+#include "llvm/ADT/SmallVector.h"               // for SmallVector, SmallVec...
+#include "llvm/ADT/StringRef.h"                 // for StringRef, operator==
+#include "llvm/Option/Option.h"                 // for ArgStringList
+#include "llvm/Support/ErrorOr.h"               // for ErrorOr
+#include "llvm/Support/FileSystem.h"            // for getMainExecutable
+#include "llvm/Support/MemoryBuffer.h"          // for MemoryBuffer
+#include "llvm/TargetParser/Host.h"             // for getDefaultTargetTriple
 
 // TODO: Clean out pragmas as IWYU improves.
 // IWYU pragma: no_include "clang/Basic/LLVM.h"

--- a/iwyu_globals.cc
+++ b/iwyu_globals.cc
@@ -9,34 +9,38 @@
 
 #include "iwyu_globals.h"
 
-#include <algorithm>                    // for sort, make_pair
-#include <cstdio>                       // for printf
-#include <cstdlib>                      // for atoi, exit, getenv
-#include <map>                          // for map
-#include <set>                          // for set
-#include <string>                       // for string, operator<, etc
-#include <utility>                      // for make_pair, pair
+#include <limits.h>                           // for INT_MAX, INT_MIN
+#include <string.h>                           // for strcmp
+#include <algorithm>                          // for remove, sort
+#include <cstdio>                             // for printf
+#include <cstdlib>                            // for exit, EXIT_FAILURE, atoi
+#include <map>                                // for map
+#include <set>                                // for operator!=, set, _Rb_tr...
+#include <string>                             // for basic_string, string
+#include <utility>                            // for pair, make_pair
 
-#include "clang/AST/PrettyPrinter.h"
-#include "clang/Basic/FileManager.h"
-#include "clang/Basic/Version.h"
-#include "clang/Driver/ToolChain.h"
-#include "clang/Frontend/CompilerInstance.h"
-#include "clang/Lex/HeaderSearch.h"
-#include "clang/Lex/Preprocessor.h"
-#include "iwyu_cache.h"
-#include "iwyu_getopt.h"
-#include "iwyu_include_picker.h"
-#include "iwyu_lexer_utils.h"
-#include "iwyu_location_util.h"
-#include "iwyu_path_util.h"
-#include "iwyu_port.h"  // for CHECK_, etc
-#include "iwyu_regex.h"
-#include "iwyu_stl_util.h"
-#include "iwyu_string_util.h"
-#include "iwyu_verrs.h"
-#include "iwyu_version.h"
-#include "llvm/Support/raw_ostream.h"
+#include "clang/AST/PrettyPrinter.h"          // for PrintingPolicy
+#include "clang/Basic/DirectoryEntry.h"       // for DirectoryEntryRef, Opti...
+#include "clang/Basic/LangOptions.h"          // for LangOptions
+#include "clang/Basic/Version.h"              // for getClangFullVersion
+#include "clang/Driver/ToolChain.h"           // for ToolChain
+#include "clang/Frontend/CompilerInstance.h"  // for CompilerInstance
+#include "clang/Lex/DirectoryLookup.h"        // for DirectoryLookup
+#include "clang/Lex/HeaderSearch.h"           // for HeaderSearch
+#include "clang/Lex/Preprocessor.h"           // for Preprocessor
+#include "iwyu_cache.h"                       // for FullUseCache
+#include "iwyu_getopt.h"                      // for no_argument, required_a...
+#include "iwyu_include_picker.h"              // for CXXStdLib, CStdLib, Inc...
+#include "iwyu_lexer_utils.h"                 // for SourceManagerCharacterD...
+#include "iwyu_location_util.h"               // for string, GetFilePath
+#include "iwyu_path_util.h"                   // for HeaderSearchPath, MakeA...
+#include "iwyu_port.h"                        // for CHECK_, GlobMatchesPath
+#include "iwyu_regex.h"                       // for ParseRegexDialect, Rege...
+#include "iwyu_string_util.h"                 // for Split
+#include "iwyu_verrs.h"                       // for raw_ostream, outs, raw_...
+#include "iwyu_version.h"                     // for IWYU_VERSION_STRING
+#include "llvm/ADT/StringRef.h"               // for StringRef
+#include "llvm/Option/ArgList.h"              // for InputArgList
 
 // TODO: Clean out pragmas as IWYU improves.
 // IWYU pragma: no_include <unistd.h>

--- a/iwyu_globals.h
+++ b/iwyu_globals.h
@@ -11,17 +11,17 @@
 #ifndef INCLUDE_WHAT_YOU_USE_IWYU_GLOBALS_H_
 #define INCLUDE_WHAT_YOU_USE_IWYU_GLOBALS_H_
 
-#include <set>                          // for set
-#include <string>                       // for string
-#include <vector>                       // for vector
+#include <set>                      // for set
+#include <string>                   // for string, basic_string
+#include <vector>                   // for vector
 
-#include "clang/Basic/FileEntry.h"
+#include "clang/Basic/FileEntry.h"  // for OptionalFileEntryRef
 
 namespace clang {
 class CompilerInstance;
-class HeaderSearch;
 class SourceManager;
 struct PrintingPolicy;
+
 namespace driver {
 class ToolChain;
 }  // namespace driver
@@ -33,10 +33,10 @@ using std::set;
 using std::string;
 using std::vector;
 
-enum class RegexDialect;
 class FullUseCache;
 class IncludePicker;
 class SourceManagerCharacterDataGetter;
+enum class RegexDialect;
 
 // To set up the global state you need to parse options with OptionsParser when
 // main starts and to call InitGlobals after the clang infrastructure is set up.

--- a/iwyu_include_picker.cc
+++ b/iwyu_include_picker.cc
@@ -9,35 +9,37 @@
 
 #include "iwyu_include_picker.h"
 
-#include <algorithm>                    // for find
-#include <cstddef>                      // for size_t
+#include <algorithm>                                   // for find, max_element
+#include <cstddef>                                     // for size_t
 // not hash_map: it's not as portable and needs hash<string>.
-#include <map>                          // for map, map<>::mapped_type, etc
-#include <memory>
-#include <numeric>                      // for accumulate
-#include <string>                       // for string, basic_string, etc
-#include <system_error>                 // for error_code
-#include <utility>                      // for pair, make_pair
-#include <vector>                       // for vector, vector<>::iterator
+#include <map>                                         // for map, operator!=
+#include <memory>                                      // for unique_ptr
+#include <numeric>                                     // for accumulate
+#include <string>                                      // for basic_string
+#include <system_error>                                // for error_code
+#include <utility>                                     // for pair, make_pair
+#include <vector>                                      // for vector
 
-#include "clang/Basic/FileManager.h"
-#include "clang/Tooling/Inclusions/StandardLibrary.h"
-#include "iwyu_location_util.h"
-#include "iwyu_path_util.h"
-#include "iwyu_port.h"
-#include "iwyu_regex.h"
-#include "iwyu_stl_util.h"
-#include "iwyu_string_util.h"
-#include "iwyu_verrs.h"
-#include "llvm/ADT/STLExtras.h"
-#include "llvm/ADT/StringRef.h"
-#include "llvm/Support/Casting.h"
-#include "llvm/Support/ErrorOr.h"
-#include "llvm/Support/FileSystem.h"
-#include "llvm/Support/Format.h"
-#include "llvm/Support/MemoryBuffer.h"
-#include "llvm/Support/SourceMgr.h"
-#include "llvm/Support/YAMLParser.h"
+#include "clang/Tooling/Inclusions/StandardLibrary.h"  // for Header, Symbol
+#include "iwyu_location_util.h"                        // for string, GetFil...
+#include "iwyu_path_util.h"                            // for ConvertToQuote...
+#include "iwyu_port.h"                                 // for CHECK_, IWYU_A...
+#include "iwyu_regex.h"                                // for RegexMatch
+#include "iwyu_stl_util.h"                             // for FindInMap, Con...
+#include "iwyu_string_util.h"                          // for StartsWith
+#include "iwyu_verrs.h"                                // for raw_ostream, errs
+#include "llvm/ADT/STLExtras.h"                        // for interleaveComma
+#include "llvm/ADT/SmallString.h"                      // for SmallString
+#include "llvm/ADT/SmallVector.h"                      // for SmallVector
+#include "llvm/ADT/StringRef.h"                        // for StringRef
+#include "llvm/ADT/Twine.h"                            // for Twine
+#include "llvm/Support/Casting.h"                      // for dyn_cast
+#include "llvm/Support/ErrorOr.h"                      // for ErrorOr
+#include "llvm/Support/FileSystem.h"                   // for exists
+#include "llvm/Support/Format.h"                       // for format, format...
+#include "llvm/Support/MemoryBuffer.h"                 // for MemoryBuffer
+#include "llvm/Support/SourceMgr.h"                    // for SourceMgr
+#include "llvm/Support/YAMLParser.h"                   // for Stream, Sequen...
 
 // TODO: Clean out pragmas as IWYU improves.
 // IWYU pragma: no_include <iterator>

--- a/iwyu_include_picker.h
+++ b/iwyu_include_picker.h
@@ -44,13 +44,14 @@
 #ifndef INCLUDE_WHAT_YOU_USE_IWYU_INCLUDE_PICKER_H_
 #define INCLUDE_WHAT_YOU_USE_IWYU_INCLUDE_PICKER_H_
 
-#include <map>                          // for map, map<>::value_compare
-#include <set>                          // for set
-#include <string>                       // for string
-#include <utility>                      // for pair
-#include <vector>                       // for vector
+#include <stddef.h>                 // for size_t
+#include <map>                      // for map
+#include <set>                      // for set
+#include <string>                   // for string, basic_string, allocator
+#include <utility>                  // for pair
+#include <vector>                   // for vector
 
-#include "clang/Basic/FileEntry.h"
+#include "clang/Basic/FileEntry.h"  // for OptionalFileEntryRef
 
 // TODO: Clean out pragmas as IWYU improves.
 // IWYU pragma: no_include <iterator>
@@ -64,9 +65,9 @@ using std::string;
 
 using std::vector;
 
+enum class RegexDialect;
 struct IncludeMapEntry;
 
-enum class RegexDialect;
 enum IncludeVisibility { kUnusedVisibility, kPublic, kPrivate };
 enum class CStdLib { None, ClangSymbols, Glibc };
 enum class CXXStdLib { None, ClangSymbols, Libstdcxx, Libcxx };

--- a/iwyu_lexer_utils.cc
+++ b/iwyu_lexer_utils.cc
@@ -8,14 +8,15 @@
 //===----------------------------------------------------------------------===//
 
 #include "iwyu_lexer_utils.h"
-#include "iwyu_globals.h"
-#include "iwyu_port.h"  // for CHECK_
 
-#include <string>
+#include <string.h>                      // for strpbrk, strstr
+#include <string>                        // for basic_string, string
 
-#include "clang/Basic/SourceLocation.h"
-#include "clang/Basic/SourceManager.h"
-#include "clang/Lex/Token.h"
+#include "clang/Basic/SourceLocation.h"  // for SourceLocation
+#include "clang/Basic/SourceManager.h"   // for SourceManager
+#include "clang/Lex/Token.h"             // for Token
+#include "iwyu_globals.h"                // for string, DefaultDataGetter
+#include "iwyu_port.h"                   // for CHECK_, CHECK_UNREACHABLE_
 
 using clang::SourceLocation;
 using clang::SourceManager;

--- a/iwyu_lexer_utils.h
+++ b/iwyu_lexer_utils.h
@@ -10,9 +10,10 @@
 #ifndef INCLUDE_WHAT_YOU_USE_IWYU_LEXER_UTILS_H_
 #define INCLUDE_WHAT_YOU_USE_IWYU_LEXER_UTILS_H_
 
-#include <string>                       // for string
+#include <string>                        // for string
 
-#include "clang/Basic/SourceLocation.h"
+#include "clang/Basic/SourceLocation.h"  // for SourceLocation
+#include "llvm/ADT/StringRef.h"          // for StringRef
 
 namespace clang {
 class SourceManager;

--- a/iwyu_location_util.cc
+++ b/iwyu_location_util.cc
@@ -9,19 +9,19 @@
 
 #include "iwyu_location_util.h"
 
-#include "clang/AST/Decl.h"
-#include "clang/AST/DeclBase.h"
-#include "clang/AST/DeclCXX.h"
-#include "clang/AST/DeclTemplate.h"
-#include "clang/AST/Expr.h"
-#include "clang/AST/ExprCXX.h"
-#include "clang/AST/NestedNameSpecifier.h"
-#include "clang/AST/Stmt.h"
-#include "clang/AST/TemplateBase.h"
-#include "clang/AST/TypeLoc.h"
-#include "clang/Basic/SourceLocation.h"
-#include "iwyu_ast_util.h"
-#include "iwyu_port.h"
+#include "clang/AST/Decl.h"                 // for FunctionDecl, NamedDecl
+#include "clang/AST/DeclBase.h"             // for Decl
+#include "clang/AST/DeclCXX.h"              // for CXXMethodDecl, CXXRecordDecl
+#include "clang/AST/DeclTemplate.h"         // for ClassTemplateSpecializati...
+#include "clang/AST/Expr.h"                 // for Expr, MemberExpr, Conditi...
+#include "clang/AST/ExprCXX.h"              // for CXXDependentScopeMemberExpr
+#include "clang/AST/NestedNameSpecifier.h"  // for NestedNameSpecifierLoc
+#include "clang/AST/Stmt.h"                 // for Stmt
+#include "clang/AST/TemplateBase.h"         // for TemplateArgumentLoc
+#include "clang/AST/TypeLoc.h"              // for TypeLoc
+#include "clang/Basic/SourceLocation.h"     // for SourceLocation, FileID
+#include "iwyu_ast_util.h"                  // for DynCastFrom, DynCastPtr
+#include "iwyu_string_util.h"               // for StartsWith
 
 // TODO: Clean out pragmas as IWYU improves.
 // IWYU pragma: no_include "clang/Basic/CustomizableOptional.h"

--- a/iwyu_location_util.h
+++ b/iwyu_location_util.h
@@ -42,15 +42,16 @@
 #ifndef INCLUDE_WHAT_YOU_USE_IWYU_LOCATION_UTIL_H_
 #define INCLUDE_WHAT_YOU_USE_IWYU_LOCATION_UTIL_H_
 
-#include <string>                       // for string
+#include <optional>                      // for nullopt
+#include <string>                        // for basic_string, string, allocator
 
-#include "clang/Basic/FileEntry.h"
-#include "clang/Basic/FileManager.h"
-#include "clang/Basic/SourceLocation.h"
-#include "clang/Basic/SourceManager.h"
-#include "clang/Lex/Token.h"
-#include "iwyu_globals.h"
-#include "iwyu_path_util.h"
+#include "clang/Basic/FileEntry.h"       // for OptionalFileEntryRef, FileEn...
+#include "clang/Basic/SourceLocation.h"  // for SourceLocation, FullSourceLoc
+#include "clang/Basic/SourceManager.h"   // for SourceManager
+#include "clang/Lex/Token.h"             // for Token
+#include "iwyu_globals.h"                // for GlobalSourceManager
+#include "iwyu_path_util.h"              // for NormalizeFilePath
+#include "llvm/ADT/StringRef.h"          // for StringRef
 
 namespace clang {
 class Decl;

--- a/iwyu_output.cc
+++ b/iwyu_output.cc
@@ -9,30 +9,34 @@
 
 #include "iwyu_output.h"
 
-#include <algorithm>                    // for sort, find
-#include <cstdio>                       // for snprintf
-#include <iterator>                     // for inserter
-#include <map>                          // for _Rb_tree_const_iterator, etc
-#include <utility>                      // for pair, make_pair, operator>
-#include <vector>                       // for vector, vector<>::iterator, etc
+#include <algorithm>                     // for any_of, max, remove_if, set_...
+#include <cstdio>                        // for size_t, snprintf
+#include <iterator>                      // for insert_iterator, inserter, pair
+#include <list>                          // for list, operator!=, _List_iter...
+#include <map>                           // for operator!=, map, _Rb_tree_it...
+#include <utility>                       // for pair, make_pair, operator>
+#include <vector>                        // for vector
 
-#include "clang/AST/ASTContext.h"
-#include "clang/AST/Decl.h"
-#include "clang/AST/DeclBase.h"
-#include "clang/AST/DeclTemplate.h"
-#include "clang/AST/Type.h"
-#include "clang/Basic/SourceLocation.h"
-#include "iwyu_ast_util.h"
-#include "iwyu_globals.h"
-#include "iwyu_include_picker.h"
-#include "iwyu_location_util.h"
-#include "iwyu_path_util.h"
-#include "iwyu_preprocessor.h"
-#include "iwyu_stl_util.h"
-#include "iwyu_string_util.h"
-#include "iwyu_verrs.h"
-#include "llvm/Support/Casting.h"
-#include "llvm/Support/raw_ostream.h"
+#include "clang/AST/ASTContext.h"        // for ASTContext
+#include "clang/AST/Decl.h"              // for NamedDecl, TagDecl, EnumDecl
+#include "clang/AST/DeclBase.h"          // for DeclContext, Decl, operator!=
+#include "clang/AST/DeclCXX.h"           // for UsingDecl, CXXRecordDecl
+#include "clang/AST/DeclTemplate.h"      // for ClassTemplateDecl, ClassTemp...
+#include "clang/AST/DeclarationName.h"   // for DeclarationName
+#include "clang/AST/Type.h"              // for ElaboratedType, QualType
+#include "clang/AST/TypeLoc.h"           // for ElaboratedTypeLoc
+#include "clang/Basic/SourceLocation.h"  // for SourceLocation, SourceRange
+#include "iwyu_ast_util.h"               // for DynCastFrom, DynCastPtr, Pri...
+#include "iwyu_globals.h"                // for GlobalFlags, CommandlineFlags
+#include "iwyu_include_picker.h"         // for IncludePicker, MappedInclude
+#include "iwyu_location_util.h"          // for GetFilePath, GetFileEntry
+#include "iwyu_path_util.h"              // for ConvertToQuotedInclude, IsHe...
+#include "iwyu_preprocessor.h"           // for string, IwyuPreprocessorInfo
+#include "iwyu_stl_util.h"               // for ContainsKey, InsertAllInto
+#include "iwyu_string_util.h"            // for EndsWith, StartsWith, Split
+#include "iwyu_verrs.h"                  // for raw_ostream, VERRS, ShouldPrint
+#include "llvm/ADT/StringRef.h"          // for StringRef
+#include "llvm/Support/Casting.h"        // for isa, cast, dyn_cast
 
 namespace include_what_you_use {
 

--- a/iwyu_output.h
+++ b/iwyu_output.h
@@ -16,24 +16,25 @@
 #ifndef INCLUDE_WHAT_YOU_USE_IWYU_OUTPUT_H_
 #define INCLUDE_WHAT_YOU_USE_IWYU_OUTPUT_H_
 
-#include <map>                          // for map
-#include <set>                          // for set
-#include <string>                       // for string, operator<
-#include <vector>                       // for vector
+#include <stddef.h>                      // for size_t
+#include <map>                           // for operator!=, map, _Rb_tree_co...
+#include <set>                           // for set
+#include <string>                        // for string, basic_string, operator<
+#include <vector>                        // for vector
 
-#include "clang/AST/Decl.h"
-#include "clang/Basic/FileEntry.h"
-#include "clang/Basic/SourceLocation.h"
-#include "iwyu_port.h"  // for CHECK_
-#include "iwyu_stl_util.h"
-#include "iwyu_use_flags.h"
+#include "clang/AST/Decl.h"              // for NamedDecl
+#include "clang/Basic/FileEntry.h"       // for OptionalFileEntryRef
+#include "clang/Basic/SourceLocation.h"  // for SourceLocation
+#include "iwyu_port.h"                   // for CHECK_
+#include "iwyu_stl_util.h"               // for InsertAllInto
+#include "iwyu_use_flags.h"              // for UseFlags
 
 // TODO: Clean out pragmas as IWYU improves.
 // IWYU pragma: no_include "clang/Basic/CustomizableOptional.h"
 
 namespace clang {
-class UsingDecl;
 class ElaboratedTypeLoc;
+class UsingDecl;
 }  // namespace clang
 
 namespace include_what_you_use {

--- a/iwyu_path_util.cc
+++ b/iwyu_path_util.cc
@@ -9,16 +9,15 @@
 
 #include "iwyu_path_util.h"
 
-#include <cstddef>
-#include <cstring>                      // for strlen
-#include <system_error>
+#include <cstring>                    // for strlen
+#include <system_error>               // for error_code
 
-#include "iwyu_stl_util.h"
-#include "llvm/ADT/STLExtras.h"
-#include "llvm/ADT/SmallString.h"
-#include "llvm/ADT/StringRef.h"
-#include "llvm/Support/FileSystem.h"
-#include "llvm/Support/Path.h"
+#include "iwyu_port.h"                // for CHECK_
+#include "iwyu_string_util.h"         // for StripRight, EndsWith, StartsWith
+#include "llvm/ADT/SmallString.h"     // for SmallString
+#include "llvm/ADT/StringRef.h"       // for StringRef
+#include "llvm/Support/FileSystem.h"  // for make_absolute
+#include "llvm/Support/Path.h"        // for append, convert_to_slash, is_ab...
 
 namespace include_what_you_use {
 

--- a/iwyu_path_util.h
+++ b/iwyu_path_util.h
@@ -12,10 +12,8 @@
 #ifndef INCLUDE_WHAT_YOU_USE_IWYU_PATH_UTIL_H_
 #define INCLUDE_WHAT_YOU_USE_IWYU_PATH_UTIL_H_
 
-#include <string>                       // for string, allocator, etc
-#include <vector>
-
-#include "iwyu_string_util.h"
+#include <string>  // for string, allocator, basic_string
+#include <vector>  // for vector
 
 namespace include_what_you_use {
 

--- a/iwyu_preprocessor.cc
+++ b/iwyu_preprocessor.cc
@@ -9,28 +9,32 @@
 
 #include "iwyu_preprocessor.h"
 
-#include <algorithm>
-#include <cstddef>                      // for size_t
-#include <cstring>
-#include <iterator>
-#include <string>                       // for string, basic_string, etc
-#include <utility>                      // for pair, make_pair
+#include <cstring>                        // for size_t, strlen
+#include <optional>                       // for nullopt
+#include <string>                         // for basic_string, allocator
+#include <utility>                        // for pair, make_pair
 
-#include "clang/AST/Decl.h"
-#include "clang/Basic/IdentifierTable.h"
-#include "clang/Lex/MacroInfo.h"
-#include "iwyu_ast_util.h"
-#include "iwyu_globals.h"
-#include "iwyu_include_picker.h"
-#include "iwyu_lexer_utils.h"
-#include "iwyu_location_util.h"
-#include "iwyu_output.h"
-#include "iwyu_path_util.h"
-#include "iwyu_port.h"  // for CHECK_
-#include "iwyu_stl_util.h"
-#include "iwyu_string_util.h"
-#include "iwyu_verrs.h"
-#include "llvm/Support/raw_ostream.h"
+#include "clang/AST/Decl.h"               // for NamedDecl
+#include "clang/Basic/IdentifierTable.h"  // for IdentifierInfo
+#include "clang/Basic/TokenKinds.h"       // for TokenKind
+#include "clang/Lex/MacroInfo.h"          // for MacroInfo, MacroDefinition
+#include "iwyu_ast_util.h"                // for PrintableLoc
+#include "iwyu_globals.h"                 // for MutableGlobalIncludePicker
+#include "iwyu_include_picker.h"          // for IncludePicker, MappedInclude
+#include "iwyu_lexer_utils.h"             // for LineHasText, SourceManagerC...
+#include "iwyu_location_util.h"           // for GetFilePath, string, GetFil...
+#include "iwyu_output.h"                  // for IwyuFileInfo
+#include "iwyu_path_util.h"               // for ConvertToQuotedInclude, Get...
+#include "iwyu_port.h"                    // for CHECK_, CHECK_UNREACHABLE_
+#include "iwyu_stl_util.h"                // for ContainsKey, FindInMap, Get...
+#include "iwyu_string_util.h"             // for StartsWith, StripLeft, Split
+#include "iwyu_verrs.h"                   // for raw_ostream, ERRSYM, VERRS
+#include "llvm/ADT/ArrayRef.h"            // for ArrayRef
+
+namespace clang {
+class MacroArgs;
+class Module;
+}  // namespace clang
 
 // TODO: Clean out pragmas as IWYU improves.
 // IWYU pragma: no_include "clang/Basic/CustomizableOptional.h"

--- a/iwyu_preprocessor.h
+++ b/iwyu_preprocessor.h
@@ -60,24 +60,26 @@
 #ifndef INCLUDE_WHAT_YOU_USE_IWYU_PREPROCESSOR_H_
 #define INCLUDE_WHAT_YOU_USE_IWYU_PREPROCESSOR_H_
 
-#include <map>                          // for map
-#include <set>                          // for set
-#include <stack>                        // for stack
-#include <string>                       // for string
-#include <utility>                      // for pair
-#include <vector>                       // for vector
+#include <map>                           // for map, multimap
+#include <set>                           // for set
+#include <stack>                         // for stack
+#include <string>                        // for string
+#include <vector>                        // for vector
 
-#include "clang/Basic/FileEntry.h"
-#include "clang/Basic/SourceLocation.h"
-#include "clang/Basic/SourceManager.h"
-#include "clang/Lex/PPCallbacks.h"
-#include "clang/Lex/Preprocessor.h"
-#include "clang/Lex/Token.h"
-#include "iwyu_output.h"
-#include "iwyu_port.h"  // for CHECK_
+#include "clang/Basic/FileEntry.h"       // for OptionalFileEntryRef, FileEn...
+#include "clang/Basic/SourceLocation.h"  // for SourceLocation, SourceRange
+#include "clang/Basic/SourceManager.h"   // for CharacteristicKind
+#include "clang/Lex/PPCallbacks.h"       // for PPCallbacks
+#include "clang/Lex/Preprocessor.h"      // for CommentHandler, Preprocessor...
+#include "clang/Lex/Token.h"             // for Token
+#include "iwyu_output.h"                 // for IwyuFileInfo
+#include "llvm/ADT/StringRef.h"          // for StringRef
 
 namespace clang {
-class MacroInfo;
+class MacroArgs;
+class MacroDefinition;
+class MacroDirective;
+class Module;
 class NamedDecl;
 }  // namespace clang
 

--- a/iwyu_regex.cc
+++ b/iwyu_regex.cc
@@ -9,11 +9,13 @@
 
 #include "iwyu_regex.h"
 
-#include <regex>
+#include <string.h>              // for strcmp
+#include <regex>                 // for regex_match, regex_replace, ECMAScript
 
-#include "iwyu_port.h"
-#include "iwyu_string_util.h"
-#include "llvm/Support/Regex.h"
+#include "iwyu_port.h"           // for CHECK_UNREACHABLE_
+#include "iwyu_string_util.h"    // for EndsWith, StartsWith
+#include "llvm/ADT/StringRef.h"  // for StringRef
+#include "llvm/Support/Regex.h"  // for Regex
 
 namespace include_what_you_use {
 

--- a/iwyu_verrs.cc
+++ b/iwyu_verrs.cc
@@ -9,9 +9,11 @@
 
 #include "iwyu_verrs.h"
 
-#include "iwyu_globals.h"
-#include "iwyu_location_util.h"
-#include "iwyu_path_util.h"
+#include <string>                // for basic_string
+
+#include "iwyu_globals.h"        // for ShouldReportIWYUViolationsFor
+#include "iwyu_location_util.h"  // for GetFilePath
+#include "iwyu_path_util.h"      // for IsSystemIncludeFile
 
 namespace include_what_you_use {
 


### PR DESCRIPTION
This is the unadorned output of:

    $ ./iwyu_tool.py -p .../out/main+deb *.cc -- \
        -Xiwyu --check_also="*/include-what-you-use/iwyu_*.h" | \
        ./fix_includes.py --nosafe_headers --reorder --comments
    (skipping .../include-what-you-use/iwyu_port.h: iwyu reports no contentful changes)
    (skipping .../include-what-you-use/iwyu_use_flags.h: iwyu reports no contentful changes)
    (skipping .../include-what-you-use/iwyu_string_util.h: iwyu reports no contentful changes)
    (skipping .../include-what-you-use/iwyu_stl_util.h: iwyu reports no contentful changes)
    (skipping .../include-what-you-use/iwyu_verrs.h: iwyu reports no contentful changes)
    (skipping .../include-what-you-use/iwyu_driver.h: iwyu reports no contentful changes)
    (skipping .../include-what-you-use/iwyu_getopt.h: iwyu reports no contentful changes)
    (skipping .../include-what-you-use/iwyu_getopt.cc: iwyu reports no contentful changes)
    (skipping .../include-what-you-use/iwyu_regex.h: iwyu reports no contentful changes)
    (skipping .../include-what-you-use/iwyu_version.h: iwyu reports no contentful changes)
    >>> Fixing #includes in '.../include-what-you-use/iwyu_ast_util.h'
    >>> Fixing #includes in '.../include-what-you-use/iwyu_globals.h'
    >>> Fixing #includes in '.../include-what-you-use/iwyu_location_util.h'
    >>> Fixing #includes in '.../include-what-you-use/iwyu_path_util.h'
    >>> Fixing #includes in '.../include-what-you-use/iwyu_ast_util.cc'
    >>> Fixing #includes in '.../include-what-you-use/iwyu_cache.h'
    >>> Fixing #includes in '.../include-what-you-use/iwyu_cache.cc'
    >>> Fixing #includes in '.../include-what-you-use/iwyu_lexer_utils.h'
    >>> Fixing #includes in '.../include-what-you-use/iwyu_output.h'
    >>> Fixing #includes in '.../include-what-you-use/iwyu_preprocessor.h'
    >>> Fixing #includes in '.../include-what-you-use/iwyu.cc'
    >>> Fixing #includes in '.../include-what-you-use/iwyu_driver.cc'
    >>> Fixing #includes in '.../include-what-you-use/iwyu_include_picker.h'
    >>> Fixing #includes in '.../include-what-you-use/iwyu_globals.cc'
    >>> Fixing #includes in '.../include-what-you-use/iwyu_include_picker.cc'
    >>> Fixing #includes in '.../include-what-you-use/iwyu_lexer_utils.cc'
    >>> Fixing #includes in '.../include-what-you-use/iwyu_location_util.cc'
    >>> Fixing #includes in '.../include-what-you-use/iwyu_output.cc'
    >>> Fixing #includes in '.../include-what-you-use/iwyu_path_util.cc'
    >>> Fixing #includes in '.../include-what-you-use/iwyu_preprocessor.cc'
    >>> Fixing #includes in '.../include-what-you-use/iwyu_regex.cc'
    >>> Fixing #includes in '.../include-what-you-use/iwyu_verrs.cc'
    IWYU edited 22 files on your behalf.

Use './fix_includes.py --comments' to add why-comments to all #includes.