### PR TITLE
[clang compat] Handle new cast kind for HLSL vector truncation

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -1840,6 +1840,7 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
       case clang::CK_AddressSpaceConversion:  // Address spaces are associated
                                               // with pointers, so no need for
                                               // the full type.
+      case clang::CK_HLSLVectorTruncation:
         break;
 
       // Ignore non-ptr-to-ptr casts.


### PR DESCRIPTION
The new cast kind CK_HLSLVectorTruncation was added in: https://github.com/llvm/llvm-project/commit/5c57fd717d5d6a285efeb8402c6fe0c8f70592f3

I can't see that it would affect IWYU analysis, so just handle it silently to placate -Wswitch.