### PR TITLE
Discern function-like vs. object-like macros in macro bodies

### DIFF
--- a/iwyu_lexer_utils.h
+++ b/iwyu_lexer_utils.h
@@ -13,6 +13,8 @@
 #include <string>                       // for string
 
 #include "clang/Basic/SourceLocation.h"
+#include "clang/Basic/TokenKinds.h"
+#include "clang/Lex/MacroInfo.h"
 #include "llvm/ADT/StringRef.h"
 
 namespace clang {
@@ -73,6 +75,13 @@ string GetIncludeNameAsWritten(
 // Get the text of a given token.
 string GetTokenText(const clang::Token& token,
                     const CharacterDataGetterInterface& data_getter);
+
+// Given a token iterator inside a macro, returns the kind of the token after
+// current, ignoring comment tokens. If there is no token after, returns
+// clang::tok::unknown.
+clang::tok::TokenKind GetNextMacroTokenKind(
+    const clang::MacroInfo* macro,
+    clang::MacroInfo::const_tokens_iterator current);
 
 }  // namespace include_what_you_use
 

--- a/tests/cxx/macro_body-d1.h
+++ b/tests/cxx/macro_body-d1.h
@@ -1,0 +1,10 @@
+//===--- macro_body-d1.h - test input file for iwyu -----------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#define OBJECT_LIKE type name

--- a/tests/cxx/macro_body-d2.h
+++ b/tests/cxx/macro_body-d2.h
@@ -1,0 +1,10 @@
+//===--- macro_body-d2.h - test input file for iwyu -----------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#define FUNCTION_LIKE(x) func(x)

--- a/tests/cxx/macro_body-i1.h
+++ b/tests/cxx/macro_body-i1.h
@@ -1,0 +1,10 @@
+//===--- macro_body-i1.h - test input file for iwyu -----------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/macro_body-d1.h"

--- a/tests/cxx/macro_body-i2.h
+++ b/tests/cxx/macro_body-i2.h
@@ -1,0 +1,10 @@
+//===--- macro_body-i2.h - test input file for iwyu -----------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/macro_body-d2.h"

--- a/tests/cxx/macro_body.cc
+++ b/tests/cxx/macro_body.cc
@@ -1,0 +1,44 @@
+//===--- macro_body.cc - test input file for iwyu -------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// Test IWYU's analysis of macro bodies.
+
+#include "tests/cxx/macro_body-i1.h"
+#include "tests/cxx/macro_body-i2.h"
+
+// IWYU_ARGS: -I .
+
+// IWYU: OBJECT_LIKE is...*macro_body-d1.h
+#define MACRO1(x) OBJECT_LIKE
+
+// IWYU: FUNCTION_LIKE is...*macro_body-d2.h
+#define MACRO2(x) FUNCTION_LIKE(x)
+
+// FUNCTION_LIKE is not a known macro without the arguments.
+// UNDEFINED is not defined, and so will not be accounted.
+#define MACRO3(x) FUNCTION_LIKE UNDEFINED
+
+// Builtin macros do not have a location, and are not reported.
+#define MACRO4(x) __FILE__
+
+/**** IWYU_SUMMARY
+
+tests/cxx/macro_body.cc should add these lines:
+#include "tests/cxx/macro_body-d1.h"
+#include "tests/cxx/macro_body-d2.h"
+
+tests/cxx/macro_body.cc should remove these lines:
+- #include "tests/cxx/macro_body-i1.h"  // lines XX-XX
+- #include "tests/cxx/macro_body-i2.h"  // lines XX-XX
+
+The full include-list for tests/cxx/macro_body.cc:
+#include "tests/cxx/macro_body-d1.h"  // for OBJECT_LIKE
+#include "tests/cxx/macro_body-d2.h"  // for FUNCTION_LIKE
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
We used to analyze macro definitions to the best of our ability, looking for identifier tokens that will lead to nested macro expansion. These are then reported as uses, so dependencies between macros are reflected in the include dependencies (which isn't always the right call -- some macros really want to delay the dependency until expansion, but I digress).

Our analysis was a little too shallow, however, and we couldn't tell the difference between object-like macros (SYMBOL) and function-like macros (EXPR(x)), which led to strange conflicts where Clang would understand that an identifier inside a macro could never expand, but IWYU would think it could, and push for a macro definition #include.

The case in point was:

    #define BAR top::assert::bar()

where 'assert' looks dangerously like the macro in <assert.h>. But 'assert' is guaranteed by the standard to be function-like, and can never expand in that context.

Improve the analysis to emulate Clang's rules for macro expansion viability, and in particular tell the difference between object-like and function-like macros.

(It would obviously be cool to be able to analyze macro bodies as if they were 'real code' [think templates], but there's no principled way to reason about a macro prior to expansion, so that's still written in the stars.)

Fixes issue #1257.