### PR TITLE
[ci] Generalize PR comment handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,20 +85,26 @@ jobs:
               xargs ./iwyu-check-license-header.py
 
       - name: IWYU dogfood
-        if: github.event_name == 'pull_request'
-        env:
-          PR_URL: ${{ github.event.pull_request.comments_url }}
         run: |
           ./iwyu-dogfood.bash ./build
-          mkdir ./dogfood-results
-          mv ./iwyu-dogfood.md ./dogfood-results/
-          echo "$PR_URL" > ./dogfood-results/pr-url
+          # Write to step summary primarily for scheduled builds.
+          cat ./iwyu-dogfood.md >> $GITHUB_STEP_SUMMARY
 
-      - name: Upload dogfood results
+      # Hand over payloads for PR comments to separate workflow via artifact.
+      - name: Prepare PR comment payload
+        if: github.event_name == 'pull_request'
+        env:
+          PR_API_URL: ${{ github.event.pull_request.comments_url }}
+        run: |
+          mkdir ./pr-comments
+          echo "$PR_API_URL" > ./pr-comments/api-url
+          cp ./iwyu-dogfood.md ./pr-comments/
+
+      - name: Upload PR comment payload
         if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@v4
         with:
-          name: dogfood-results
-          path: ./dogfood-results
+          name: pr-comments
+          path: ./pr-comments
           retention-days: 1
           if-no-files-found: error

--- a/.github/workflows/pr-comments-bot.yml
+++ b/.github/workflows/pr-comments-bot.yml
@@ -1,7 +1,7 @@
 name: pr-comments-bot
 
 # NOTE: this workflow does not run in a pull_request context, and thus
-# GITHUB_TOKEN has slightly eleveated permissions.
+# GITHUB_TOKEN has slightly elevated permissions.
 # That means we need to be particularly careful not to run untrusted code such
 # as submitted in PRs.
 # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
@@ -34,16 +34,16 @@ jobs:
                curl \
                jq
 
-      - name: Download dogfood results
+      - name: Download PR comments payloads
         uses: actions/download-artifact@v4
         with:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          name: dogfood-results
-          path: ./dogfood-results
+          name: pr-comments
+          path: ./pr-comments
 
-      - name: Add dogfood PR comment
-        if: ${{ hashFiles('./dogfood-results/pr-url') != '' }}
+      - name: Add dogfood PR comment if available
+        if: ${{ hashFiles('./pr-comments/iwyu-dogfood.md') != '' }}
         env:
           API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -51,8 +51,8 @@ jobs:
             -sS \
             -L \
             -X POST \
-            "$(cat ./dogfood-results/pr-url)" \
+            "$(cat ./pr-comments/api-url)" \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer $API_TOKEN" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            --data "{ \"body\": $(jq -R -s '.' ./dogfood-results/iwyu-dogfood.md) }"
+            --data "{ \"body\": $(jq -R -s '.' ./pr-comments/iwyu-dogfood.md) }"


### PR DESCRIPTION
Turn things around so we always run the IWYU dogfood step, even for scheduled builds. Put the step summary back.

For PRs, bundle dogfood results into pr-comments artifact to be picked up by pr-comments-bot workflow.

Generalize wording and fix a typo in pr-comments-bot.yml.

This makes it possible to add a new informational step by simply producing a Markdown doc in ci.yml, bundle it, and push it as a comment in pr-comments-bot.yml.