### PR TITLE
Fix crash on construction inside unresolved call

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -4330,11 +4330,13 @@ class IwyuAstConsumer
     };
 
     if (const CallExpr* call_expr = get_call_expr(construct_expr_node)) {
-      const FunctionDecl* fn_decl = call_expr->getDirectCallee();
-      // For nontemplated functions, 'CXXConstructExpr' type appears to be
-      // sugared and hence handled correctly inside 'ReportTypeUse'.
-      if (GetTplInstData(fn_decl, call_expr).provided_types.count(type))
-        return true;
+      // There is no callee for unresolved call exprs in template definitions.
+      if (const FunctionDecl* fn_decl = call_expr->getDirectCallee()) {
+        // For nontemplated functions, 'CXXConstructExpr' type appears to be
+        // sugared and hence handled correctly inside 'ReportTypeUse'.
+        if (GetTplInstData(fn_decl, call_expr).provided_types.count(type))
+          return true;
+      }
     }
     return false;
   }

--- a/tests/cxx/implicit_ctor.cc
+++ b/tests/cxx/implicit_ctor.cc
@@ -112,6 +112,19 @@ void TestNonAutocastConstruction(const NoAutocastCtor& par) {
   const NoAutocastCtor& x2 = {3, 4};
 }
 
+struct NonAggregate {
+  NonAggregate();
+};
+
+void OverloadedFn(int, NonAggregate);
+void OverloadedFn(float, NonAggregate);
+
+template <typename T>
+void TestNoCrashOnUnresolvedCall(T t) {
+  OverloadedFn(t, NonAggregate{});
+  t.SomeFn(NonAggregate{});
+}
+
 /**** IWYU_SUMMARY
 
 tests/cxx/implicit_ctor.cc should add these lines:


### PR DESCRIPTION
There is no callee for unresolved call expressions in template definitions.

This fixes #1434.