### PR TITLE
Consider variable definitions uses of extern declarations

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -1699,6 +1699,23 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
     return true;
   }
 
+  bool VisitVarDecl(VarDecl* decl) {
+    if (CanIgnoreCurrentASTNode())
+      return true;
+
+    if (decl->isThisDeclarationADefinition()) {
+      // For variable definitions, report use of all previously seen decls with
+      // external storage.
+      const VarDecl* redecl = decl;
+      while ((redecl = redecl->getPreviousDecl())) {
+        if (!redecl->hasExternalStorage())
+          continue;
+        ReportDeclUse(CurrentLoc(), redecl, nullptr, UF_DefinitionUse);
+      }
+    }
+    return true;
+  }
+
   // Special handling for C++ methods to detect covariant return types.
   // These are defined as a derived class overriding a method with a different
   // return type from the base.

--- a/tests/c/var_def_is_use-d1.h
+++ b/tests/c/var_def_is_use-d1.h
@@ -1,0 +1,11 @@
+//===--- var_def_is_use-d1.h - test input file for iwyu -------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/c/var_def_is_use-i1.h"
+#include "tests/c/var_def_is_use-i2.h"

--- a/tests/c/var_def_is_use-i1.h
+++ b/tests/c/var_def_is_use-i1.h
@@ -1,0 +1,10 @@
+//===--- var_def_is_use-i1.h - test input file for iwyu -------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+extern int extern_global;

--- a/tests/c/var_def_is_use-i2.h
+++ b/tests/c/var_def_is_use-i2.h
@@ -1,0 +1,10 @@
+//===--- var_def_is_use-i2.h - test input file for iwyu -------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+extern int extern_global;

--- a/tests/c/var_def_is_use.c
+++ b/tests/c/var_def_is_use.c
@@ -1,0 +1,31 @@
+//===--- var_def_is_use.c - test input file for iwyu ----------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_ARGS: -I .
+
+#include "var_def_is_use-d1.h"
+
+// IWYU: extern_global is...*var_def_is_use-i1.h
+// IWYU: extern_global is...*var_def_is_use-i2.h
+int extern_global = 20;
+
+/**** IWYU_SUMMARY
+
+tests/c/var_def_is_use.c should add these lines:
+#include "tests/c/var_def_is_use-i1.h"
+#include "tests/c/var_def_is_use-i2.h"
+
+tests/c/var_def_is_use.c should remove these lines:
+- #include "var_def_is_use-d1.h"  // lines XX-XX
+
+The full include-list for tests/c/var_def_is_use.c:
+#include "tests/c/var_def_is_use-i1.h"  // for extern_global
+#include "tests/c/var_def_is_use-i2.h"  // for extern_global
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
For every variable definition, traverse all preceding declarations and record uses of ones with external storage (which is potentially all of them, I don't think non-extern redeclarations are allowed).

Use the same mechanics as for non-member functions to mark them up as definition-uses.

Fixes #1461.