### PR TITLE
Fix handling function references

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -830,8 +830,6 @@ class BaseAstVisitor : public RecursiveASTVisitor<Derived> {
       return true;
 
     if (FunctionDecl* fn_decl = DynCastFrom(expr->getDecl())) {
-      if (!IsImplicitlyInstantiatedDfn(fn_decl))
-        return true;
       if (const auto* call_expr =  // Skip intermediate ImplicitCastExpr node.
           current_ast_node_->GetAncestorAs<CallExpr>(2)) {
         if (call_expr->getDirectCallee() == fn_decl)
@@ -3453,6 +3451,7 @@ class InstantiatedTemplateVisitor
     // the uninstantiated function, so we don't need to re-traverse
     // them here.
     AstFlattenerVisitor nodeset_getter(compiler());
+    ValueSaver<AstFlattenerVisitor::NodeSet> s(&nodes_to_ignore_);
     // This gets to the decl for the (uninstantiated) template-as-written:
     const FunctionDecl* decl_as_written =
         fn_decl->getTemplateInstantiationPattern();

--- a/tests/cxx/funcptrs-i1.h
+++ b/tests/cxx/funcptrs-i1.h
@@ -57,6 +57,9 @@ int FunctionTemplate(Class*) {
 template <typename T>
 IndirectClass FunctionTemplate2();
 
+template <typename T>
+decltype(T::StaticMemberFunction()) FunctionTemplateWithoutDef();
+
 extern template IndirectClass FunctionTemplate2<int>();
 
 template<typename T>
@@ -64,11 +67,19 @@ class ClassTemplate {
  public:
   int MemberFunction() const { return 20; }
 
+  void MemberFunctionUsingTplArg() {
+    T t;
+  }
+
   template<typename R>
   int MemberTemplate() const { return R(50).Value(); }
 
   static int StaticMemberFunction() {
     return 100;
+  }
+
+  static void StaticMemberFunctionUsingTplArg() {
+    T t;
   }
 
   template<typename R>

--- a/tests/cxx/funcptrs.cc
+++ b/tests/cxx/funcptrs.cc
@@ -91,6 +91,11 @@ void NonMemberFunctions() {
   // references.
   // IWYU: FunctionTemplate2 is...*funcptrs-i1.h
   &FunctionTemplate2<int>;
+
+  // IWYU: FunctionTemplateWithoutDef is...*funcptrs-i1.h
+  // IWYU: Class needs a declaration
+  // IWYU: Class is...*funcptrs-i1.h
+  &FunctionTemplateWithoutDef<Class>;
 }
 
 void ClassMembers() {
@@ -201,6 +206,11 @@ void ClassTemplateMembers() {
   // IWYU: Class needs a declaration
   &ClassTemplate<Class>::StaticMemberFunction;
 
+  // IWYU: ClassTemplate is...*funcptrs-i1.h
+  // IWYU: Class needs a declaration
+  // IWYU: Class is...*funcptrs-i1.h
+  &ClassTemplate<Class>::StaticMemberFunctionUsingTplArg;
+
   // IWYU: Retval needs a declaration
   // IWYU: Retval is...*funcptrs-i1.h
   // IWYU: ClassTemplate is...*funcptrs-i1.h
@@ -210,6 +220,11 @@ void ClassTemplateMembers() {
   // IWYU: ClassTemplate is...*funcptrs-i1.h
   // IWYU: Class needs a declaration
   &ClassTemplate<Class>::MemberFunction;
+
+  // IWYU: ClassTemplate is...*funcptrs-i1.h
+  // IWYU: Class needs a declaration
+  // IWYU: Class is...*funcptrs-i1.h
+  &ClassTemplate<Class>::MemberFunctionUsingTplArg;
 
   // IWYU: Retval needs a declaration
   // IWYU: Retval is...*funcptrs-i1.h
@@ -228,6 +243,6 @@ tests/cxx/funcptrs.cc should remove these lines:
 - #include "tests/cxx/funcptrs-d1.h"  // lines XX-XX
 
 The full include-list for tests/cxx/funcptrs.cc:
-#include "tests/cxx/funcptrs-i1.h"  // for Class, ClassTemplate, Enum, Function, FunctionReturningRecordType, FunctionTemplate, FunctionTemplate2, Retval
+#include "tests/cxx/funcptrs-i1.h"  // for Class, ClassTemplate, Enum, Function, FunctionReturningRecordType, FunctionTemplate, FunctionTemplate2, FunctionTemplateWithoutDef, Retval
 
 ***** IWYU_SUMMARY */


### PR DESCRIPTION
Additional filtering of function references has been removed. This fixes reporting of template argument type when the template has no definition in the translation unit but the full type info is needed to build the instantiated function prototype, as well as handling instantiations of regular member functions of class templates. It was a regression introduced in #1300.

To make it possible to do, function reference handling has been decoupled from return type handling. Function references differ from calls in that the return type should not be reported in the former case. It was achieved by means of (not fully) complemetary `if`-conditions inside `TraverseDeclRefExpr` and `IwyuBaseAstVisitor::HandleFunctionCall` functions stating that fn refs should be analyzed only for instantiated template functions with definitions, meanwhile return types should be reported in the opposite case. But it is not fully correct. In fact, the full return type info is required on any function call. It is just convenient to report it on instantiated template visitation because the type may be provided by some `typedef`-ed template argument. But it stops working e.g. when the function template has no definition in the translation unit, just a declaration. This change enables separate improvement of function reference and function call handling.