### PR TITLE
Reject attempts at using PCH

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -123,10 +123,8 @@
 #include "clang/Basic/Specifiers.h"
 #include "clang/Basic/TypeTraits.h"
 #include "clang/Frontend/CompilerInstance.h"
-#include "clang/Frontend/CompilerInvocation.h"
 #include "clang/Frontend/FrontendAction.h"
 #include "clang/Lex/Preprocessor.h"
-#include "clang/Lex/PreprocessorOptions.h"
 #include "clang/Sema/Sema.h"
 #include "iwyu_ast_util.h"
 #include "iwyu_cache.h"
@@ -3869,23 +3867,10 @@ class IwyuAstConsumer
     // though, because that will drag in every overload even if we're
     // only using one.  Instead, we keep track of the using decl and
     // mark it as touched when something actually uses it.
-    IwyuFileInfo* file_info =
-        preprocessor_info().FileInfoFor(CurrentFileEntry());
-    if (file_info) {
-      file_info->AddUsingDecl(decl);
-    } else {
-      // For using declarations in a PCH, the preprocessor won't have any
-      // location information. As far as we know, that's the only time the
-      // file-info will be null, so assert that we have a PCH on the
-      // command-line.
-      const string& pch_include =
-           compiler()->getInvocation().getPreprocessorOpts().ImplicitPCHInclude;
-      CHECK_(!pch_include.empty());
-    }
+    preprocessor_info().FileInfoFor(CurrentFileEntry())->AddUsingDecl(decl);
 
     if (CanIgnoreCurrentASTNode())
       return true;
-
     return Base::VisitUsingDecl(decl);
   }
 

--- a/iwyu_driver.cc
+++ b/iwyu_driver.cc
@@ -35,6 +35,7 @@
 #include "clang/Frontend/FrontendOptions.h"
 #include "clang/FrontendTool/Utils.h"
 #include "clang/Lex/HeaderSearchOptions.h"
+#include "clang/Lex/PreprocessorOptions.h"
 #include "iwyu_verrs.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
@@ -58,6 +59,7 @@ using clang::CompilerInvocation;
 using clang::DiagnosticOptions;
 using clang::DiagnosticsEngine;
 using clang::FrontendAction;
+using clang::PreprocessorOptions;
 using clang::driver::Action;
 using clang::driver::Command;
 using clang::driver::Compilation;
@@ -302,6 +304,13 @@ bool ExecuteAction(int argc, const char** argv,
   // Show the invocation, with -v.
   if (invocation->getHeaderSearchOpts().Verbose) {
     errs() << "clang invocation:\n" << JobsToString(jobs, "\n") << "\n";
+  }
+
+  // Reject attempts at using precompiled headers.
+  const PreprocessorOptions& opts = invocation->getPreprocessorOpts();
+  if (!opts.ImplicitPCHInclude.empty() || !opts.PCHThroughHeader.empty()) {
+    errs() << "error: include-what-you-use does not support PCH\n";
+    return false;
   }
 
   // FIXME: This is copied from cc1_main.cpp; simplify and eliminate.

--- a/tests/driver/use_pch.c
+++ b/tests/driver/use_pch.c
@@ -1,0 +1,21 @@
+//===--- use_pch.c - test input file for IWYU -----------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// Check that IWYU fails when user attempts to bring in a PCH using
+// -include-pch.
+
+// IWYU_ARGS: -include-pch some.pch
+
+// IWYU~: include-what-you-use does not support PCH
+
+/**** IWYU_SUMMARY(1)
+
+// No IWYU summary expected.
+
+***** IWYU_SUMMARY */

--- a/tests/driver/use_pch_msvc.c
+++ b/tests/driver/use_pch_msvc.c
@@ -1,0 +1,24 @@
+//===--- use_pch_msvc.c - test input file for IWYU ------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// Check that IWYU fails for MSVC spelling of PCH args.
+
+// IWYU_ARGS: --driver-mode=cl /I . /Yu tests/driver/use_pch_msvc.h
+
+// Clang for some reason creates a precompiler job when /Yu (use PCH) is
+// present. We filter it out, but warn, so expect that warning.
+// IWYU~: ignoring unsupported job type: precompiler
+
+// IWYU~: include-what-you-use does not support PCH
+
+/**** IWYU_SUMMARY(1)
+
+// No IWYU summary expected.
+
+***** IWYU_SUMMARY */

--- a/tests/driver/use_pch_msvc.h
+++ b/tests/driver/use_pch_msvc.h
@@ -1,0 +1,11 @@
+//===--- use_pch_msvc.h - test input file for IWYU ------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// This file has to exist, but is otherwise unused.
+


### PR DESCRIPTION
IWYU as-is cannot support PCH, because we care deeply about the include graph, and it does not appear to be preserved when Clang interprets the precompiled header format.

We used to fail mysteriously with segmentation faults due to missing files; now we fail with an explicit message on startup.

Remove null-check for this scenario in iwyu:VisitUsingDecl, that code should now be unreachable.