### PR TITLE
[ci] Update actions/checkout to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
           echo "IWYU_CHECKOUT_REF=${{github.sha}}" >> $GITHUB_ENV
 
       - name: Check out branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{env.IWYU_CHECKOUT_REF}}
 


### PR DESCRIPTION
GitHub warns:

    Node.js 16 actions are deprecated. Please update the following
    actions to use Node.js 20: actions/checkout@v3. [...]

The actions/checkout@v4 release appears to use Node 20 by default, so upgrade.