### PR TITLE
Analyze template-nested typedef usage context

### DIFF
--- a/tests/cxx/typedef_in_template-i1.h
+++ b/tests/cxx/typedef_in_template-i1.h
@@ -13,4 +13,7 @@
 
 class Class1 {};
 
+class IndirectClass;
+using NonProviding = IndirectClass;
+
 #endif // INCLUDE_WHAT_YOU_USE_TESTS_CXX_TYPEDEF_IN_TEMPLATE_I1_H_

--- a/tests/cxx/typedef_in_template.cc
+++ b/tests/cxx/typedef_in_template.cc
@@ -113,6 +113,39 @@ struct UsesAliasedSugaredParameter {
 // IWYU: IndirectClass needs a declaration
 constexpr auto s2 = sizeof(UsesAliasedSugaredParameter<IndirectClass>);
 
+// Passing aliased type as a template argument.
+
+template <typename T>
+struct Identity {
+  using Type = T;
+};
+
+// IWYU: IndirectClass is...*indirect.h
+using Providing = IndirectClass;
+
+void ArgumentTypeProvision() {
+  Identity<Providing>::Type p1;
+  (void)sizeof(p1);
+  p1.Method();
+  Identity<Providing>::Type* p2 = nullptr;
+  (void)sizeof(*p2);
+  p2->Method();
+
+  // IWYU: NonProviding is...*typedef_in_template-i1.h
+  // IWYU: IndirectClass is...*indirect.h
+  Identity<NonProviding>::Type n1;
+  // IWYU: IndirectClass is...*indirect.h
+  (void)sizeof(n1);
+  // IWYU: IndirectClass is...*indirect.h
+  n1.Method();
+  // IWYU: NonProviding is...*typedef_in_template-i1.h
+  Identity<NonProviding>::Type* n2 = nullptr;
+  // IWYU: IndirectClass is...*indirect.h
+  (void)sizeof(*n2);
+  // IWYU: IndirectClass is...*indirect.h
+  n2->Method();
+}
+
 /**** IWYU_SUMMARY
 
 tests/cxx/typedef_in_template.cc should add these lines:
@@ -127,7 +160,7 @@ tests/cxx/typedef_in_template.cc should remove these lines:
 
 The full include-list for tests/cxx/typedef_in_template.cc:
 #include "tests/cxx/indirect.h"  // for IndirectClass
-#include "tests/cxx/typedef_in_template-i1.h"  // for Class1
+#include "tests/cxx/typedef_in_template-i1.h"  // for Class1, NonProviding
 #include "tests/cxx/typedef_in_template-i2.h"  // for Class2, Pair
 
 ***** IWYU_SUMMARY */


### PR DESCRIPTION
Figure out if `typedef` or type alias referred type is actually provided by some of template specialization arguments when used outside of template instantiation (inside it `InstantiatedTemplateVisitor` should already do that job in `CanIgnoreType` method).

`IsProvidedByTplArg` routine can be further extended to work with alias templates as well (currently, even simplest cases like `template <typename T> using Identity = T;` aren't handled).

TODO: take into account provided default type template arguments.