### PR TITLE
[ci] Disable CMake RPATH stripping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,7 @@ jobs:
                 -DCMAKE_C_COMPILER=clang$LLVM_TAG \
                 -DCMAKE_CXX_COMPILER=clang++$LLVM_TAG \
                 -DCMAKE_INSTALL_PREFIX=./ \
+                -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=on \
                 ../
           ninja
 


### PR DESCRIPTION
cmake --install by default runs a step to clear RPATH from executables.

Since we install IWYU into the build directory, no files are moved around, but the RPATH settings the linker put in to point to our dylib dependencies will be deleted.

This causes the dogfood step to fail, as it doesn't know where to look for dylib dependencies.

It's not clear why this started failing now, maybe because the apt packages now default harder to dynamic linking.