### PR TITLE
Remove redundant debug/safe_iterator.tcc mapping

### DIFF
--- a/gcc.stl.headers.imp
+++ b/gcc.stl.headers.imp
@@ -310,7 +310,6 @@
   # ( cd /usr/crosstool/v12/gcc-4.3.1-glibc-2.3.6-grte/x86_64-unknown-linux-gnu/x86_64-unknown-linux-gnu/include/c++/4.3.1 && grep -R '^ *# *include.*tcc' * | perl -nle 'm/^([^:]+).*[<"]([^>"]+)[>"]/ && print qq@    { include: ["<$2>", private, "<$1>", public ] },@' | sort )
   # I had to manually edit some of the entries to say the map-to is private.
   { include: ["<bits/cmath.tcc>", private, "<cmath>", public ] },
-  { include: ["<debug/safe_iterator.tcc>", private, "<debug/safe_iterator.h>", public ] },
   { include: ["<tr1_impl/random.tcc>", private, "<tr1_impl/random>", private ] },
   # Some bits->bits //includes: A few files in bits re-export
   # symbols from other files in bits.


### PR DESCRIPTION
I added complete mappings for debug/ GCC headers in abc3aeefa0af810e4ec00a2c14bae538568dd8c8, but I failed to notice that debug/safe_local_iterator.tcc was already mapped.

That leads to an assertion failure for conflicting visibilities for:

    include-what-you-use \
        -Xiwyu --no_default_mappings \
        -Xiwyu --mapping_file=gcc.stl.headers.imp \
        ...

Remove the old mapping, it's superseded by the new.