### PR TITLE
[ci] Remove manual checkout ref logic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,20 +46,8 @@ jobs:
         run: |
           sudo touch /usr/lib/llvm-$LLVM_MAJOR/lib/libclang-$LLVM_MAJOR.so.1
 
-      - name: Select checkout ref (PR)
-        if: github.event_name == 'pull_request'
-        run: |
-          echo "IWYU_CHECKOUT_REF=${{github.event.pull_request.head.sha}}" >> $GITHUB_ENV
-
-      - name: Select checkout ref (push/schedule)
-        if: github.event_name == 'push' || github.event_name == 'schedule'
-        run: |
-          echo "IWYU_CHECKOUT_REF=${{github.sha}}" >> $GITHUB_ENV
-
       - name: Check out branch
         uses: actions/checkout@v4
-        with:
-          ref: ${{env.IWYU_CHECKOUT_REF}}
 
       - name: Build include-what-you-use
         run: |


### PR DESCRIPTION
In 44fa8c7bd042907dd7bb9a42dbefdf1ad346c313, we ran into some undefined
problem when upgrading from actions/checkout@v2 to v3, where the checked
out Git revision changed.

A workaround was added to consistently checkout the PR branch HEAD, or
mainline HEAD for nightly builds.

The GitHub documentation describes the variables used by
actions/checkout by default:
https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request

* GITHUB_SHA: Last merge commit on the GITHUB_REF branch
* GITHUB_REF: PR merge branch refs/pull/PULL_REQUEST_NUMBER/merge

This has always left me confused, but now I think I understand:
GITHUB_REF points to an ephemeral branch where the PR is
non-fast-forward-merged onto its target (typically mainline).

GITHUB_SHA is simply the merge commit at the HEAD of the GITHUB_REF
branch.

The net result of letting actions/checkout decide is that a PR build
will check out GITHUB_SHA, and will run on a tree as-if the PR had
already been merged to mainline, independent of its heritage (i.e. if it
applies without conflict, it need not be fully rebased).

This is a much better default behavior for contributors, because they
don't need to rebase on top of mainline to get e.g. Clang compatibility
fixes or ensure their changes are covered by any new tests on mainline.

It is slightly confusing for an old dog like myself, because the
_revision_ that's built will never exist. However, the _content_ that's
built should be identical after rebase+merge.
