### PR TITLE
Use C++ C compatibility headers consistently

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -87,7 +87,7 @@
 //     already get it via foo.h, IWYU won't recommend foo.cc to
 //     #include bar.h, unless it already does so.
 
-#include <stdio.h>
+#include <cstdio>
 #include <cstdlib>                      // for atoi, exit
 #include <functional>
 #include <map>                          // for map, swap, etc

--- a/iwyu_globals.cc
+++ b/iwyu_globals.cc
@@ -9,11 +9,11 @@
 
 #include "iwyu_globals.h"
 
-#include <limits.h>
-#include <string.h>
 #include <algorithm>                    // for sort, make_pair
+#include <climits>
 #include <cstdio>                       // for printf
 #include <cstdlib>                      // for atoi, exit, getenv
+#include <cstring>
 #include <map>                          // for map
 #include <set>                          // for set
 #include <string>                       // for string, operator<, etc

--- a/iwyu_include_picker.h
+++ b/iwyu_include_picker.h
@@ -44,7 +44,7 @@
 #ifndef INCLUDE_WHAT_YOU_USE_IWYU_INCLUDE_PICKER_H_
 #define INCLUDE_WHAT_YOU_USE_IWYU_INCLUDE_PICKER_H_
 
-#include <stddef.h>
+#include <cstddef>
 #include <map>                          // for map, map<>::value_compare
 #include <set>                          // for set
 #include <string>                       // for string

--- a/iwyu_lexer_utils.cc
+++ b/iwyu_lexer_utils.cc
@@ -9,7 +9,7 @@
 
 #include "iwyu_lexer_utils.h"
 
-#include <string.h>
+#include <cstring>
 #include <string>
 
 #include "clang/Basic/SourceLocation.h"

--- a/iwyu_output.h
+++ b/iwyu_output.h
@@ -16,7 +16,7 @@
 #ifndef INCLUDE_WHAT_YOU_USE_IWYU_OUTPUT_H_
 #define INCLUDE_WHAT_YOU_USE_IWYU_OUTPUT_H_
 
-#include <stddef.h>
+#include <cstddef>
 #include <map>                          // for map
 #include <set>                          // for set
 #include <string>                       // for string, operator<

--- a/iwyu_regex.cc
+++ b/iwyu_regex.cc
@@ -9,7 +9,7 @@
 
 #include "iwyu_regex.h"
 
-#include <string.h>
+#include <cstring>
 #include <regex>
 
 #include "iwyu_port.h"


### PR DESCRIPTION
Use `<cxxx>` instead of `<xxx.h>` in the IWYU code base.

The only exception is iwyu_getopt.cc, which is C code vendored from https://github.com/kimgr/getopt_port, so we want to stay as close to it as possible.