### PR TITLE
Short-circuit default argument expression traversal

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -173,6 +173,7 @@ using clang::CXXBaseSpecifier;
 using clang::CXXCatchStmt;
 using clang::CXXConstructExpr;
 using clang::CXXConstructorDecl;
+using clang::CXXDefaultArgExpr;
 using clang::CXXDeleteExpr;
 using clang::CXXDestructorDecl;
 using clang::CXXForRangeStmt;
@@ -2327,6 +2328,12 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
     }
 
     ReportTypeUse(CurrentLoc(), type.getTypePtr(), DerefKind::RemoveRefs);
+    return true;
+  }
+
+  bool TraverseCXXDefaultArgExpr(CXXDefaultArgExpr*) {
+    // They should already be handled at the function declaration site,
+    // not at the call site.
     return true;
   }
 

--- a/tests/cxx/no_def_arg_call_site-d1.h
+++ b/tests/cxx/no_def_arg_call_site-d1.h
@@ -1,0 +1,28 @@
+//===--- no_def_arg_call_site-d1.h - test input file for iwyu -------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/no_def_arg_call_site-i1.h"
+
+struct Struct {
+  // IWYU: GetInt is...*no_def_arg_call_site-i2.h
+  static void FnWithDefArg(int = GetInt());
+};
+
+/**** IWYU_SUMMARY
+
+tests/cxx/no_def_arg_call_site-d1.h should add these lines:
+#include "tests/cxx/no_def_arg_call_site-i2.h"
+
+tests/cxx/no_def_arg_call_site-d1.h should remove these lines:
+- #include "tests/cxx/no_def_arg_call_site-i1.h"  // lines XX-XX
+
+The full include-list for tests/cxx/no_def_arg_call_site-d1.h:
+#include "tests/cxx/no_def_arg_call_site-i2.h"  // for GetInt
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/no_def_arg_call_site-i1.h
+++ b/tests/cxx/no_def_arg_call_site-i1.h
@@ -1,0 +1,10 @@
+//===--- no_def_arg_call_site-i1.h - test input file for iwyu -------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/no_def_arg_call_site-i2.h"

--- a/tests/cxx/no_def_arg_call_site-i2.h
+++ b/tests/cxx/no_def_arg_call_site-i2.h
@@ -1,0 +1,10 @@
+//===--- no_def_arg_call_site-i2.h - test input file for iwyu -------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+int GetInt();

--- a/tests/cxx/no_def_arg_call_site.cc
+++ b/tests/cxx/no_def_arg_call_site.cc
@@ -1,0 +1,31 @@
+//===--- no_def_arg_call_site.cc - test input file for iwyu ---------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_ARGS: -Xiwyu --check_also="tests/cxx/no_def_arg_call_site-d1.h" -I .
+
+// Tests that IWYU doesn't report default function arguments when analyzing call
+// site.
+
+#include "tests/cxx/no_def_arg_call_site-d1.h"
+
+template <typename T>
+void TplFn() {
+  T::FnWithDefArg();
+}
+
+void Fn() {
+  TplFn<Struct>();
+  Struct::FnWithDefArg();
+}
+
+/**** IWYU_SUMMARY
+
+(tests/cxx/no_def_arg_call_site.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
There is no point in default argument analysis at function call site because all the needed types and declarations should be provided by the function definition header. IWYU reports them during `ParmVarDecl` traversal.

This fixes the original problem reported in #1121.