### PR TITLE
Trust Clang for macro tracking

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -226,6 +226,7 @@ using clang::OverloadExpr;
 using clang::PPCallbacks;
 using clang::ParmVarDecl;
 using clang::PointerType;
+using clang::Preprocessor;
 using clang::QualType;
 using clang::QualifiedTypeLoc;
 using clang::RecordDecl;
@@ -4468,10 +4469,11 @@ class IwyuAction : public ASTFrontendAction {
     // CompilerInstance and ToolChain objects.
     InitGlobals(compiler, toolchain);
 
-    auto* const preprocessor_consumer = new IwyuPreprocessorInfo();
-    compiler.getPreprocessor().addPPCallbacks(
+    Preprocessor& preprocessor = compiler.getPreprocessor();
+    auto* const preprocessor_consumer = new IwyuPreprocessorInfo(preprocessor);
+    preprocessor.addPPCallbacks(
         std::unique_ptr<PPCallbacks>(preprocessor_consumer));
-    compiler.getPreprocessor().addCommentHandler(preprocessor_consumer);
+    preprocessor.addCommentHandler(preprocessor_consumer);
 
     auto* const visitor_state =
         new VisitorState(&compiler, *preprocessor_consumer);

--- a/iwyu_preprocessor.h
+++ b/iwyu_preprocessor.h
@@ -95,7 +95,9 @@ using std::multimap;
 class IwyuPreprocessorInfo : public clang::PPCallbacks,
                              public clang::CommentHandler {
  public:
-  IwyuPreprocessorInfo() = default;
+  explicit IwyuPreprocessorInfo(const clang::Preprocessor& preprocessor)
+      : preprocessor_(preprocessor) {
+  }
 
   // The client *must* call this from the beginning of HandleTranslationUnit()
   void HandlePreprocessingDone();
@@ -269,9 +271,6 @@ class IwyuPreprocessorInfo : public clang::PPCallbacks,
                       clang::SourceLocation usage_location,
                       clang::SourceLocation dfn_location);
 
-  // As above, but get the definition location from macros_definition_loc_.
-  void FindAndReportMacroUse(const string& name, clang::SourceLocation loc);
-
   // Helper for PopulateIntendsToProvideMap().
   void AddAllIncludesAsFileEntries(
       clang::OptionalFileEntryRef includer,
@@ -288,6 +287,9 @@ class IwyuPreprocessorInfo : public clang::PPCallbacks,
   // there is a pending "begin_keep" pragma.
   bool HasOpenBeginKeep(clang::OptionalFileEntryRef file) const;
 
+  // The Clang preprocessor for this compilation.
+  const clang::Preprocessor& preprocessor_;
+
   // The C++ source file passed in as an argument to the compiler (as
   // opposed to other files seen via #includes).
   clang::OptionalFileEntryRef main_file_;
@@ -297,13 +299,6 @@ class IwyuPreprocessorInfo : public clang::PPCallbacks,
   // main_file_ and its associated .h and -inl.h files, if they exist.
   // But users can add to it via the --check_also flag.
   set<clang::OptionalFileEntryRef> files_to_report_iwyu_violations_for_;
-
-  // These store macros seen, as we see them, and also macros that are
-  // called from other macros.  We use this to do limited iwyu-testing
-  // on macro tokens (we'd love to test macro bodies more completely
-  // -- like we do template bodies -- but macros don't give us enough
-  // context to know how to interpret the tokens we see, in general).
-  map<string, clang::SourceLocation> macros_definition_loc_;  // key: macro name
 
   // This should logically be a set, but set<> needs Token::operator<
   // which we don't have.  Luckily, a vector works just as well.

--- a/iwyu_preprocessor.h
+++ b/iwyu_preprocessor.h
@@ -272,8 +272,6 @@ class IwyuPreprocessorInfo : public clang::PPCallbacks,
   // As above, but get the definition location from macros_definition_loc_.
   void FindAndReportMacroUse(const string& name, clang::SourceLocation loc);
 
-  // Final-processing routines done after all header files have been read.
-  void DoFinalMacroChecks();
   // Helper for PopulateIntendsToProvideMap().
   void AddAllIncludesAsFileEntries(
       clang::OptionalFileEntryRef includer,


### PR DESCRIPTION
We used to keep track of macro definitions ourselves as a
definition-location-by-name map.

The Clang preprocessor now exposes macro definition information where
macros are used (since 2012, Clang SVN revision 169665), so we can get
rid of this redundant mapping.

The extra accounting we do for macros inside macros now needs access to
the Clang preprocessor to lookup macro info from a token (previously a
lookup by name), so wire it when IwyuPreprocessorInfo is created.

No functional change intended.
