### PR TITLE
[clang compat] Update InclusionDirective override

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,4 +1,5 @@
 BasedOnStyle: Google
+BinPackParameters: false
 AllowShortBlocksOnASingleLine: false
 AllowShortIfStatementsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: false

--- a/iwyu_preprocessor.cc
+++ b/iwyu_preprocessor.cc
@@ -756,11 +756,17 @@ void IwyuPreprocessorInfo::Defined(const Token& id,
   ReportMacroUse(GetName(id), id.getLocation(), GetMacroDefLoc(definition));
 }
 
-void IwyuPreprocessorInfo::InclusionDirective(
-    SourceLocation hash_loc, const Token& include_token, StringRef filename,
-    bool is_angled, CharSourceRange filename_range, OptionalFileEntryRef file,
-    StringRef search_path, StringRef relative_path, const Module* imported,
-    CharacteristicKind file_type) {
+void IwyuPreprocessorInfo::InclusionDirective(SourceLocation hash_loc,
+                                              const Token& include_token,
+                                              StringRef filename,
+                                              bool is_angled,
+                                              CharSourceRange filename_range,
+                                              OptionalFileEntryRef file,
+                                              StringRef search_path,
+                                              StringRef relative_path,
+                                              const Module* suggested_module,
+                                              bool module_imported,
+                                              CharacteristicKind file_type) {
   include_filename_loc_ = filename_range.getBegin();
 }
 

--- a/iwyu_preprocessor.h
+++ b/iwyu_preprocessor.h
@@ -208,7 +208,8 @@ class IwyuPreprocessorInfo : public clang::PPCallbacks,
                           clang::OptionalFileEntryRef file,
                           llvm::StringRef search_path,
                           llvm::StringRef relative_path,
-                          const clang::Module* imported,
+                          const clang::Module* suggested_module,
+                          bool module_imported,
                           clang::SrcMgr::CharacteristicKind file_type) override;
 
   void FileChanged(clang::SourceLocation loc, FileChangeReason reason,


### PR DESCRIPTION
PPCallbacks::InclusionDirective was modified in
https://github.com/llvm/llvm-project/commit/da95d926f6fce4ed9707c77908ad96624268f134

Update override to match. No functional change.

This marks a clean break from clang-18, which was branched before this
change.