### PR TITLE
Keep directly included overloads

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -139,6 +139,7 @@
 #include "iwyu_verrs.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/iterator_range.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/ManagedStatic.h"
 #include "llvm/Support/TargetSelect.h"
@@ -2213,18 +2214,15 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
     }
     const NamedDecl* first_decl = *expr->decls_begin();
     OptionalFileEntryRef first_decl_file_entry = GetFileEntry(first_decl);
-    for (OverloadExpr::decls_iterator it = expr->decls_begin();
-         it != expr->decls_end(); ++it) {
-      if (GetFileEntry(*it) != first_decl_file_entry)
+    for (const NamedDecl* decl : expr->decls()) {
+      if (GetFileEntry(decl) != first_decl_file_entry)
         return true;
     }
 
     // For now, we're only worried about function calls.
     // TODO(csilvers): are there other kinds of overloads we need to check?
     const FunctionDecl* arbitrary_fn_decl = nullptr;
-    for (OverloadExpr::decls_iterator it = expr->decls_begin();
-         it != expr->decls_end(); ++it) {
-      const NamedDecl* decl = *it;
+    for (const NamedDecl* decl : expr->decls()) {
       // Sometimes a UsingShadowDecl comes between us and the 'real' decl.
       if (const UsingShadowDecl* using_shadow_decl = DynCastFrom(decl))
         decl = using_shadow_decl->getTargetDecl();

--- a/tests/cxx/overload_expr-d1.h
+++ b/tests/cxx/overload_expr-d1.h
@@ -1,0 +1,31 @@
+//===--- overload_expr-d1.h - test input file for iwyu --------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/overload_expr-i1.h"
+#include "tests/cxx/overload_expr-int.h"
+
+// 'overload_expr-int.h' should be kept because it is directly included
+// (in contrast to '...-float.h').
+
+template <typename T>
+T TplFn1() {
+  return ns::add(T{}, T{});
+}
+
+/**** IWYU_SUMMARY
+
+tests/cxx/overload_expr-d1.h should add these lines:
+
+tests/cxx/overload_expr-d1.h should remove these lines:
+- #include "tests/cxx/overload_expr-i1.h"  // lines XX-XX
+
+The full include-list for tests/cxx/overload_expr-d1.h:
+#include "tests/cxx/overload_expr-int.h"  // for add
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/overload_expr-d2.h
+++ b/tests/cxx/overload_expr-d2.h
@@ -1,0 +1,39 @@
+//===--- overload_expr-d2.h - test input file for iwyu --------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/overload_expr-i1.h"
+
+// IWYU should report any of the files declaring 'ns::add' because it is
+// a qualified name.
+
+template <typename T>
+T TplFn2() {
+  // IWYU: ns::add is...*overload_expr-int.h
+  return ns::add(T{}, T{});
+}
+
+template <typename T>
+void TplFn3() {
+  // It is allowed not to include any definition of 'OverloadedFn' at this
+  // point.
+  return OverloadedFn(T{});
+}
+
+/**** IWYU_SUMMARY
+
+tests/cxx/overload_expr-d2.h should add these lines:
+#include "tests/cxx/overload_expr-int.h"
+
+tests/cxx/overload_expr-d2.h should remove these lines:
+- #include "tests/cxx/overload_expr-i1.h"  // lines XX-XX
+
+The full include-list for tests/cxx/overload_expr-d2.h:
+#include "tests/cxx/overload_expr-int.h"  // for add
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/overload_expr-float.h
+++ b/tests/cxx/overload_expr-float.h
@@ -1,0 +1,17 @@
+//===--- overload_expr-float.h - test input file for iwyu -----------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_OVERLOAD_EXPR_FLOAT_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_OVERLOAD_EXPR_FLOAT_H_
+
+namespace ns {
+  float add(float, float);
+}
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_OVERLOAD_EXPR_FLOAT_H_

--- a/tests/cxx/overload_expr-i1.h
+++ b/tests/cxx/overload_expr-i1.h
@@ -1,0 +1,13 @@
+//===--- overload_expr-i1.h - test input file for iwyu --------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/overload_expr-int.h"
+#include "tests/cxx/overload_expr-float.h"
+#include "tests/cxx/overload_expr-i2.h"
+#include "tests/cxx/overload_expr-i3.h"

--- a/tests/cxx/overload_expr-i2.h
+++ b/tests/cxx/overload_expr-i2.h
@@ -1,0 +1,12 @@
+//===--- overload_expr-i2.h - test input file for iwyu --------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+struct A;
+
+void OverloadedFn(A);

--- a/tests/cxx/overload_expr-i3.h
+++ b/tests/cxx/overload_expr-i3.h
@@ -1,0 +1,10 @@
+//===--- overload_expr-i3.h - test input file for iwyu --------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+void OverloadedFn(char);

--- a/tests/cxx/overload_expr-int.h
+++ b/tests/cxx/overload_expr-int.h
@@ -1,0 +1,17 @@
+//===--- overload_expr-int.h - test input file for iwyu -------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_OVERLOAD_EXPR_INT_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_OVERLOAD_EXPR_INT_H_
+
+namespace ns {
+  int add(int, int);
+}
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_OVERLOAD_EXPR_INT_H_

--- a/tests/cxx/overload_expr.cc
+++ b/tests/cxx/overload_expr.cc
@@ -1,0 +1,39 @@
+//===--- overload_expr.cc - test input file for iwyu ----------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_ARGS: -Xiwyu --check_also="tests/cxx/overload_expr-d?.h" \
+//            -Xiwyu --mapping_file=tests/cxx/overload_expr.imp \
+//            -I .
+
+// Tests various cases of unresolved lookup expression handling.
+
+#include "tests/cxx/overload_expr-d1.h"
+#include "tests/cxx/overload_expr-d2.h"
+
+struct A {};
+
+int main() {
+  TplFn1<int>();
+  // IWYU: OverloadedFn is...*overload_expr-i2.h
+  TplFn3<A>();
+}
+
+/**** IWYU_SUMMARY
+
+tests/cxx/overload_expr.cc should add these lines:
+#include "tests/cxx/overload_expr-i2.h"
+
+tests/cxx/overload_expr.cc should remove these lines:
+
+The full include-list for tests/cxx/overload_expr.cc:
+#include "tests/cxx/overload_expr-d1.h"  // for TplFn1
+#include "tests/cxx/overload_expr-d2.h"  // for TplFn3
+#include "tests/cxx/overload_expr-i2.h"  // for OverloadedFn
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/overload_expr.imp
+++ b/tests/cxx/overload_expr.imp
@@ -1,0 +1,4 @@
+# The presence of the mapping file should not spoil IWYU analysis.
+[
+    { "symbol": ["TplFn1", "private", "\"tests/cxx/overload_expr-d1.h\"", "public"] },
+]


### PR DESCRIPTION
I've decided to report only that overloaded function decls which are already directly `#include`d, as opposed to the suggestion in the removed TODO, so as to avoid lots of unwanted `#include`s in real-world STL cases (things like `std::begin` may be defined in many headers). When no overload is included directly but the name is qualified (i.e. can not be found via ADL), an arbitrary (the first one) overloaded declaration is suggested to keep the code compilable.

Filtering of suitable overloads has not been done.

This fixes #636, #823, #1111, #1293, and, partially, #1250.