### PR TITLE
Handle variables marked as 'extern'

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -2542,11 +2542,12 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
     if (parent_type == nullptr) {
       // It's not a type; analyze different kinds of declarations.
       if (const auto *decl = ast_node->GetParentAs<ValueDecl>()) {
-        // We can shortcircuit static data member declarations immediately,
-        // they can always be forward-declared.
+        // We can shortcircuit static data member and 'extern' variable
+        // declarations immediately, they can always be forward-declared.
         if (const auto *var_decl = dyn_cast<VarDecl>(decl)) {
           if (!var_decl->isThisDeclarationADefinition() &&
-              var_decl->isStaticDataMember()) {
+              (var_decl->isStaticDataMember() ||
+               var_decl->hasExternalStorage())) {
             return true;
           }
         }

--- a/tests/cxx/extern_variable.cc
+++ b/tests/cxx/extern_variable.cc
@@ -1,0 +1,33 @@
+//===--- extern_variable.cc - test input file for iwyu --------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_ARGS: -I . -Wno-extern-initializer
+
+// Tests handling variables marked as 'extern'.
+
+#include "tests/cxx/direct.h"
+
+// IWYU: IndirectClass needs a declaration
+extern IndirectClass forward_declarable;
+
+// IWYU: IndirectClass is...*indirect.h
+extern IndirectClass initialized = {1};
+
+/**** IWYU_SUMMARY
+
+tests/cxx/extern_variable.cc should add these lines:
+#include "tests/cxx/indirect.h"
+
+tests/cxx/extern_variable.cc should remove these lines:
+- #include "tests/cxx/direct.h"  // lines XX-XX
+
+The full include-list for tests/cxx/extern_variable.cc:
+#include "tests/cxx/indirect.h"  // for IndirectClass
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/quoted_includes_first.h
+++ b/tests/cxx/quoted_includes_first.h
@@ -18,6 +18,7 @@ inline int GetBaseError() {
 
 extern std::exception global_exception;
 extern IndirectSubDirClass global_var;
+inline IndirectSubDirClass header_defined_var;
 
 /**** IWYU_SUMMARY
 


### PR DESCRIPTION
They are forward-declarable when not initialized.

An inline variable added to `quoted_includes_first.h` so as to keep the quoted `#include` in the IWYU suggestion for the header.

Hoping that C89 is eventually supported...