### PR TITLE
Add bits/memory_resource.h (memory_resource) and bits/uses_allocators.h (memory) - close #1486

### DIFF
--- a/gcc.stl.headers.imp
+++ b/gcc.stl.headers.imp
@@ -129,6 +129,7 @@
   { include: ["<bits/unique_ptr.h>", private, "<memory>", public ] },
   { include: ["<bits/unordered_map.h>", private, "<unordered_map>", public ] },
   { include: ["<bits/unordered_set.h>", private, "<unordered_set>", public ] },
+  { include: ["<bits/uses_allocator.h>", private, "<memory>", public ] },
   { include: ["<bits/utility.h>", private, "<utility>", public ] },
   { include: ["<bits/valarray_after.h>", private, "<valarray>", public ] },
   { include: ["<bits/valarray_array.h>", private, "<valarray>", public ] },

--- a/gcc.stl.headers.imp
+++ b/gcc.stl.headers.imp
@@ -56,6 +56,7 @@
   { include: ["<bits/locale_facets.tcc>", private, "<locale>", public ] },
   { include: ["<bits/localefwd.h>", private, "<locale>", public ] },
   { include: ["<bits/mask_array.h>", private, "<valarray>", public ] },
+  { include: ["<bits/memory_resource.h>", private, "<memory_resource>", public ] },
   { include: ["<bits/memoryfwd.h>", private, "<memory>", public ] },
   { include: ["<bits/move.h>", private, "<utility>", public ] },
   { include: ["<bits/nested_exception.h>", private, "<exception>", public ] },

--- a/iwyu_include_picker.cc
+++ b/iwyu_include_picker.cc
@@ -772,6 +772,7 @@ const IncludeMapEntry libstdcpp_include_map[] = {
   { "<bits/unique_ptr.h>", kPrivate, "<memory>", kPublic },
   { "<bits/unordered_map.h>", kPrivate, "<unordered_map>", kPublic },
   { "<bits/unordered_set.h>", kPrivate, "<unordered_set>", kPublic },
+  { "<bits/uses_allocator.h>", kPrivate, "<memory>", kPublic },
   { "<bits/utility.h>", kPrivate, "<utility>", kPublic },
   { "<bits/valarray_after.h>", kPrivate, "<valarray>", kPublic },
   { "<bits/valarray_array.h>", kPrivate, "<valarray>", kPublic },

--- a/iwyu_include_picker.cc
+++ b/iwyu_include_picker.cc
@@ -699,6 +699,7 @@ const IncludeMapEntry libstdcpp_include_map[] = {
   { "<bits/locale_facets.tcc>", kPrivate, "<locale>", kPublic },
   { "<bits/localefwd.h>", kPrivate, "<locale>", kPublic },
   { "<bits/mask_array.h>", kPrivate, "<valarray>", kPublic },
+  { "<bits/memory_resource.h>", kPrivate, "<memory_resource>", kPublic },
   { "<bits/memoryfwd.h>", kPrivate, "<memory>", kPublic },
   { "<bits/move.h>", kPrivate, "<utility>", kPublic },
   { "<bits/nested_exception.h>", kPrivate, "<exception>", kPublic },


### PR DESCRIPTION
As mentioned in #1486 this suppresses a warning due to ie uses of `std::polymorphic_allocator` among the others.
I've also added what's needed for `bits/uses_allocator.h` (see [here](https://github.com/skypjack/entt/actions/runs/8314254276/job/22751212347#step:5:677) for false positive reported by IWYU).