### PR TITLE
Use "non-member" instead of "free" consistently

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -720,8 +720,8 @@ class BaseAstVisitor : public RecursiveASTVisitor<Derived> {
       return true;
 
     const Type* parent_type = TypeOfParentIfMethod(expr);
-    // If we're a free function -- bool operator==(MyClass a, MyClass b) --
-    // we still want to have a parent_type, as if we were defined as
+    // If we're a non-member function -- bool operator==(MyClass a, MyClass b)
+    // -- we still want to have a parent_type, as if we were defined as
     // MyClass::operator==.  So we go through the arguments and take the
     // first one that's a class, and associate the function with that.
     if (!parent_type) {
@@ -1204,7 +1204,7 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
   // myvec.end(), foo)), so we need to manually map back.  We map
   // __normal_iterator<foo, vector> to vector<> and __wrap_iter<foo> to foo,
   // assuming that the vector<> class includes the typedef.  Likewise, we map
-  // any free function taking a private iterator (such as operator==) the
+  // any non-member function taking a private iterator (such as operator==) the
   // same way, assuming that that (templatized) function is instantiated
   // as part of the vector class.
   //    We do something similar for _List_iterator and _List_const_iterator
@@ -1218,7 +1218,7 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
   const Type* MapPrivateDeclToPublicType(const NamedDecl* decl) const {
     const NamedDecl* class_decl = decl;
     // If we're a member method, then the __normal_iterator or __wrap_iter will
-    // be the parent: __normal_iterator::operator=.  If we're a free
+    // be the parent: __normal_iterator::operator=.  If we're a non-member
     // overloaded operator, then the __normal_iterator will be the
     // first argument: operator==(__normal_iterator<...>& lhs, ...);
     if (const CXXMethodDecl* method_decl = DynCastFrom(class_decl)) {
@@ -1685,7 +1685,7 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
       return true;
 
     if (decl->isThisDeclarationADefinition()) {
-      // For free functions, report use of all previously seen decls.
+      // For non-member functions, report use of all previously seen decls.
       if (decl->getKind() == Decl::Function) {
         FunctionDecl* redecl = decl;
         while ((redecl = redecl->getPreviousDecl()))
@@ -2058,7 +2058,7 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
     return true;
   }
 
-  // We want to mark use of the base type For 'free function' operator
+  // We want to mark use of the base type For non-member operator
   // overloads ('ostream& operator<<(ostream& o, int x)') just like we
   // do for member functions ('ostream& ostream::operator<<(int x)')
   // -- for iwyu purposes, 'x << 4' is just semantic sugar around

--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -329,11 +329,11 @@ UseFlags ComputeUseFlags(const ASTNode* ast_node) {
   if (IsNodeInsideCXXMethodBody(ast_node))
     flags |= UF_InCxxMethodBody;
 
-  // Definitions of free functions are a little special, because they themselves
-  // count as uses of all prior declarations (ideally we should probably just
-  // require one but it's hard to say which, so we pick all previously seen).
-  // Later IWYU analysis phases do some canonicalization that isn't
-  // necessary/valid for this case, so mark it up for later.
+  // Definitions of non-member functions are a little special, because they
+  // themselves count as uses of all prior declarations (ideally we should
+  // probably just require one but it's hard to say which, so we pick all
+  // previously seen). Later IWYU analysis phases do some canonicalization that
+  // isn't necessary/valid for this case, so mark it up for later.
   if (const auto* fd = ast_node->GetAs<FunctionDecl>()) {
     if (fd->getKind() == Decl::Function && fd->isThisDeclarationADefinition())
       flags |= UF_FunctionDfn;
@@ -1643,7 +1643,7 @@ const Expr* GetFirstClassArgument(CallExpr* expr) {
       // If a method is called, return 'this'.
       return expr->getArg(0);
     }
-    // Handle free functions.
+    // Handle non-member functions.
     CHECK_(callee_decl->getNumParams() == expr->getNumArgs() &&
         "Require one-to-one match between call arguments and decl parameters");
     int params_count = callee_decl->getNumParams();

--- a/iwyu_ast_util.h
+++ b/iwyu_ast_util.h
@@ -868,7 +868,7 @@ const clang::Type* TypeOfParentIfMethod(const clang::CallExpr* expr);
 
 // Given a function call, return the first argument that's a class
 // (possibly a template specialization).  Note we ignore pointers to a
-// class.  This is used with 'free' overloaded operators ('ostream&
+// class.  This is used with non-member overloaded operators ('ostream&
 // operator<<(ostream& a, int x)' to figure out what class the
 // operator 'logically' belongs to.  This is a heuristic (the operator
 // may "belong" to more than one argument, for instance), but covers

--- a/tests/cxx/badinc-i2-inl.h
+++ b/tests/cxx/badinc-i2-inl.h
@@ -57,15 +57,17 @@ template<typename T> class I2_InlFileTemplateClass {
   T a;
 };
 
-inline int InlFileFreeFn() {
+inline int InlFileNonMemberFn() {
   return 7;
 }
 
-template<typename T> int InlFileFreeTemplateFn() {
+template <typename T>
+int InlFileNonMemberTemplateFn() {
   return 8;
 }
 
-template<> int InlFileFreeTemplateFn<int>() {
+template <>
+int InlFileNonMemberTemplateFn<int>() {
   return 9;
 }
 

--- a/tests/cxx/badinc-i2.h
+++ b/tests/cxx/badinc-i2.h
@@ -134,8 +134,9 @@ class I2_Subclass : public I2_ThisClassIsOnlySubclassedWithVirtualMethod {
 class I2_InlFileClass;   // defined in badinc-i2-inl.h
 template<typename T> class I2_InlFileTemplateClass;  // ditto
 
-inline int InlFileFreeFn();   // defined in badinc-d1-inl.h
-template<typename T> int InlFileFreeTemplateFn();   // ditto
+inline int InlFileNonMemberFn();  // defined in badinc-d1-inl.h
+template <typename T>
+int InlFileNonMemberTemplateFn();  // ditto
 
 extern int inlfile_var;   // defined in badinc-d1-inl.h
 

--- a/tests/cxx/badinc.cc
+++ b/tests/cxx/badinc.cc
@@ -1374,12 +1374,12 @@ int main() {
   // IWYU: I2_TemplateClass::InlFileTemplateClassFn is...*badinc-i2-inl.h
   // IWYU: I2_TemplateClass is...*badinc-i2.h
   local_i2_template_class.CcFileFn();
-  // IWYU: InlFileFreeFn is...*badinc-i2-inl.h
-  InlFileFreeFn();
-  // IWYU: InlFileFreeTemplateFn is...*badinc-i2-inl.h
-  InlFileFreeTemplateFn<float>();
-  // IWYU: InlFileFreeTemplateFn is...*badinc-i2-inl.h
-  InlFileFreeTemplateFn<int>();     // a specialization
+  // IWYU: InlFileNonMemberFn is...*badinc-i2-inl.h
+  InlFileNonMemberFn();
+  // IWYU: InlFileNonMemberTemplateFn is...*badinc-i2-inl.h
+  InlFileNonMemberTemplateFn<float>();
+  // IWYU: InlFileNonMemberTemplateFn is...*badinc-i2-inl.h
+  InlFileNonMemberTemplateFn<int>();  // a specialization
   // IWYU: inlfile_var is...*badinc-i2-inl.h
   (void)(inlfile_var);
   // TODO(csilvers): IWYU: I1_FunctionPtr is...*badinc-i1.h
@@ -1438,7 +1438,7 @@ int main() {
   // IWYU: I1_Class is...*badinc-i1.h
   // IWYU: I1_const_ptr is...*badinc-i1.h
   local_i1_const_ptr.indirect_del();
-  // This calls *ptr_, but in a free function.
+  // This calls *ptr_, but in a non-member function.
   // IWYU: operator== is...*badinc-i1.h
   // IWYU: I1_const_ptr is...*badinc-i1.h
   (void)(local_i1_const_ptr == i1_class);

--- a/tests/cxx/funcptrs.cc
+++ b/tests/cxx/funcptrs.cc
@@ -16,7 +16,7 @@
 // 2) Calls: FunctionThatTakesFptr(function);
 // 3) Naked expressions: &function;
 //
-// A 'function' can be a free function, a static member function, a member
+// A 'function' can be a non-member function, a static member function, a member
 // function, or any template instantiation of the above.
 
 #include "tests/cxx/direct.h"
@@ -50,7 +50,7 @@ void FunctionThatTakesMptr(int (ClassTemplate<Class>::*mptr)() const);
 // Each test creates function pointers to a plain function and a template
 // instantiation, and for classes similarly for instance member functions.
 
-void FreeFunctions() {
+void NonMemberFunctions() {
   // Assignment of function pointer to function and template instantiation.
   // IWYU: Class needs a declaration
   // IWYU: Enum is...*funcptrs-i1.h


### PR DESCRIPTION
The C++ standard uses "non-member functions" consistently (and even has some revisions only changing from "free function" to "non-member function").

Follow terminology in IWYU.

No functional change.