### PR TITLE
[ci] Add experimental workflow_run action for IWYU dogfood

### DIFF
--- a/.github/workflows/dogfood-comment.yml
+++ b/.github/workflows/dogfood-comment.yml
@@ -1,0 +1,57 @@
+name: IWYU dogfood comment
+
+# NOTE: this workflow does not run in a pull_request context, and thus
+# GITHUB_TOKEN has slightly eleveated permissions.
+# That means we need to be particularly careful not to run untrusted code such
+# as submitted in PRs.
+# https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+
+on:
+  workflow_run:
+    workflows: [IWYU CI]
+    types:
+      - completed
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  dogfood-comment:
+    # Only run if triggered from a successful PR build.
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: true
+    steps:
+      - name: Install prerequisites
+        run: |
+          sudo apt update
+          sudo apt install -y \
+               curl \
+               jq
+
+      - name: Download dogfood results
+        uses: actions/download-artifact@v4
+        with:
+          run_id: ${{github.event.workflow_run.id }}
+          name: dogfood-results
+          path: ./dogfood-results
+
+      - name: Add dogfood PR comment
+        if: ${{ hashFiles('./dogfood-results/pr-url') != '' }}
+        env:
+          API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          curl \
+            -sS \
+            -L \
+            -X POST \
+            "$(cat ./dogfood-results/pr-url)" \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $API_TOKEN" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            --data '{ "body": "$(jq -R -s '.' ./dogfood-results/iwyu-dogfood.md)" }'


### PR DESCRIPTION
GitHub Actions have somewhat Kafkaesque security limitations;

* A workflow triggered by a 'pull_request' from a fork does not have write access to the main repo (to prevent submitting PRs containing code that could steal secrets or self-approve PRs, etc.)
* The recommended approach is to build+test code in 'pull_request' workflows, but hand over to separate 'workflow_run' actions for privileged operations. Context is transfered by file using artifacts
* However, the 'workflow_run' action will only trigger if it exists on the master branch (the base branch is not enough, presumably because someone could open two PRs and base one on the other)

This GitHub blog post was highly enlightening:
https://securitylab.github.com/research/github-actions-preventing-pwn-requests/

So I need to merge this mostly untested to master in order to be able to try it with a triggering PR. Hopefully this is close enough to functional that I don't have to iterate much.