### PR TITLE
Isolate platform specific headers to a translation unit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,7 @@ add_llvm_executable(include-what-you-use
   iwyu_location_util.cc
   iwyu_output.cc
   iwyu_path_util.cc
+  iwyu_port.cc
   iwyu_preprocessor.cc
   iwyu_regex.cc
   iwyu_verrs.cc

--- a/iwyu_port.cc
+++ b/iwyu_port.cc
@@ -1,0 +1,26 @@
+//===--- iwyu_port.cc - portability shims ---------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#if defined(_WIN32)
+
+#include "Shlwapi.h"  // for PathMatchSpecA
+
+bool GlobMatchesPath(const char *glob, const char *path) {
+  return PathMatchSpecA(path, glob);
+}
+
+#else  // #if defined(_WIN32)
+
+#include <fnmatch.h>
+
+bool GlobMatchesPath(const char *glob, const char *path) {
+  return fnmatch(glob, path, 0) == 0;
+}
+
+#endif  // #if defined(_WIN32)

--- a/iwyu_port.h
+++ b/iwyu_port.h
@@ -64,28 +64,6 @@ class OstreamVoidifier {
   ::include_what_you_use::FatalMessageEmitter( \
       __FILE__, __LINE__, message).stream()
 
-#if defined(_WIN32)
-
-#define NOMINMAX 1 // Prevent Windows headers from redefining min/max.
-#include "Shlwapi.h"  // for PathMatchSpecA
-
-// This undef is necessary to prevent conflicts between llvm
-// and Windows headers.
-// objbase.h has #define interface struct.
-#undef interface
-
-inline bool GlobMatchesPath(const char *glob, const char *path) {
-  return PathMatchSpecA(path, glob);
-}
-
-#else  // #if defined(_WIN32)
-
-#include <fnmatch.h>
-
-inline bool GlobMatchesPath(const char *glob, const char *path) {
-  return fnmatch(glob, path, 0) == 0;
-}
-
-#endif  // #if defined(_WIN32)
+bool GlobMatchesPath(const char *glob, const char *path);
 
 #endif  // INCLUDE_WHAT_YOU_USE_PORT_H_


### PR DESCRIPTION
Including Windows related headers in iwyu_port.h pollutes other translation units with Windows-specific definitions.  Move the function GlobMatchesPath to have external linkage instead of being inline and move the platform-specific code to a new file iwyu_port.cc

Fixes #1485