### PR TITLE
[iwyu_tool] Make IWYU path provided by IWYU_BINARY absolute

### DIFF
--- a/iwyu_tool.py
+++ b/iwyu_tool.py
@@ -212,8 +212,9 @@ def split_command(cmdstr):
 
 def find_include_what_you_use():
     """ Find IWYU executable and return its full pathname. """
-    if 'IWYU_BINARY' in os.environ:
-        return os.environ.get('IWYU_BINARY')
+    env_iwyu_path = os.environ.get('IWYU_BINARY')
+    if env_iwyu_path:
+        return os.path.realpath(env_iwyu_path)
 
     # TODO: Investigate using shutil.which when Python 2 has passed away.
     executable_name = 'include-what-you-use'

--- a/iwyu_tool_test.py
+++ b/iwyu_tool_test.py
@@ -379,5 +379,20 @@ class CompilationDBTests(unittest.TestCase):
             [iwyu_tool.IWYU_EXECUTABLE, '-c', 'test.c'])
 
 
+class FindIWYUTests(unittest.TestCase):
+    def test_iwyu_binary_made_absolute(self):
+        oldval = os.environ.get('IWYU_BINARY')
+        try:
+            # Seed IWYU_BINARY with a relative path.
+            os.environ['IWYU_BINARY'] = './build/include-what-you-use'
+
+            # Check that find_iwyu returns absolute.
+            path = iwyu_tool.find_include_what_you_use()
+            self.assertTrue(os.path.isabs(path), 'Expected absolute: %r' % path)
+        finally:
+            if oldval:
+                os.environ['IWYU_BINARY'] = oldval
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
In a766b58d60781c4a89dd0c70904f9facde0ace3f, we added the ability to configure the path of IWYU executable using an environment variable.

At around the same time we added abspath canonicalization for any include-what-you-use found on the PATH, but we omitted it for the path configured by env var.

Make them behave the same, and thereby fix a bug where using IWYU_BINARY with a relative path would fail to find IWYU.