### PR TITLE
Fix crash on 'type_info' in MS compatibility mode

### DIFF
--- a/iwyu_preprocessor.cc
+++ b/iwyu_preprocessor.cc
@@ -1168,6 +1168,8 @@ bool IwyuPreprocessorInfo::ForwardDeclareIsExported(
     const NamedDecl* decl) const {
   // Use end-location so that any trailing comments match only on the last line.
   SourceLocation loc = decl->getEndLoc();
+  if (!loc.isValid())
+    return false;
 
   // Is the decl part of a begin_exports/end_exports block?
   OptionalFileEntryRef file = GetFileEntry(loc);

--- a/tests/cxx/clmode.cc
+++ b/tests/cxx/clmode.cc
@@ -19,15 +19,21 @@
 // IWYU: IndirectClass is...*indirect.h
 IndirectClass random_use;
 
+// Test that IWYU doesn't crash on implicitly added 'type_info' declaration.
+// IWYU: type_info needs a declaration
+type_info* pt = nullptr;
+
 /**** IWYU_SUMMARY
 
 tests/cxx/clmode.cc should add these lines:
 #include "tests/cxx/indirect.h"
+class type_info;
 
 tests/cxx/clmode.cc should remove these lines:
 - #include "tests/cxx/direct.h"  // lines XX-XX
 
 The full include-list for tests/cxx/clmode.cc:
 #include "tests/cxx/indirect.h"  // for IndirectClass
+class type_info;
 
 ***** IWYU_SUMMARY */


### PR DESCRIPTION
When running in MS-compatibility mode, one of the `std::type_info` redeclarations is implicitly added by clang [here](https://github.com/llvm/llvm-project/blob/llvmorg-17.0.6/clang/lib/Sema/Sema.cpp#L333). It has no valid source location information.