### PR TITLE
[ci] Rename 'IWYU dogfood comment' workflow

### DIFF
--- a/.github/workflows/pr-comments-bot.yml
+++ b/.github/workflows/pr-comments-bot.yml
@@ -1,4 +1,4 @@
-name: IWYU dogfood comment
+name: pr-comments-bot
 
 # NOTE: this workflow does not run in a pull_request context, and thus
 # GITHUB_TOKEN has slightly eleveated permissions.
@@ -17,7 +17,7 @@ defaults:
     shell: bash
 
 jobs:
-  dogfood-comment:
+  add-pr-comments:
     # Only run if triggered from a successful PR build.
     if: >
       github.event.workflow_run.event == 'pull_request' &&


### PR DESCRIPTION
It can be generalized to add any number of different comments to the PR triggering it, so there's nothing dogfood-specific here.

Further generalization needs to happen across ci.yml and pr-comments-bot.yml, so those will be done separately later.