### PR TITLE
[ci] Add CI steps for IWYU dogfooding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,7 @@ jobs:
           mkdir build
           cd ./build
           cmake -G Ninja \
+                -DCMAKE_EXPORT_COMPILE_COMMANDS=on \
                 -DCMAKE_C_COMPILER=clang$LLVM_TAG \
                 -DCMAKE_CXX_COMPILER=clang++$LLVM_TAG \
                 -DCMAKE_INSTALL_PREFIX=./ \
@@ -82,3 +83,23 @@ jobs:
         run: |
           git ls-tree --full-tree --name-only -r HEAD | \
               xargs ./iwyu-check-license-header.py
+
+      - name: IWYU dogfood
+        if: github.event_name == 'pull_request'
+        env:
+          PR_URL: ${{ github.event.pull_request.comments_url }}
+        run: |
+          ./iwyu-dogfood.bash ./build
+          cat ./iwyu-dogfood.md >> $GITHUB_STEP_SUMMARY
+          mkdir ./dogfood-results
+          mv ./iwyu-dogfood.md ./dogfood-results/
+          echo "$PR_URL" > ./dogfood-results/pr-url
+
+      - name: Upload dogfood results
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: dogfood-results
+          path: ./dogfood-results
+          retention-days: 1
+          if-no-files-found: error

--- a/iwyu-dogfood.bash
+++ b/iwyu-dogfood.bash
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+##===--- iwyu-dogfood.bash ------------------------------------------------===##
+#
+#                     The LLVM Compiler Infrastructure
+#
+# This file is distributed under the University of Illinois Open Source
+# License. See LICENSE.TXT for details.
+#
+##===----------------------------------------------------------------------===##
+
+# This script is used to run IWYU over its own code base and produce a report
+# suitable for GitHub pull requests.
+# It assumes both include-what-you-use executable and compile_commands.json
+# compilation database are present in the build directory specified.
+
+if [ -z "$1" ]; then
+    echo "usage: $0 <build-path>"
+    exit 1
+fi
+builddir="$1"
+
+# Generate a --check_also arg for every header-only module.
+HEADER_ONLY=" \
+iwyu_port.h \
+iwyu_stl_util.h \
+iwyu_string_util.h \
+iwyu_use_flags.h \
+iwyu_version.h \
+"
+check_alsos=$(for h in $HEADER_ONLY; do echo "-Xiwyu --check_also=*/$h"; done)
+
+# Run IWYU over all source files using iwyu_tool.py with CMake-generated
+# compilation database.
+export IWYU_BINARY=$builddir/bin/include-what-you-use
+./iwyu_tool.py -v -p "$builddir" *.cc -- $check_alsos > iwyu-dogfood.out 2>&1
+iwyu_exit=$?
+
+# Apply changes in-tree using fix_includes.py.
+./fix_includes.py --nosafe_headers --reorder < iwyu-dogfood.out \
+                  > iwyu-dogfood.fix
+fix_includes_exit=$?
+
+# Let Git produce a diff of all suggested changes
+git diff > iwyu-dogfood.diff
+
+# Print out a GitHub Markdown result file.
+cat<<EOF > iwyu-dogfood.md
+### Informational: IWYU dogfood results
+
+<details>
+<summary>include-what-you-use (exit: $iwyu_exit)</summary>
+
+\`\`\`
+$(cat iwyu-dogfood.out)
+\`\`\`
+
+</details>
+
+<details>
+<summary>fix_includes.py (exit: $fix_includes_exit)</summary>
+
+\`\`\`
+$(cat iwyu-dogfood.fix)
+\`\`\`
+
+</details>
+
+<details>
+<summary>diff</summary>
+
+\`\`\`diff
+$(cat iwyu-dogfood.diff)
+\`\`\`
+
+</details>
+EOF


### PR DESCRIPTION
Add a script `iwyu-dogfood.bash`, that runs IWYU on itself and processes
the output into a nice Markdown report called `iwyu-dogfood.md`.

Enable `CMAKE_EXPORT_COMPILE_COMMANDS` to make `compile_commands.json`
available to the analysis.

Upload the report + a file containing the current PR API URL as an
artifact, to be picked up by the separate `dogfood-comment.yaml` workflow_run, which in turn
translates the file into a PR comment.