### PR TITLE
Handle 'decltype'

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -199,6 +199,7 @@ using clang::ConceptSpecializationExpr;
 using clang::Decl;
 using clang::DeclContext;
 using clang::DeclRefExpr;
+using clang::DecltypeType;
 using clang::DeducedTemplateSpecializationType;
 using clang::ElaboratedType;
 using clang::ElaboratedTypeKeyword;
@@ -2443,6 +2444,14 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
         ReportTypeUse(CurrentLoc(), type, DerefKind::None);
       }
     }
+    return true;
+  }
+
+  bool VisitDecltypeType(DecltypeType* type) {
+    if (CanIgnoreCurrentASTNode())
+      return true;
+    if (!CanForwardDeclareType(current_ast_node()))
+      ReportTypeUse(CurrentLoc(), type, DerefKind::None);
     return true;
   }
 

--- a/tests/cxx/decltype.cc
+++ b/tests/cxx/decltype.cc
@@ -28,6 +28,18 @@ decltype(WithStatic::obj) obj;
 // IWYU: IndirectClass is...*indirect.h
 decltype(WithStatic::tpl) tpl;
 
+// IWYU: IndirectClass is...*indirect.h
+class Derived : decltype(WithStatic::obj) {};
+
+void Fn() {
+  // IWYU: IndirectClass is...*indirect.h
+  (void)&decltype(WithStatic::obj)::a;
+  // IWYU: IndirectClass is...*indirect.h
+  (void)sizeof(decltype(WithStatic::obj));
+  // No need of the full type in fwd-declarable context.
+  decltype(WithStatic::obj)* p = nullptr;
+}
+
 /**** IWYU_SUMMARY
 
 tests/cxx/decltype.cc should add these lines:

--- a/tests/cxx/ptr_ref_aliases.cc
+++ b/tests/cxx/ptr_ref_aliases.cc
@@ -126,6 +126,9 @@ void Fn() {
   const std::type_info& type_info2 = typeid(NonProvidingRefAlias);
   const std::type_info& type_info3 = typeid(ProvidingPtrAlias);
   const std::type_info& type_info4 = typeid(ProvidingRefAlias);
+
+  decltype(ptr_nonprovided) dpn;
+  decltype(ref_nonprovided) drn = GetRef();
 }
 
 namespace ns {


### PR DESCRIPTION
I wanted to fix it by refactoring IWYU as discussed in #1340, but the `else` branch inside `InstantiatedTemplateVisitor::AnalyzeTemplateTypeParmUse` hinders. Let's proceed with the current approach.