### PR TITLE
Handle non-autocast cases of implicit construction

### DIFF
--- a/tests/cxx/badinc.cc
+++ b/tests/cxx/badinc.cc
@@ -704,6 +704,7 @@ I1_TemplateClass<I1_Class> i1_templateclass_object;
 // IWYU: I1_TemplateClass is...*badinc-i1.h
 // IWYU: I1_Class needs a declaration
 // IWYU: I1_Class is...*badinc-i1.h
+// IWYU: I1_Union is...*badinc-i1.h
 I1_TemplateClass<std::vector<I1_Class> > i1_nested_templateclass(i1_union);
 // We need full type info for i1_templateclass because we never
 // fwd-declare a class with default template parameters.
@@ -1297,6 +1298,7 @@ int main() {
   I2_Class i2_class_from_struct = ctor_cast_struct;   // ctor takes a reference
   // IWYU: I2_Class is...*badinc-i2.h
   // IWYU: I2_Class::~I2_Class is...*badinc-i2-inl.h
+  // IWYU: I2_Union is...*badinc-i2.h
   I2_Class i2_class_from_union = ctor_cast_union;   // ctor takes a value
 
   // User-defined casts need the full from-type (to call its operator totype()).
@@ -1553,6 +1555,7 @@ int main() {
       // IWYU: I1_TemplateClass is...*badinc-i1.h
       // IWYU: I2_Class needs a declaration
       // IWYU: I2_Class is...*badinc-i2.h
+      // IWYU: I1_Union is...*badinc-i1.h
       = new I1_TemplateClass<I2_Class, I1_Struct>(i1_union);
   // IWYU: I1_Class needs a declaration
   // IWYU: I1_Class is...*badinc-i1.h
@@ -1620,6 +1623,7 @@ int main() {
   // IWYU: I1_TemplateClass is...*badinc-i1.h
   // IWYU: I2_Class needs a declaration
   // IWYU: I2_Class is...*badinc-i2.h
+  // IWYU: I1_Union is...*badinc-i1.h
   I1_TemplateClass<I2_Class, I1_Struct> local_i1_templateclass(i1_union);
   // IWYU: I2_Class::~I2_Class is...*badinc-i2-inl.h
   // IWYU: I1_Struct needs a declaration
@@ -1627,6 +1631,7 @@ int main() {
   // IWYU: I1_TemplateClass is...*badinc-i1.h
   // IWYU: I2_Class needs a declaration
   // IWYU: I2_Class is...*badinc-i2.h
+  // IWYU: I1_Union is...*badinc-i1.h
   (void)I1_TemplateClass<I2_Class, I1_Struct>(i1_union);
 
   (void)(*(new int(4)));

--- a/tests/cxx/decltype.cc
+++ b/tests/cxx/decltype.cc
@@ -22,24 +22,24 @@ struct WithStatic {
   static Tpl<IndirectClass> tpl;
 };
 
-// TODO: IWYU: IndirectClass is...*indirect.h
+// IWYU: IndirectClass is...*indirect.h
 decltype(WithStatic::obj) obj;
-// TODO: IWYU: Tpl is...*decltype-i1.h
+// IWYU: Tpl is...*decltype-i1.h
 // IWYU: IndirectClass is...*indirect.h
 decltype(WithStatic::tpl) tpl;
 
 /**** IWYU_SUMMARY
 
 tests/cxx/decltype.cc should add these lines:
+#include "tests/cxx/decltype-i1.h"
 #include "tests/cxx/indirect.h"
-template <typename T> struct Tpl;
 
 tests/cxx/decltype.cc should remove these lines:
 - #include "tests/cxx/decltype-d1.h"  // lines XX-XX
 - #include "tests/cxx/direct.h"  // lines XX-XX
 
 The full include-list for tests/cxx/decltype.cc:
+#include "tests/cxx/decltype-i1.h"  // for Tpl
 #include "tests/cxx/indirect.h"  // for IndirectClass
-template <typename T> struct Tpl;
 
 ***** IWYU_SUMMARY */

--- a/tests/cxx/deduced.cc
+++ b/tests/cxx/deduced.cc
@@ -14,10 +14,23 @@
 #include "tests/cxx/direct.h"
 
 // IWYU: IndirectClass needs a declaration
+IndirectClass& GetRef();
+
+// IWYU: IndirectClass needs a declaration
 void Fn(IndirectClass& i) {
   auto&& fwd_ref = i;
   // IWYU: IndirectClass is...*indirect.h
   fwd_ref.Method();
+
+  // IWYU: IndirectClass is...*indirect.h
+  auto param_copy = i;
+  auto& param_ref1 = i;
+  decltype(auto) param_ref2 = i;
+
+  // IWYU: IndirectClass is...*indirect.h
+  auto value = GetRef();
+  auto& ref1 = GetRef();
+  decltype(auto) ref2 = GetRef();
 }
 
 /**** IWYU_SUMMARY

--- a/tests/cxx/implicit_ctor-d2.h
+++ b/tests/cxx/implicit_ctor-d2.h
@@ -1,0 +1,14 @@
+//===--- implicit_ctor-d2.h - test input file for iwyu --------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+struct NoAutocastCtor;
+struct NoTrivialCtorDtor;
+
+using NonProviding = NoAutocastCtor;
+using NoTrivialCtorDtorNonProvidingAlias = NoTrivialCtorDtor;

--- a/tests/cxx/implicit_ctor-i2.h
+++ b/tests/cxx/implicit_ctor-i2.h
@@ -11,3 +11,13 @@ struct IndirectWithImplicitCtor {
   // This is the implicit ctor.
   IndirectWithImplicitCtor(int x) {}
 };
+
+struct NoAutocastCtor {
+  NoAutocastCtor();
+  NoAutocastCtor(int, int);
+};
+
+struct NoTrivialCtorDtor {
+  NoTrivialCtorDtor();
+  ~NoTrivialCtorDtor();
+};

--- a/tests/cxx/implicit_ctor.cc
+++ b/tests/cxx/implicit_ctor.cc
@@ -18,9 +18,13 @@
 // relying on the previous rule to make the code complete definition
 // available. This is so called "autocast".
 //
+// In other cases of implicit construction (without specifying class name
+// explicitly), the complete class definition needs to be available.
+//
 // This tests that logic.
 
 #include "tests/cxx/implicit_ctor-d1.h"
+#include "tests/cxx/implicit_ctor-d2.h"
 
 // No reporting types for "autocast" for .cpp-file-local functions...
 // IWYU: IndirectWithImplicitCtor needs a declaration
@@ -58,6 +62,55 @@ IndirectWithImplicitCtor indirect
     // IWYU: IndirectWithImplicitCtor is...*implicit_ctor-i2.h
     = 1;
 
+// IWYU: NoAutocastCtor is...*implicit_ctor-i2.h
+using Providing = NoAutocastCtor;
+// IWYU: NoTrivialCtorDtor is...*implicit_ctor-i2.h
+using NoTrivialCtorDtorProvidingAlias = NoTrivialCtorDtor;
+
+// IWYU: NoAutocastCtor needs a declaration
+void FnTakingDirectly(NoAutocastCtor);
+void FnTakingByProvidingAlias(Providing);
+void FnTakingByNonProvidingAlias(NonProviding);
+
+template <typename T>
+void TplFn(T t);
+
+// IWYU: NoAutocastCtor needs a declaration
+void TestNonAutocastConstruction(const NoAutocastCtor& par) {
+  // IWYU: NoAutocastCtor is...*implicit_ctor-i2.h
+  FnTakingDirectly(par);
+  FnTakingByProvidingAlias(par);
+  // IWYU: NoAutocastCtor is...*implicit_ctor-i2.h
+  FnTakingByNonProvidingAlias(par);
+
+  Providing* p = nullptr;
+  NonProviding* n = nullptr;
+  FnTakingDirectly(*p);
+  // IWYU: NoAutocastCtor is...*implicit_ctor-i2.h
+  FnTakingDirectly(*n);
+
+  // IWYU: NoAutocastCtor is...*implicit_ctor-i2.h
+  TplFn(par);
+  TplFn<Providing>(par);
+  // IWYU: NoAutocastCtor is...*implicit_ctor-i2.h
+  TplFn<NonProviding>(par);
+
+  // Test handling presence of intermediate 'CXXBindTemporaryExpr' node
+  // in the AST.
+
+  // IWYU: NoTrivialCtorDtor needs a declaration
+  NoTrivialCtorDtor* nt = nullptr;
+  TplFn<NoTrivialCtorDtorProvidingAlias>(*nt);
+  // IWYU: NoTrivialCtorDtor is...*implicit_ctor-i2.h
+  TplFn<NoTrivialCtorDtorNonProvidingAlias>(*nt);
+
+  // IWYU: NoAutocastCtor needs a declaration
+  // IWYU: NoAutocastCtor is...*implicit_ctor-i2.h
+  const NoAutocastCtor& x1 = {};
+  // IWYU: NoAutocastCtor needs a declaration
+  // IWYU: NoAutocastCtor is...*implicit_ctor-i2.h
+  const NoAutocastCtor& x2 = {3, 4};
+}
 
 /**** IWYU_SUMMARY
 
@@ -68,6 +121,7 @@ tests/cxx/implicit_ctor.cc should remove these lines:
 
 The full include-list for tests/cxx/implicit_ctor.cc:
 #include "tests/cxx/implicit_ctor-d1.h"  // for ImplicitCtorFn, ImplicitCtorRefFn, InlineImplicitCtorRefFn
-#include "tests/cxx/implicit_ctor-i2.h"  // for IndirectWithImplicitCtor
+#include "tests/cxx/implicit_ctor-d2.h"  // for NoTrivialCtorDtorNonProvidingAlias, NonProviding
+#include "tests/cxx/implicit_ctor-i2.h"  // for IndirectWithImplicitCtor, NoAutocastCtor, NoTrivialCtorDtor
 
 ***** IWYU_SUMMARY */


### PR DESCRIPTION
Efforts have been made to avoid unwanted reporting of provided types.

Surprisingly, some `decltype` cases became fixed. This is because `CXXConstructExpr` appears also in explicit construction cases, e.g. on variable definitions. It implies that there is currently some redundancy in reporting types of variables: they are reported on `CXXConstructExpr` visiting as well as on written type visiting. It doesn't mean that `decltype` is fully supported now: there remain non-construction cases where its underlying type should be reported but isn't, like using as a base class in some class declaration, or using as a nested name specifier.

Union type suggestions are appeared in the `badinc` test because the constructors take them by value, therefore their complete types are actually needed for copy-initialization.