### PR TITLE
Use Python3 shutil.which to search for IWYU

### DIFF
--- a/iwyu_test_util.py
+++ b/iwyu_test_util.py
@@ -20,6 +20,7 @@ import operator
 import os
 import re
 import shlex
+import shutil
 import subprocess
 import sys
 import unittest
@@ -182,21 +183,7 @@ class Features:
 _FEATURES = Features()
 
 
-def _Which(program, paths):
-    """Searches specified paths for program."""
-    if sys.platform == 'win32' and not program.lower().endswith('.exe'):
-        program += '.exe'
-
-    for path in paths:
-        candidate = os.path.join(os.path.normpath(path), program)
-        if os.path.isfile(candidate):
-            return candidate
-
-    return None
-
-
-_SYSTEM_PATHS = [p.strip('"') for p in os.environ["PATH"].split(os.pathsep)]
-_IWYU_PATH = _Which('include-what-you-use', _SYSTEM_PATHS)
+_IWYU_PATH = shutil.which('include-what-you-use')
 
 
 def SetIwyuPath(iwyu_path):
@@ -209,8 +196,7 @@ def SetIwyuPath(iwyu_path):
 def _GetIwyuPath():
   """Returns the path to IWYU or raises IOError if it cannot be found."""
   if not _IWYU_PATH:
-    raise IOError('Failed to locate IWYU.\nSearched\n %s' %
-                  '\n '.join(_SYSTEM_PATHS))
+    raise IOError('\'include-what-you-use\' not found in PATH')
   return _IWYU_PATH
 
 

--- a/iwyu_tool.py
+++ b/iwyu_tool.py
@@ -35,6 +35,7 @@ import sys
 import json
 import time
 import shlex
+import shutil
 import argparse
 import tempfile
 import subprocess
@@ -216,18 +217,16 @@ def find_include_what_you_use():
     if env_iwyu_path:
         return os.path.realpath(env_iwyu_path)
 
-    # TODO: Investigate using shutil.which when Python 2 has passed away.
-    executable_name = 'include-what-you-use'
-    if sys.platform.startswith('win'):
-        executable_name += '.exe'
+    # Search in same dir as this script.
+    iwyu_path = shutil.which('include-what-you-use',
+                             path=os.path.dirname(__file__))
+    if iwyu_path:
+        return os.path.realpath(iwyu_path)
 
-    search_path = [os.path.dirname(__file__)]
-    search_path += os.environ.get('PATH', '').split(os.pathsep)
-
-    for dirpath in search_path:
-        full = os.path.join(dirpath, executable_name)
-        if os.path.isfile(full):
-            return os.path.realpath(full)
+    # Search the system PATH.
+    iwyu_path = shutil.which('include-what-you-use')
+    if iwyu_path:
+        return os.path.realpath(iwyu_path)
 
     return None
 


### PR DESCRIPTION
We had at least two implementations of 'which', remove a bunch of custom code in favor of shutil.which.

No functional change intended.