### PR TITLE
mappings: Map sig_atomic_t to signal.h

### DIFF
--- a/gcc.symbols.imp
+++ b/gcc.symbols.imp
@@ -97,6 +97,7 @@
   { "symbol": [ "useconds_t", "private", "<sys/types.h>", "public"] },
   { "symbol": [ "wchar_t", "private", "<stddef.h>", "public"] },
   { "symbol": [ "wchar_t", "private", "<stdlib.h>", "public"] },
+  { "symbol": [ "sig_atomic_t", "private", "<signal.h>", "public"] },
   { "symbol": [ "size_t", "private", "<stddef.h>", "public"] },
   { "symbol": [ "size_t", "private", "<signal.h>", "public"] },
   { "symbol": [ "size_t", "private", "<stdio.h>", "public"] },

--- a/iwyu_include_picker.cc
+++ b/iwyu_include_picker.cc
@@ -159,6 +159,7 @@ const IncludeMapEntry libc_symbol_map[] = {
   { "regex_t", kPrivate, "<regex.h>", kPublic },
   { "regmatch_t", kPrivate, "<regex.h>", kPublic },
   { "regoff_t", kPrivate, "<regex.h>", kPublic },
+  { "sig_atomic_t", kPrivate, "<signal.h>", kPublic },
   { "sigevent", kPrivate, "<signal.h>", kPublic },
   { "siginfo_t", kPrivate, "<signal.h>", kPublic },
   { "sigset_t", kPrivate, "<signal.h>", kPublic },


### PR DESCRIPTION
Otherwise on glibc this maps to bits/types/sig_atomic_t.h, which is glibc internal.