### PR TITLE
Add mapping for static_assert(3)

### DIFF
--- a/gcc.symbols.imp
+++ b/gcc.symbols.imp
@@ -105,6 +105,7 @@
   { symbol: [ "size_t", private, "<time.h>", public ] },
   { symbol: [ "size_t", private, "<uchar.h>", public ] },
   { symbol: [ "size_t", private, "<wchar.h>", public ] },
+  { symbol: [ "static_assert", private, "<assert.h>", public ] },
   # Macros that can be defined in more than one file, don't have the
   # same __foo_defined guard that other types do, so the grep above
   # doesn't discover them.  Until I figure out a better way, I just

--- a/iwyu_include_picker.cc
+++ b/iwyu_include_picker.cc
@@ -190,6 +190,7 @@ const IncludeMapEntry libc_symbol_map[] = {
   { "size_t", kPrivate, "<time.h>", kPublic },
   { "size_t", kPrivate, "<uchar.h>", kPublic },
   { "size_t", kPrivate, "<wchar.h>", kPublic },
+  { "static_assert", kPrivate, "<assert.h>", kPublic },
   // Macros that can be defined in more than one file, don't have the
   // same __foo_defined guard that other types do, so the grep above
   // doesn't discover them.  Until I figure out a better way, I just


### PR DESCRIPTION
It is a keyword in C++, but in C it is a macro from <assert.h>.