### PR TITLE
Generalize UF_FunctionDfn

### DIFF
--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -336,7 +336,7 @@ UseFlags ComputeUseFlags(const ASTNode* ast_node) {
   // isn't necessary/valid for this case, so mark it up for later.
   if (const auto* fd = ast_node->GetAs<FunctionDecl>()) {
     if (fd->getKind() == Decl::Function && fd->isThisDeclarationADefinition())
-      flags |= UF_FunctionDfn;
+      flags |= UF_DefinitionUse;
   }
 
   return flags;

--- a/iwyu_use_flags.h
+++ b/iwyu_use_flags.h
@@ -17,7 +17,7 @@ typedef unsigned UseFlags;
 
 const UseFlags UF_None = 0;
 const UseFlags UF_InCxxMethodBody = 1;       // use is inside a C++ method body
-const UseFlags UF_FunctionDfn = 2;           // use is a function being defined
+const UseFlags UF_DefinitionUse = 2;         // use is itself a definition
 const UseFlags UF_ExplicitInstantiation = 4; // use targets an explicit instantiation
 }
 


### PR DESCRIPTION
UF_FunctionDfn is currently only used for functions, but the same kind of rules could be applied for other exported symbols.

Rename to UF_DefinitionUse, and try to generalize/clarify the wording in some comments.

No functional change.