### PR TITLE
Report better location for BinaryOperator types

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -2017,10 +2017,14 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
       return true;
 
     for (const Stmt* child : expr->children()) {
-      const Type* type = GetTypeOf(cast<Expr>(child));
+      // Dig past implicit casts and parens to get the real location.
+      const Expr* term = cast<Expr>(child)->IgnoreImpCasts()->IgnoreParens();
+
+      // If the term expression is pointer-typed we need the full types for
+      // pointer arithmetic.
+      const Type* type = GetTypeOf(term);
       if (type->isPointerType()) {
-        // It's a pointer-typed expression.
-        ReportTypeUse(CurrentLoc(), type, DerefKind::RemoveRefsAndPtr);
+        ReportTypeUse(GetLocation(term), type, DerefKind::RemoveRefsAndPtr);
       }
     }
 

--- a/tests/cxx/pointer_arith.cc
+++ b/tests/cxx/pointer_arith.cc
@@ -103,6 +103,34 @@ void BuiltinPointerArithmetic() {
   x = pi - &i;
 }
 
+// Pointer arithmetic is inside a macro, but only using arguments, macro doesn't
+// know about the types involved. Should be reported at expansion.
+#define DISTANCE(ptr1, ptr2) ((ptr1) - (ptr2))
+
+void MacroArgPointerArithmetic() {
+  // IWYU: IndirectClass needs a declaration
+  IndirectClass* p1 = &ic1;
+  // IWYU: IndirectClass needs a declaration
+  IndirectClass* p2 = &ic2;
+
+  // IWYU: IndirectClass is...*indirect.h
+  (void)DISTANCE(p2, p1);
+}
+
+// Pointer arithmetic is entirely inside macro, caller doesn't know about the
+// types involved. Should be reported at spelling inside macro.
+
+// IWYU: IndirectClass needs a declaration
+static IndirectClass* table;
+
+// IWYU: IndirectClass is...*indirect.h
+#define GET_NTH(n) (*(table + n))
+
+void MacroBodyPointerArithmetic() {
+  // Use is entirely contained in macro.
+  (void)GET_NTH(10);
+}
+
 /**** IWYU_SUMMARY
 
 tests/cxx/pointer_arith.cc should add these lines:


### PR DESCRIPTION
The current location for a BinaryOperator points to the actual operator ('+', '-', etc), not the terms we're reporting types for.

This confused the logic in GetCanonicalUseLocation trying to determine who is responsible for the use, so it said the macro spelling was responsible for pointer arithmetic on arguments.

Strip parentheses and implicit casts to get to the actual term expressions, and explicitly use their location.

Add tests for pointer arithmetic in macros, both on macro args and entirely encapsulated in the macro.

Fixes #1483.