### PR TITLE
[clang compat] Handle new cast kind for HLSL array temporaries

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -1859,6 +1859,7 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
       case clang::CK_AddressSpaceConversion:  // Address spaces are associated
                                               // with pointers, so no need for
                                               // the full type.
+      case clang::CK_HLSLArrayRValue:
       case clang::CK_HLSLVectorTruncation:
         break;
 


### PR DESCRIPTION
The new cast kind CK_HLSLArrayRValue was added in: https://github.com/llvm/llvm-project/commit/9434c083475e42f47383f3067fe2a155db5c6a30

I can't see that it would affect IWYU analysis, so just handle it silently to placate -Wswitch.