### PR TITLE
Add and use DropFrom string util

### DIFF
--- a/iwyu_output.cc
+++ b/iwyu_output.cc
@@ -487,9 +487,9 @@ string MungedForwardDeclareLineForTemplates(const TemplateDecl* decl) {
   ReplaceAll(&line, " final ", " ");
 
   // Get rid of the superclasses, if any (this will nix the body too).
-  line = Split(line, " :", 2)[0];
+  DropFrom(&line, " :");
   // Get rid of the template body, if any (true if no superclasses).
-  line = Split(line, " {", 2)[0];
+  DropFrom(&line, " {");
 
   // The template name is now the last word on the line. Replace it by its
   // fully-qualified form.

--- a/iwyu_string_util.h
+++ b/iwyu_string_util.h
@@ -88,6 +88,19 @@ inline bool StripPast(string* str, const string& substr) {
   return true;
 }
 
+// Finds the first occurrence of substr in *str and removes from *str
+// everything after the occurrence and the occurrence itself.  For
+// example, string s = "What a hat!"; DropFrom(&s, "hat"); will make s
+// "W".
+inline bool DropFrom(string* str, const string& substr) {
+  const size_t pos = str->find(substr);
+  if (pos == string::npos)
+    return false;
+
+  *str = str->substr(0, pos);
+  return true;
+}
+
 // Removes leading whitespace.
 inline void StripWhiteSpaceLeft(string* str) {
   for (string::size_type i = 0; i < str->size(); ++i) {


### PR DESCRIPTION
We had one place in MungedForwardDeclareLineForTemplates where Split was used to cut a string on a separator.

Using Split for this is both noisy at the callsite and non-performant.

Add DropFrom, which finds the separator and drops the rest of the string from there. Use it to simplify MungedForwardDeclareLineForTemplates a little.