### PR TITLE
Fix dereferencing of forwarding references

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -1761,6 +1761,34 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
     return true;
   }
 
+  // The explicit traversal of 'CXXForRangeStmt' is introduced to avoid
+  // a problem with code like this:
+  //
+  // using ProvidingRefAlias = Container&;
+  // ProvidingRefAlias ref_provided = ...;
+  // for (int x : ref_provided) ...
+  //
+  // After initialization of implicit range variable, the specific providing
+  // type is desugared. Due to this, it is reported e.g. on handling
+  // the implicit call of 'begin()' method despite being provided by alias.
+  // Explicit traversal without handling for-loop implicit variables allows
+  // to avoid such an unwanted reporting of the provided type. The code does
+  // essentially the same that the default implementation does when
+  // 'shouldVisitImplicitCode()' returns 'false'.
+  bool TraverseCXXForRangeStmt(CXXForRangeStmt* stmt) {
+    if (!this->getDerived().WalkUpFromCXXForRangeStmt(stmt))
+      return false;
+    if (Stmt* init_stmt = stmt->getInit()) {
+      if (!this->getDerived().TraverseStmt(init_stmt))
+        return false;
+    }
+    if (!this->getDerived().TraverseStmt(stmt->getLoopVarStmt()))
+      return false;
+    if (!this->getDerived().TraverseStmt(stmt->getRangeInit()))
+      return false;
+    return this->getDerived().TraverseStmt(stmt->getBody());
+  }
+
   // The type of the for-range-init expression is fully required, because the
   // compiler generates method calls to it, e.g. 'for (auto t : ts)' translates
   // roughly into 'for (auto i = std::begin(ts); i != std::end(ts); ++i)'.
@@ -2563,16 +2591,19 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
     type = Desugar(type);
     if (deref_kind == DerefKind::RemoveRefs ||
         deref_kind == DerefKind::RemoveRefsAndPtr) {
-      if (const auto* ref_type = dyn_cast_or_null<ReferenceType>(type))
-        type = ref_type->getPointeeTypeAsWritten().getTypePtr();
-      // Keep deref_kind to remove possible additional references in type alias
-      // chain.
-      // TODO(bolshakov): shouldn't Desugar be called here and below as well?
+      if (const auto* ref_type = dyn_cast_or_null<ReferenceType>(type)) {
+        // Keep deref_kind to remove possible additional references in type
+        // alias chain.
+        return ReportTypeUseInternal(
+            used_loc, ref_type->getPointeeTypeAsWritten().getTypePtr(),
+            blocked_types, deref_kind);
+      }
     }
     if (deref_kind == DerefKind::RemoveRefsAndPtr) {
       if (const auto* ptr_type = dyn_cast_or_null<PointerType>(type)) {
-        type = ptr_type->getPointeeType().getTypePtr();
-        deref_kind = DerefKind::None;
+        return ReportTypeUseInternal(used_loc,
+                                     ptr_type->getPointeeType().getTypePtr(),
+                                     blocked_types, DerefKind::None);
       }
     }
 

--- a/iwyu.cc
+++ b/iwyu.cc
@@ -2646,11 +2646,10 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
                  << typedef_decl->getQualifiedNameAsString()
                  << " owns the underlying type:\n";
         // If any of the used types are themselves typedefs, this will
-        // result in a recursive expansion.  Note we are careful to
-        // recurse inside this class, and not go back to subclasses.
+        // result in a recursive expansion.
         const Type* type = typedef_decl->getUnderlyingType().getTypePtr();
-        IwyuBaseAstVisitor<Derived>::ReportTypeUseInternal(
-            used_loc, type, provided_with_typedef, deref_kind);
+        ReportTypeUseInternal(used_loc, type, provided_with_typedef,
+                              deref_kind);
       }
       return;
     }

--- a/tests/cxx/deduced.cc
+++ b/tests/cxx/deduced.cc
@@ -1,0 +1,34 @@
+//===--- deduced.cc - test input file for iwyu ----------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_ARGS: -I .
+
+// Tests deduced type handling.
+
+#include "tests/cxx/direct.h"
+
+// IWYU: IndirectClass needs a declaration
+void Fn(IndirectClass& i) {
+  auto&& fwd_ref = i;
+  // IWYU: IndirectClass is...*indirect.h
+  fwd_ref.Method();
+}
+
+/**** IWYU_SUMMARY
+
+tests/cxx/deduced.cc should add these lines:
+#include "tests/cxx/indirect.h"
+
+tests/cxx/deduced.cc should remove these lines:
+- #include "tests/cxx/direct.h"  // lines XX-XX
+
+The full include-list for tests/cxx/deduced.cc:
+#include "tests/cxx/indirect.h"  // for IndirectClass
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
The code in `ReportTypeUseInternal` was designed with assumption that clang collapses subsequent reference types into a single one. But it turns out that `getPointeeTypeAsWritten()` may return another reference type when applied to a reference type produced with forwarding reference syntax. The subsequent `IsPointerOrReferenceAsWritten` check short-circuited referenced type reporting despite it should be reported. This problem is solved here with recursive `ReportTypeUseInternal` calls from dereferencing branches.

The explicit traversal of `CXXForRangeStmt` is introduced to avoid regression with code like this:

```cpp
using ProvidingRefAlias = Container&;
ProvidingRefAlias ref_provided = ...;
for (int x : ref_provided) ...
```

During initialization of implicit range variable, the specific providing type occurs to be lost. That variable is initialized like being declared with forwarding reference, and didn't show the bug prior to this fix of forwarding references. I've decided to write explicit traversal without handling for-loop implicit variables to avoid unwanted reporting of the provided type. The code does essentially the same that default implementation does when `shouldVisitImplicitCode()` returns `false`. In principle, it could allow more finely-grained control over reporting use of iterator type and related operators in the future.