### PR TITLE
Fix -Wmissing-field-initializers warning

### DIFF
--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -947,7 +947,7 @@ TemplateInstantiationData GetTplInstDataForFunction(
     resugar_map = GetTplTypeResugarMapForFunctionNoCallExpr(decl, 0);
     resugar_map = ResugarTypeComponents(
         resugar_map);  // add in resugar_map's decomposition
-    return TemplateInstantiationData{resugar_map};
+    return TemplateInstantiationData{resugar_map, {}};
   }
 
   // If calling_expr is a CXXConstructExpr of CXXNewExpr, then it's
@@ -1508,7 +1508,7 @@ TemplateInstantiationData GetTplInstDataForClassNoComponentTypes(
   map<const Type*, const Type*> retval;
   const auto* tpl_spec_type = type->getAs<TemplateSpecializationType>();
   if (!tpl_spec_type) {
-    return TemplateInstantiationData{retval};
+    return TemplateInstantiationData{retval, {}};
   }
 
   // Pull the template arguments out of the specialization type. If this is


### PR DESCRIPTION
056396f424995a850b6ca27ba0f6251cdc43a013 added TemplateInstantiationData struct to bundle resugar map with provided types.

Clang complains if not all fields of a struct are initialized as part of an aggregate initializer; GCC doesn't.

Explicitly initialize both fields always.