### PR TITLE
Improve recursive handling of type aliases

### DIFF
--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -686,7 +686,7 @@ class TypeEnumeratorWithoutSubstituted
     if (IsSubstTemplateTypeParmType(type))
       return true;
 
-    seen_types_.insert(GetCanonicalType(type));
+    seen_types_.insert(Desugar(type));
 
     return Base::TraverseType(qual_type);
   }

--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -568,6 +568,11 @@ static bool IsSubstTemplateTypeParmType(const Type* type) {
   do {
     if (isa<SubstTemplateTypeParmType>(type))
       return true;
+    if (isa<TypedefType>(type) || isa<TemplateSpecializationType>(type)) {
+      // Still may be substituted outer template parameter but needs additional
+      // analysis outside this function.
+      return false;
+    }
     prev_type = type;
     type = type->getLocallyUnqualifiedSingleStepDesugaredType().getTypePtr();
   } while (type != prev_type);

--- a/tests/cxx/iwyu_stricter_than_cpp-d5.h
+++ b/tests/cxx/iwyu_stricter_than_cpp-d5.h
@@ -1,0 +1,14 @@
+//===--- iwyu_stricter_than_cpp-d5.h - test input file for iwyu -----------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "iwyu_stricter_than_cpp-i4.h"
+
+// No forward-declaration of 'IndirectClass' here.
+
+IndirectStruct4::IndirectClassNonProvidingTypedef RetNonProvidingTypedef();

--- a/tests/cxx/iwyu_stricter_than_cpp-i4.h
+++ b/tests/cxx/iwyu_stricter_than_cpp-i4.h
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_IWYU_STRICTER_THAN_CPP_I4_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_IWYU_STRICTER_THAN_CPP_I4_H_
+
 class IndirectClass;
 
 struct IndirectStruct4 {
@@ -14,3 +17,5 @@ struct IndirectStruct4 {
 
   using IndirectClassNonProvidingAl = IndirectClass;
 };
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_IWYU_STRICTER_THAN_CPP_I4_H_

--- a/tests/cxx/iwyu_stricter_than_cpp.cc
+++ b/tests/cxx/iwyu_stricter_than_cpp.cc
@@ -48,6 +48,7 @@
 #include "tests/cxx/iwyu_stricter_than_cpp-autocast2.h"
 #include "tests/cxx/iwyu_stricter_than_cpp-d2.h"
 #include "tests/cxx/iwyu_stricter_than_cpp-d3.h"
+#include "tests/cxx/iwyu_stricter_than_cpp-d5.h"
 
 template <typename T>
 void UsingFn() {
@@ -449,6 +450,9 @@ void TestFunctionReturn() {
   using Alias = TplIndirectStruct3<IndirectStruct2, IndirectStruct2>;
 
   Call<Alias, TplAllForwardDeclaredFn>();
+
+  // IWYU: IndirectClass is...*indirect.h
+  RetNonProvidingTypedef();
 }
 
 void TestDefaultTplArgs() {
@@ -493,6 +497,7 @@ The full include-list for tests/cxx/iwyu_stricter_than_cpp.cc:
 #include "tests/cxx/indirect.h"  // for IndirectClass
 #include "tests/cxx/iwyu_stricter_than_cpp-autocast.h"  // for FnRefs, FnValues, HeaderDefinedFnRefs, HeaderDefinedTplFnRefs, TplFnRefs, TplFnValues
 #include "tests/cxx/iwyu_stricter_than_cpp-d3.h"  // for IndirectStruct3ProvidingAl, IndirectStruct3ProvidingTypedef, IndirectStruct4ProvidingAl, IndirectStruct4ProvidingTypedef
+#include "tests/cxx/iwyu_stricter_than_cpp-d5.h"  // for RetNonProvidingTypedef
 #include "tests/cxx/iwyu_stricter_than_cpp-def_tpl_arg.h"  // for TplWithDefaultArgs
 #include "tests/cxx/iwyu_stricter_than_cpp-fnreturn.h"  // for DoesEverythingRightFn, DoesNotForwardDeclareAndIncludesFn, DoesNotForwardDeclareFn, DoesNotForwardDeclareProperlyFn, IncludesFn, TplAllForwardDeclaredFn, TplAllNeededTypesProvidedFn, TplDoesEverythingRightAgainFn, TplDoesEverythingRightFn, TplDoesNotForwardDeclareAndIncludesFn, TplDoesNotForwardDeclareFn, TplDoesNotForwardDeclareProperlyFn, TplIncludesFn, TplOnlyArgumentTypeProvidedFn, TplOnlyTemplateProvidedFn
 #include "tests/cxx/iwyu_stricter_than_cpp-i2.h"  // for IndirectStruct2, TplIndirectStruct2

--- a/tests/cxx/typedef_chain_in_template-d1.h
+++ b/tests/cxx/typedef_chain_in_template-d1.h
@@ -9,6 +9,7 @@
 
 // This header mimics std::vector in libstdc++.
 
+#include "tests/cxx/typedef_chain_class.h"
 #include "tests/cxx/typedef_chain_in_template-i1.h"
 
 template<typename T>

--- a/tests/cxx/typedef_chain_in_template-d5.h
+++ b/tests/cxx/typedef_chain_in_template-d5.h
@@ -1,0 +1,30 @@
+//===--- typedef_chain_in_template-d5.h - test input file for iwyu --------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/typedef_chain_in_template-i1.h"
+#include "tests/cxx/typedef_chain_in_template-i2.h"
+
+template <typename T>
+struct IdentityStructComplex {
+  using Type = typename TypedefWrapper<T>::value_type;
+};
+
+template <typename T>
+using IdentityAlias = T;
+
+template <typename T>
+using IdentityAliasComplex = IdentityAlias<T>;
+
+template <typename T>
+struct Tpl {
+  static constexpr auto s = sizeof(T);
+};
+
+using TplWithNonProvidedAliased1 = Tpl<NonProvidingAlias>;
+using TplWithNonProvidedAliased2 = Tpl<NonProvidingAliasTpl<1>>;

--- a/tests/cxx/typedef_chain_in_template-i1.h
+++ b/tests/cxx/typedef_chain_in_template-i1.h
@@ -9,8 +9,13 @@
 
 // This header mimics ext/alloc_traits.h in libstdc++.
 
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_TYPEDEF_CHAIN_IN_TEMPLATE_I1_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_TYPEDEF_CHAIN_IN_TEMPLATE_I1_H_
+
 template<typename T>
 struct TypedefWrapper {
   typedef T value_type;
   typedef value_type& reference;
 };
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_TYPEDEF_CHAIN_IN_TEMPLATE_I1_H_

--- a/tests/cxx/typedef_chain_in_template-i2.h
+++ b/tests/cxx/typedef_chain_in_template-i2.h
@@ -1,0 +1,15 @@
+//===--- typedef_chain_in_template-i2.h - test input file for iwyu --------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+class TypedefChainClass;
+
+using NonProvidingAlias = TypedefChainClass;
+
+template <int>
+using NonProvidingAliasTpl = TypedefChainClass;

--- a/tests/cxx/typedef_chain_in_template.cc
+++ b/tests/cxx/typedef_chain_in_template.cc
@@ -19,6 +19,7 @@
 #include "tests/cxx/typedef_chain_in_template-d2.h"
 #include "tests/cxx/typedef_chain_in_template-d3.h"
 #include "tests/cxx/typedef_chain_in_template-d4.h"
+#include "tests/cxx/typedef_chain_in_template-d5.h"
 
 void UsageAsWithLibstdcpp() {
   // IWYU: TypedefChainClass needs a declaration
@@ -56,6 +57,25 @@ void UsageWithLongerTypedefChain() {
   c.GetContent2().Method();
 }
 
+void Fn() {
+  // IWYU: TypedefChainClass needs a declaration
+  // IWYU: TypedefChainClass is...*typedef_chain_class.h
+  IdentityStructComplex<TypedefChainClass>::Type isc;
+  // IWYU: TypedefChainClass is...*typedef_chain_class.h
+  isc.Method();
+
+  // IWYU: TypedefChainClass needs a declaration
+  // IWYU: TypedefChainClass is...*typedef_chain_class.h
+  IdentityAliasComplex<TypedefChainClass> iac;
+  // IWYU: TypedefChainClass is...*typedef_chain_class.h
+  iac.Method();
+
+  // IWYU: TypedefChainClass is...*typedef_chain_class.h
+  (void)sizeof(TplWithNonProvidedAliased1);
+  // IWYU: TypedefChainClass is...*typedef_chain_class.h
+  (void)sizeof(TplWithNonProvidedAliased2);
+}
+
 /**** IWYU_SUMMARY
 
 tests/cxx/typedef_chain_in_template.cc should add these lines:
@@ -69,5 +89,6 @@ The full include-list for tests/cxx/typedef_chain_in_template.cc:
 #include "tests/cxx/typedef_chain_in_template-d2.h"  // for ContainerAsLibcpp
 #include "tests/cxx/typedef_chain_in_template-d3.h"  // for ContainerShortTypedefChain
 #include "tests/cxx/typedef_chain_in_template-d4.h"  // for ContainerLongTypedefChain
+#include "tests/cxx/typedef_chain_in_template-d5.h"  // for IdentityAliasComplex, IdentityStructComplex, TplWithNonProvidedAliased1, TplWithNonProvidedAliased2
 
 ***** IWYU_SUMMARY */

--- a/tests/cxx/typedef_chain_in_template.cc
+++ b/tests/cxx/typedef_chain_in_template.cc
@@ -19,39 +19,49 @@
 #include "tests/cxx/typedef_chain_in_template-d2.h"
 #include "tests/cxx/typedef_chain_in_template-d3.h"
 #include "tests/cxx/typedef_chain_in_template-d4.h"
-#include "tests/cxx/typedef_chain_class.h"
-// Unused include to trigger IWYU summary telling what symbols are used from
-// every file.
-#include "tests/cxx/direct.h"
 
 void UsageAsWithLibstdcpp() {
+  // IWYU: TypedefChainClass needs a declaration
+  // IWYU: TypedefChainClass is...*typedef_chain_class.h
   ContainerAsLibstdcpp<TypedefChainClass> c;
+  // IWYU: TypedefChainClass is...*typedef_chain_class.h
   c.GetContent().Method();
 }
 
 void UsageAsWithLibcpp() {
+  // IWYU: TypedefChainClass needs a declaration
+  // IWYU: TypedefChainClass is...*typedef_chain_class.h
   ContainerAsLibcpp<TypedefChainClass> c;
+  // IWYU: TypedefChainClass is...*typedef_chain_class.h
   c.GetContent().Method();
 }
 
 void UsageWithShorterTypedefChain() {
+  // IWYU: TypedefChainClass needs a declaration
+  // IWYU: TypedefChainClass is...*typedef_chain_class.h
   ContainerShortTypedefChain<TypedefChainClass> c;
+  // IWYU: TypedefChainClass is...*typedef_chain_class.h
   c.GetContent1().Method();
+  // IWYU: TypedefChainClass is...*typedef_chain_class.h
   c.GetContent2().Method();
 }
 
 void UsageWithLongerTypedefChain() {
+  // IWYU: TypedefChainClass needs a declaration
+  // IWYU: TypedefChainClass is...*typedef_chain_class.h
   ContainerLongTypedefChain<TypedefChainClass> c;
+  // IWYU: TypedefChainClass is...*typedef_chain_class.h
   c.GetContent1().Method();
+  // IWYU: TypedefChainClass is...*typedef_chain_class.h
   c.GetContent2().Method();
 }
 
 /**** IWYU_SUMMARY
 
 tests/cxx/typedef_chain_in_template.cc should add these lines:
+#include "tests/cxx/typedef_chain_class.h"
 
 tests/cxx/typedef_chain_in_template.cc should remove these lines:
-- #include "tests/cxx/direct.h"  // lines XX-XX
 
 The full include-list for tests/cxx/typedef_chain_in_template.cc:
 #include "tests/cxx/typedef_chain_class.h"  // for TypedefChainClass

--- a/tests/cxx/typedef_chain_no_follow-d4.h
+++ b/tests/cxx/typedef_chain_no_follow-d4.h
@@ -13,3 +13,10 @@ template <typename T>
 using IdentityAlias = T;
 
 using ProvidingWithAliasTpl = IdentityAlias<TypedefChainClass>;
+
+template <typename T>
+struct IdentityStruct {
+  using Type = T;
+};
+
+using ProvidingWithStructTpl = IdentityStruct<TypedefChainClass>::Type;

--- a/tests/cxx/typedef_chain_no_follow-d4.h
+++ b/tests/cxx/typedef_chain_no_follow-d4.h
@@ -1,0 +1,15 @@
+//===--- typedef_chain_no_follow-d4.h - test input file for iwyu ----------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/typedef_chain_class.h"
+
+template <typename T>
+using IdentityAlias = T;
+
+using ProvidingWithAliasTpl = IdentityAlias<TypedefChainClass>;

--- a/tests/cxx/typedef_chain_no_follow.cc
+++ b/tests/cxx/typedef_chain_no_follow.cc
@@ -26,6 +26,9 @@ void TypedefDeclaredInGlobalNamespace() {
 
   ProvidingWithAliasTpl pwat;
   pwat.Method();
+
+  ProvidingWithStructTpl pwst;
+  pwst.Method();
 }
 
 // Tests how we handle a typedef declared in a class.  Main purpose is to make
@@ -54,6 +57,6 @@ The full include-list for tests/cxx/typedef_chain_no_follow.cc:
 #include "tests/cxx/typedef_chain_no_follow-d1.h"  // for TypedefChainTypedef
 #include "tests/cxx/typedef_chain_no_follow-d2.h"  // for NonContainer1
 #include "tests/cxx/typedef_chain_no_follow-d3.h"  // for NonContainer2
-#include "tests/cxx/typedef_chain_no_follow-d4.h"  // for ProvidingWithAliasTpl
+#include "tests/cxx/typedef_chain_no_follow-d4.h"  // for ProvidingWithAliasTpl, ProvidingWithStructTpl
 
 ***** IWYU_SUMMARY */

--- a/tests/cxx/typedef_chain_no_follow.cc
+++ b/tests/cxx/typedef_chain_no_follow.cc
@@ -15,6 +15,7 @@
 #include "tests/cxx/typedef_chain_no_follow-d1.h"
 #include "tests/cxx/typedef_chain_no_follow-d2.h"
 #include "tests/cxx/typedef_chain_no_follow-d3.h"
+#include "tests/cxx/typedef_chain_no_follow-d4.h"
 // Unused include to trigger IWYU summary telling what symbols are used from
 // every file.
 #include "tests/cxx/direct.h"
@@ -22,6 +23,9 @@
 void TypedefDeclaredInGlobalNamespace() {
   TypedefChainTypedef tct;
   tct.Method();
+
+  ProvidingWithAliasTpl pwat;
+  pwat.Method();
 }
 
 // Tests how we handle a typedef declared in a class.  Main purpose is to make
@@ -50,5 +54,6 @@ The full include-list for tests/cxx/typedef_chain_no_follow.cc:
 #include "tests/cxx/typedef_chain_no_follow-d1.h"  // for TypedefChainTypedef
 #include "tests/cxx/typedef_chain_no_follow-d2.h"  // for NonContainer1
 #include "tests/cxx/typedef_chain_no_follow-d3.h"  // for NonContainer2
+#include "tests/cxx/typedef_chain_no_follow-d4.h"  // for ProvidingWithAliasTpl
 
 ***** IWYU_SUMMARY */


### PR DESCRIPTION
It turns out that the presence of `SubstTemplateTypeParmType` inside an alias type sugar chain doesn't necessarily mean that it is a user-provided template parameter. It may occur e. g. when an alias template is used inside the `typedef` declaration, and its template parameter is specified inside that declaration. The regression had been introduced in 2d26dd1b33 and found on MS STL `vector` implementation when IWYU started to require `_Simple_types` type info for such a code:
```cpp
std::vector v{1, 2, 3};
(void)v.begin();
```
due to the returned `iterator` type alias.

Besides that, this PR brings several other improvements:

- avoiding erroneous consideration of aliased component types as provided just because their forward declaration is in the other (internal alias declaring) file;

- correct handling of aliased types in contexts other than direct aliased type usage (e. g. when handling function return type);

- recursive handling of nested alias templates similar to `typedef`s;

- avoiding of losing nested `typedef` internals during recursive collecting their provided types, like `Class` inside such an elaborated alias: `using AliasedClass = Identity<Class>::Alias;`.