### PR TITLE
Simplify non-member function definition handling

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -1685,11 +1685,12 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
       return true;
 
     if (decl->isThisDeclarationADefinition()) {
-      // For non-member functions, report use of all previously seen decls.
+      // For non-member function definitions, report use of all previously seen
+      // decls.
       if (decl->getKind() == Decl::Function) {
-        FunctionDecl* redecl = decl;
+        const FunctionDecl* redecl = decl;
         while ((redecl = redecl->getPreviousDecl()))
-          ReportDeclUse(CurrentLoc(), redecl);
+          ReportDeclUse(CurrentLoc(), redecl, nullptr, UF_DefinitionUse);
       }
     } else {
       // Make all our types forward-declarable.

--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -329,16 +329,6 @@ UseFlags ComputeUseFlags(const ASTNode* ast_node) {
   if (IsNodeInsideCXXMethodBody(ast_node))
     flags |= UF_InCxxMethodBody;
 
-  // Definitions of non-member functions are a little special, because they
-  // themselves count as uses of all prior declarations (ideally we should
-  // probably just require one but it's hard to say which, so we pick all
-  // previously seen). Later IWYU analysis phases do some canonicalization that
-  // isn't necessary/valid for this case, so mark it up for later.
-  if (const auto* fd = ast_node->GetAs<FunctionDecl>()) {
-    if (fd->getKind() == Decl::Function && fd->isThisDeclarationADefinition())
-      flags |= UF_DefinitionUse;
-  }
-
   return flags;
 }
 


### PR DESCRIPTION
Function definitions can only be reported from VisitFunctionDecl, so there's no need to search the AST for every use report in ComputeUseFlags.

(The same is not true for IsNodeInsideCXXMethodBody; that will actually be true for arbitrarily deep subtrees.)

Instead, pass the use-flag explicitly in VisitFunctionDecl when reporting declarations.

While here, clarify a comment and make more const-correct.