### PR TITLE
[ci] Generalize workaround for broken packaging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,9 +38,13 @@ jobs:
                libclang$LLVM_TAG-dev \
                clang$LLVM_TAG
 
+      - name: Capture LLVM major version
+        run: |
+          echo "LLVM_MAJOR=$(ls -1d /usr/lib/llvm-* | sort | tail -n1 | sed 's/.*llvm-//')" >> $GITHUB_ENV
+
       - name: Work around broken packaging
         run: |
-          sudo touch /usr/lib/llvm-19/lib/libclang-19.so.1
+          sudo touch /usr/lib/llvm-$LLVM_MAJOR/lib/libclang-$LLVM_MAJOR.so.1
 
       - name: Select checkout ref (PR)
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
Every time a new major version of the Clang APT packages rolls out, our build breaks because libclang-NN.so.1 is not properly installed. Then after a few weeks it usually sorts itself out, for some reason.

We don't use this shared library, but the LLVM/Clang CMake modules self-verify and fail if the file does not exist.

We've worked around it for a number of releases by simply touching the missing filename after the build fails for the first time. But since this appears to be a recurring problem, generalize to:

* find the latest /usr/lib/llvm-NN directory
* extract the NN major version number
* use the version NN to dynamically generate an .so name to touch

Whether the file exists or not, this should placate CMake.