### PR TITLE
Improve handling nested typedefs

### DIFF
--- a/tests/cxx/typedef_in_template.cc
+++ b/tests/cxx/typedef_in_template.cc
@@ -118,6 +118,20 @@ constexpr auto s2 = sizeof(UsesAliasedSugaredParameter<IndirectClass>);
 template <typename T>
 struct Identity {
   using Type = T;
+
+  struct Inner {
+    using Type = T;
+  };
+};
+
+template <typename T>
+struct Outer {
+  template <typename U>
+  struct Inner {
+    // IWYU: Pair needs a declaration
+    // IWYU: Pair is...*typedef_in_template-i2.h
+    using AliasedTpl = Pair<T, U>;
+  };
 };
 
 // IWYU: IndirectClass is...*indirect.h
@@ -144,6 +158,15 @@ void ArgumentTypeProvision() {
   (void)sizeof(*n2);
   // IWYU: IndirectClass is...*indirect.h
   n2->Method();
+
+  Identity<Providing>::Inner::Type p3;
+
+  Outer<Providing>::Inner<Providing>::AliasedTpl pp;
+
+  // IWYU: IndirectClass needs a declaration
+  Outer<Providing>::Inner<IndirectClass*>::AliasedTpl p_ptr;
+  // IWYU: IndirectClass needs a declaration
+  Outer<IndirectClass*>::Inner<Providing>::AliasedTpl ptr_p;
 }
 
 /**** IWYU_SUMMARY


### PR DESCRIPTION
This fixes two problems:

- The aliased type was analyzed as a whole despite it may be a template specialization type, and the outer template specialization type may provide some of its arguments but not the aliased template spec type as a whole.

- In the case of a nested name specifier chain, e. g.
`Tpl1<Alias1>::Class::Tpl2<Alias2>::Struct::Tpl3<Alias3>::Typedef`,
only the rightmost prefix was analyzed. Now, provided types from all the chain are harvested.