### PR TITLE
Fix crash on function template parameter pack

### DIFF
--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -920,6 +920,8 @@ static map<const Type*, const Type*> GetDefaultedArgResugarMap(
   for (unsigned i = 0; i < count; ++i) {
     if (const auto* param_decl =
             dyn_cast<TemplateTypeParmDecl>(params->getParam(i))) {
+      if (param_decl->isParameterPack())
+        continue;
       const QualType type = args->get(i).getAsType().getCanonicalType();
       if (param_decl->hasDefaultArgument() &&
           param_decl->getDefaultArgument().getCanonicalType() == type) {

--- a/tests/cxx/template_args.cc
+++ b/tests/cxx/template_args.cc
@@ -237,6 +237,18 @@ IndirectClass& i = TplParamRetType<IndirectClass&>();
 
 // ---------------------------------------------------------------
 
+// Test that IWYU doesn't crash on function template type parameter packs.
+
+template <typename...>
+void TplFnWithParameterPack() {
+}
+
+void TestParameterPack() {
+  TplFnWithParameterPack();
+}
+
+// ---------------------------------------------------------------
+
 /**** IWYU_SUMMARY
 
 tests/cxx/template_args.cc should add these lines:


### PR DESCRIPTION
Parameter packs cannot have defaults.