### PR TITLE
Make test include guards consistent

### DIFF
--- a/tests/cxx/cvr-base.h
+++ b/tests/cxx/cvr-base.h
@@ -7,9 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef CVR_BASE_H
-#define CVR_BASE_H
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_CVR_BASE_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_CVR_BASE_H_
 
 class Base {};
 
-#endif
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_CVR_BASE_H_

--- a/tests/cxx/cvr-class.h
+++ b/tests/cxx/cvr-class.h
@@ -7,9 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef CVR_CLASS_H
-#define CVR_CLASS_H
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_CVR_CLASS_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_CVR_CLASS_H_
 
 class Class {};
 
-#endif
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_CVR_CLASS_H_

--- a/tests/cxx/cvr-derived.h
+++ b/tests/cxx/cvr-derived.h
@@ -7,11 +7,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef CVR_DERIVED_H
-#define CVR_DERIVED_H
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_CVR_DERIVED_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_CVR_DERIVED_H_
 
 #include "tests/cxx/cvr-base.h"
 
 class Derived : public Base {};
 
-#endif
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_CVR_DERIVED_H_

--- a/tests/cxx/internal/include_cycle-d1.h
+++ b/tests/cxx/internal/include_cycle-d1.h
@@ -7,8 +7,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef INCLUDE_CYCLE_D1_H
-#define INCLUDE_CYCLE_D1_H
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_INTERNAL_INCLUDE_CYCLE_D1_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_INTERNAL_INCLUDE_CYCLE_D1_H_
 
 // Include itself (cycle length 1)
 #include "tests/cxx/internal/include_cycle-d1.h"
@@ -18,4 +18,4 @@
 
 struct IncludeCycleD1 {};
 
-#endif  /* #ifndef INCLUDE_CYCLE_D1_H */
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_INTERNAL_INCLUDE_CYCLE_D1_H_

--- a/tests/cxx/internal/include_cycle-i1.h
+++ b/tests/cxx/internal/include_cycle-i1.h
@@ -7,9 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef INCLUDE_CYCLE_I1_H
-#define INCLUDE_CYCLE_I1_H
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_INTERNAL_INCLUDE_CYCLE_I1_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_INTERNAL_INCLUDE_CYCLE_I1_H_
 
 #include "tests/cxx/internal/include_cycle-d1.h"
 
-#endif  /* #ifndef INCLUDE_CYCLE_I1_H */
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_INTERNAL_INCLUDE_CYCLE_I1_H_

--- a/tests/cxx/iwyu_stricter_than_cpp-autocast.h
+++ b/tests/cxx/iwyu_stricter_than_cpp-autocast.h
@@ -7,8 +7,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef IWYU_STRICTER_THAN_CPP_AUTOCAST_H_
-#define IWYU_STRICTER_THAN_CPP_AUTOCAST_H_
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_IWYU_STRICTER_THAN_CPP_AUTOCAST_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_IWYU_STRICTER_THAN_CPP_AUTOCAST_H_
 
 // The two rules the author has to follow to disable iwyu's
 // stricter-than-C++ rule and force it to fall back on the c++
@@ -166,7 +166,7 @@ void Fn(NoAutocastForSpec<char>);
 // IWYU: AutocastInPartialSpec needs a declaration
 void Fn(AutocastInPartialSpec<char*>);
 
-#endif  // IWYU_STRICTER_THAN_CPP_AUTOCAST_H_
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_IWYU_STRICTER_THAN_CPP_AUTOCAST_H_
 
 /**** IWYU_SUMMARY
 

--- a/tests/cxx/iwyu_stricter_than_cpp-d1.h
+++ b/tests/cxx/iwyu_stricter_than_cpp-d1.h
@@ -7,8 +7,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef IWYU_STRICTER_THAN_CPP_D1_H_
-#define IWYU_STRICTER_THAN_CPP_D1_H_
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_IWYU_STRICTER_THAN_CPP_D1_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_IWYU_STRICTER_THAN_CPP_D1_H_
 
 #include "tests/cxx/iwyu_stricter_than_cpp-i1.h"
 #include "tests/cxx/iwyu_stricter_than_cpp-i2.h"
@@ -74,4 +74,4 @@ struct TplDirectStruct6 {
 template <typename T>
 struct TplIndirectStructForwardDeclaredInD1;
 
-#endif
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_IWYU_STRICTER_THAN_CPP_D1_H_

--- a/tests/cxx/iwyu_stricter_than_cpp-d3.h
+++ b/tests/cxx/iwyu_stricter_than_cpp-d3.h
@@ -7,8 +7,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef IWYU_STRICTER_THAN_CPP_D3_H_
-#define IWYU_STRICTER_THAN_CPP_D3_H_
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_IWYU_STRICTER_THAN_CPP_D3_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_IWYU_STRICTER_THAN_CPP_D3_H_
 
 #include "tests/cxx/iwyu_stricter_than_cpp-i3.h"
 #include "tests/cxx/iwyu_stricter_than_cpp-i4.h"
@@ -19,4 +19,4 @@ typedef IndirectStruct4 IndirectStruct4ProvidingTypedef;
 using IndirectStruct3ProvidingAl = IndirectStruct3;
 using IndirectStruct4ProvidingAl = IndirectStruct4;
 
-#endif
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_IWYU_STRICTER_THAN_CPP_D3_H_

--- a/tests/cxx/iwyu_stricter_than_cpp-d4.h
+++ b/tests/cxx/iwyu_stricter_than_cpp-d4.h
@@ -7,8 +7,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef IWYU_STRICTER_THAN_CPP_D4_H_
-#define IWYU_STRICTER_THAN_CPP_D4_H_
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_IWYU_STRICTER_THAN_CPP_D4_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_IWYU_STRICTER_THAN_CPP_D4_H_
 
 #include "tests/cxx/iwyu_stricter_than_cpp-i5.h"
 
@@ -25,4 +25,4 @@ struct TplDirectStruct7 {
   T2* t2;
 };
 
-#endif
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_IWYU_STRICTER_THAN_CPP_D4_H_

--- a/tests/cxx/ptr_ref_aliases-d3.h
+++ b/tests/cxx/ptr_ref_aliases-d3.h
@@ -7,9 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef PTR_REF_ALIASES_D3_H_
-#define PTR_REF_ALIASES_D3_H_
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_PTR_REF_ALIASES_D3_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_PTR_REF_ALIASES_D3_H_
 
 struct IndirectBase {};
 
-#endif
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_PTR_REF_ALIASES_D3_H_

--- a/tests/cxx/ptr_ref_aliases-i2.h
+++ b/tests/cxx/ptr_ref_aliases-i2.h
@@ -7,8 +7,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef PTR_REF_ALIASES_I2_H_
-#define PTR_REF_ALIASES_I2_H_
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_PTR_REF_ALIASES_I2_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_PTR_REF_ALIASES_I2_H_
 
 #include "tests/cxx/ptr_ref_aliases-d3.h"
 
@@ -19,4 +19,4 @@ struct Indirect : IndirectBase {
   Indirect& operator<<(int);
 };
 
-#endif
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_PTR_REF_ALIASES_I2_H_


### PR DESCRIPTION
Located all inconsistent include guards using:

    git grep -P '#ifndef (?!INCLUDE_WHAT_YOU)' tests/cxx

Manually patched them up to have consistent form.