### PR TITLE
Add and use more complete functionality for special files

### DIFF
--- a/iwyu_path_util.cc
+++ b/iwyu_path_util.cc
@@ -81,11 +81,13 @@ string Basename(const string& path) {
 }
 
 string GetCanonicalName(string file_path) {
-  // For this special 'path' we just return it.
-  // Note that we leave the 'quotes' to make it different from regular paths.
-  if (file_path == "<built-in>" || file_path == "<stdin>")
+  // Clang special filenames are already canonical.
+  // <stdin> is not a special filename, but it's canonical too.
+  if (IsSpecialFilename(file_path) || file_path == "<stdin>")
     return file_path;
 
+  // All known special filenames which look like quoted-includes are handled
+  // above. Reject anything else that looks like a quoted-include.
   CHECK_(!IsQuotedInclude(file_path));
 
   file_path = NormalizeFilePath(file_path);

--- a/iwyu_path_util.h
+++ b/iwyu_path_util.h
@@ -15,6 +15,8 @@
 #include <string>                       // for string, allocator, etc
 #include <vector>
 
+#include "llvm/ADT/StringRef.h"
+
 namespace include_what_you_use {
 
 using std::string;
@@ -85,6 +87,13 @@ bool IsQuotedInclude(const string& s);
 // Returns whether this is a system (as opposed to user) include
 // file, based on where it lives.
 bool IsSystemIncludeFile(const string& filepath);
+
+// Returns true if argument is one of the special filenames used by Clang for
+// implicit buffers ("<built-in>", "<command-line>", etc).
+inline bool IsSpecialFilename(llvm::StringRef name) {
+  return (name.equals("<built-in>") || name.equals("<command line>") ||
+          name.equals("<scratch space>") || name.equals("<inline asm>"));
+}
 
 }  // namespace include_what_you_use
 

--- a/iwyu_preprocessor.cc
+++ b/iwyu_preprocessor.cc
@@ -441,7 +441,7 @@ void IwyuPreprocessorInfo::MaybeProtectInclude(
     SourceLocation includer_loc, OptionalFileEntryRef includee,
     const string& include_name_as_written) {
   OptionalFileEntryRef includer = GetFileEntry(includer_loc);
-  if (IsBuiltinOrCommandLineFile(includer))
+  if (IsSpecialFile(includer))
     return;
 
   string protect_reason;
@@ -551,7 +551,7 @@ void IwyuPreprocessorInfo::FinalizeProtectedIncludes() {
 void IwyuPreprocessorInfo::AddDirectInclude(
     SourceLocation includer_loc, OptionalFileEntryRef includee,
     const string& include_name_as_written) {
-  if (IsBuiltinOrCommandLineFile(includee))
+  if (IsSpecialFile(includee))
     return;
 
   // For files we're going to be reporting IWYU errors for, we need
@@ -788,7 +788,7 @@ void IwyuPreprocessorInfo::FileChanged_EnterFile(
   const SourceLocation include_loc = GlobalSourceManager()->getIncludeLoc(
       GlobalSourceManager()->getFileID(file_beginning));
   string include_name_as_written;
-  if (!IsBuiltinOrCommandLineFile(GetFileEntry(include_loc))) {
+  if (!IsInSpecialFile(include_loc)) {
     CHECK_(include_filename_loc_.isValid() &&
            "Include from not built-in file must have inclusion directive");
     include_name_as_written = GetIncludeNameAsWritten(include_filename_loc_);
@@ -801,7 +801,7 @@ void IwyuPreprocessorInfo::FileChanged_EnterFile(
   if (new_file)
     AddDirectInclude(include_loc, new_file, include_name_as_written);
 
-  if (IsBuiltinOrCommandLineFile(new_file))
+  if (IsSpecialFile(new_file))
     return;
 
   ProcessHeadernameDirectivesInFile(file_beginning);
@@ -873,7 +873,7 @@ void IwyuPreprocessorInfo::ReportMacroUse(const string& name,
                                           SourceLocation usage_location,
                                           SourceLocation dfn_location) {
   // Don't report macro uses that aren't actually in a file somewhere.
-  if (!dfn_location.isValid() || GetFilePath(dfn_location) == "<built-in>")
+  if (IsInSpecialFile(dfn_location))
     return;
   OptionalFileEntryRef used_in = GetFileEntry(usage_location);
   if (ShouldReportIWYUViolationsFor(used_in)) {


### PR DESCRIPTION
The IsBuiltinFile and IsBuiltinOrCommandLineFile predicates were used in
a few places to determine if includers/includees were actual files.

This would fail to match some non-files like `"<scratch space>"`, but was
also not very ergonomic, as callers would have to resolve file entry in
order to check for builtin-ness.

Add IsSpecialFilename, to check if a string is one of the known special
filenames. Use it from GetCanonicalName.

Add IsSpecialFile, which covers more special files, as the successor of
IsBuiltinOrCommandLineFile.

Add a templated IsInSpecialFile, which maps any supported type (tokens,
decls, locations, etc) to a file, and then checks if said file is
special.

I don't see this solving any concrete bugs, but it seems like an
eaiser-to-use and more complete model.