### PR TITLE
Ignore default function call arguments on "type deduction"

### DIFF
--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -55,6 +55,7 @@ using clang::ArrayType;
 using clang::BlockPointerType;
 using clang::CXXConstructExpr;
 using clang::CXXConstructorDecl;
+using clang::CXXDefaultArgExpr;
 using clang::CXXDeleteExpr;
 using clang::CXXDependentScopeMemberExpr;
 using clang::CXXDestructorDecl;
@@ -999,6 +1000,8 @@ TemplateInstantiationData GetTplInstDataForFunction(
   //                 under it, take the pre-cast type instead?
   set<const Type*> fn_arg_types;
   for (unsigned i = 0; i < num_args; ++i) {
+    if (isa<CXXDefaultArgExpr>(fn_args[i]))
+      break;
     const Type* argtype = GetSugaredTypeOf(fn_args[i]);
     // TODO(csilvers): handle RecordTypes that are a TemplateSpecializationDecl
     InsertAllInto(GetComponentsOfType(argtype), &fn_arg_types);

--- a/tests/cxx/default_tpl_arg-d2.h
+++ b/tests/cxx/default_tpl_arg-d2.h
@@ -22,6 +22,16 @@ void FnWithProvidedDefaultTplArg() {
 // 'IndirectClass' type because this header '#include's it directly and hence
 // provides.
 template <typename T = IndirectClass>
-void FnWithProvidedDefaultTplArgAndDefaultCallArg(T* = nullptr) {
+void FnWithProvidedDefaultTplArgAndDefaultCallArg1(T* = nullptr) {
+  T t;
+}
+
+template <typename T = IndirectClass>
+void FnWithProvidedDefaultTplArgAndDefaultCallArg2(T = T{}) {
+  T t;
+}
+
+template <typename T = IndirectClass>
+void FnWithProvidedDefaultTplArgAndDefaultCallArg3(T = {}) {
   T t;
 }

--- a/tests/cxx/default_tpl_arg.cc
+++ b/tests/cxx/default_tpl_arg.cc
@@ -64,19 +64,22 @@ void Fn() {
   // IWYU: FnWithNonProvidedDefaultTplArgAndDefaultCallArg is...*default_tpl_arg-i1.h
   // IWYU: IndirectClass is...*indirect.h
   FnWithNonProvidedDefaultTplArgAndDefaultCallArg();
-  // TODO: should not report here.
-  // IWYU: IndirectClass is...*indirect.h
-  FnWithProvidedDefaultTplArgAndDefaultCallArg();
+  FnWithProvidedDefaultTplArgAndDefaultCallArg1();
 
   // IWYU: FnWithNonProvidedDefaultTplArgAndDefaultCallArg is...*default_tpl_arg-i1.h
   FnWithNonProvidedDefaultTplArgAndDefaultCallArg(p);
-  FnWithProvidedDefaultTplArgAndDefaultCallArg(p);
+  FnWithProvidedDefaultTplArgAndDefaultCallArg1(p);
 
   // IWYU: FnWithNonProvidedDefaultTplArgAndDefaultCallArg is...*default_tpl_arg-i1.h
   // IWYU: IndirectClass is...*indirect.h
   FnWithNonProvidedDefaultTplArgAndDefaultCallArg(n);
   // IWYU: IndirectClass is...*indirect.h
-  FnWithProvidedDefaultTplArgAndDefaultCallArg(n);
+  FnWithProvidedDefaultTplArgAndDefaultCallArg1(n);
+
+  // Some additional variations of default arguments. Should not report
+  // IndirectClass because it is provided by the templates.
+  FnWithProvidedDefaultTplArgAndDefaultCallArg2();
+  FnWithProvidedDefaultTplArgAndDefaultCallArg3();
 }
 
 /**** IWYU_SUMMARY
@@ -90,7 +93,7 @@ tests/cxx/default_tpl_arg.cc should remove these lines:
 - #include "tests/cxx/direct.h"  // lines XX-XX
 
 The full include-list for tests/cxx/default_tpl_arg.cc:
-#include "tests/cxx/default_tpl_arg-d2.h"  // for FnWithProvidedDefaultTplArg, FnWithProvidedDefaultTplArgAndDefaultCallArg
+#include "tests/cxx/default_tpl_arg-d2.h"  // for FnWithProvidedDefaultTplArg, FnWithProvidedDefaultTplArgAndDefaultCallArg1, FnWithProvidedDefaultTplArgAndDefaultCallArg2, FnWithProvidedDefaultTplArgAndDefaultCallArg3
 #include "tests/cxx/default_tpl_arg-i1.h"  // for FnWithNonProvidedDefaultTplArg, FnWithNonProvidedDefaultTplArgAndDefaultCallArg, NonProvidingAlias, UninstantiatedTpl
 #include "tests/cxx/indirect.h"  // for IndirectClass, IndirectTemplate
 


### PR DESCRIPTION
Function call default arguments don't take part in deducing type template parameters, and should be ignored on `resugar_map` building.

This fixes the second problem reported in #1121.
