### PR TITLE
 Fix LLVM_DEFINITIONS usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,8 +126,10 @@ set_target_properties(include-what-you-use PROPERTIES
   CXX_EXTENSIONS OFF
 )
 
+separate_arguments(LLVM_DEFINITIONS_LIST NATIVE_COMMAND ${LLVM_DEFINITIONS})
+
 target_compile_definitions(include-what-you-use PRIVATE
-  ${LLVM_DEFINITIONS}
+  ${LLVM_DEFINITIONS_LIST}
   IWYU_GIT_REV="${iwyu_git_rev}"
 )
 target_include_directories(include-what-you-use PRIVATE


### PR DESCRIPTION
MSVC gives warn:

`command line : warning C5102: ignoring invalid command-line macro definition '_CRT_SECURE_NO_DEPRECATE -D_
       CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_DEPRECATE -D_CRT_NONSTDC_NO_WARNINGS -D_SCL_SECURE_NO_DEPRECATE -D_
       SCL_SECURE_NO_WARNINGS -DUNICODE -D_UNICODE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_M
       ACROS'`

  
see [Embedding LLVM in your project](https://llvm.org/docs/CMake.html#embedding-llvm-in-your-project)