### PR TITLE
Remove same-file-overload-set logic at inst side

### DIFF
--- a/tests/cxx/badinc.cc
+++ b/tests/cxx/badinc.cc
@@ -1121,16 +1121,21 @@ int main() {
 
   // Calling an overloaded function.  In the first two cases,
   // CallOverloadedFunctionSameFile() is responsible for the call,
-  // since it's just a single file.  In the second two cases, we
-  // can't know the file required until now (when the templated
-  // function is instantiated).
+  // since it's just a single file. But in general, we cannot know it for sure.
+  // Hence it is reported because the template-defining file doesn't include
+  // the function-defining file directly. In the second two cases, we can't know
+  // the file required until now (when the templated function is instantiated).
+  // IWYU: I1_OverloadedFunction is...*badinc-i1.h
   CallOverloadedFunctionSameFile(5);
+  // IWYU: I1_OverloadedFunction is...*badinc-i1.h
   CallOverloadedFunctionSameFile(5.0f);
   // IWYU: I1_And_I2_OverloadedFunction is...*badinc-i1.h
   CallOverloadedFunctionDifferentFiles(5);
   // IWYU: I1_And_I2_OverloadedFunction is...*badinc-i2.h
   CallOverloadedFunctionDifferentFiles(5.0f);
-  // This should not be an IWYU violation either: the iwyu use is in the fn.
+  // Again, it is reported because the template defining file doesn't include
+  // the function defining file directly.
+  // IWYU: i1_ns::I1_NamespaceTemplateFn is...*badinc-i1.h
   CallOverloadWithUsingShadowDecl(5);
 
   // Calling operator<< when the first argument is a macro.  We should

--- a/tests/cxx/overload_expr-d2.h
+++ b/tests/cxx/overload_expr-d2.h
@@ -25,15 +25,25 @@ void TplFn3() {
   return OverloadedFn(T{});
 }
 
+template <typename T>
+void TplFn4() {
+  // All the overloads which are visible without ADL are in a single file, hence
+  // report it here even if not included directly.
+  // IWYU: OverloadedFn2 is...*overload_expr-i4.h
+  OverloadedFn2(T{});
+}
+
 /**** IWYU_SUMMARY
 
 tests/cxx/overload_expr-d2.h should add these lines:
+#include "tests/cxx/overload_expr-i4.h"
 #include "tests/cxx/overload_expr-int.h"
 
 tests/cxx/overload_expr-d2.h should remove these lines:
 - #include "tests/cxx/overload_expr-i1.h"  // lines XX-XX
 
 The full include-list for tests/cxx/overload_expr-d2.h:
+#include "tests/cxx/overload_expr-i4.h"  // for OverloadedFn2
 #include "tests/cxx/overload_expr-int.h"  // for add
 
 ***** IWYU_SUMMARY */

--- a/tests/cxx/overload_expr-i1.h
+++ b/tests/cxx/overload_expr-i1.h
@@ -11,3 +11,4 @@
 #include "tests/cxx/overload_expr-float.h"
 #include "tests/cxx/overload_expr-i2.h"
 #include "tests/cxx/overload_expr-i3.h"
+#include "tests/cxx/overload_expr-i4.h"

--- a/tests/cxx/overload_expr-i4.h
+++ b/tests/cxx/overload_expr-i4.h
@@ -1,4 +1,4 @@
-//===--- overload_expr-i2.h - test input file for iwyu --------------------===//
+//===--- overload_expr-i4.h - test input file for iwyu --------------------===//
 //
 //                     The LLVM Compiler Infrastructure
 //
@@ -7,12 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-struct A;
+// All the OverloadedFn2 overloads visible without ADL are in the same file.
 
-void OverloadedFn(A);
-
-namespace ns {
-struct B;
-
-void OverloadedFn2(B);
-}  // namespace ns
+void OverloadedFn2(int);
+void OverloadedFn2(char);

--- a/tests/cxx/overload_expr.cc
+++ b/tests/cxx/overload_expr.cc
@@ -18,10 +18,16 @@
 
 struct A {};
 
+namespace ns {
+struct B {};
+}  // namespace ns
+
 int main() {
   TplFn1<int>();
   // IWYU: OverloadedFn is...*overload_expr-i2.h
   TplFn3<A>();
+  // IWYU: OverloadedFn2 is...*overload_expr-i2.h
+  TplFn4<ns::B>();
 }
 
 /**** IWYU_SUMMARY
@@ -33,7 +39,7 @@ tests/cxx/overload_expr.cc should remove these lines:
 
 The full include-list for tests/cxx/overload_expr.cc:
 #include "tests/cxx/overload_expr-d1.h"  // for TplFn1
-#include "tests/cxx/overload_expr-d2.h"  // for TplFn3
-#include "tests/cxx/overload_expr-i2.h"  // for OverloadedFn
+#include "tests/cxx/overload_expr-d2.h"  // for TplFn3, TplFn4
+#include "tests/cxx/overload_expr-i2.h"  // for OverloadedFn, OverloadedFn2
 
 ***** IWYU_SUMMARY */


### PR DESCRIPTION
See discussion in #1525.

Besides, this fixes reporting ADL-found function declarations when all the non-ADL declarations are in a single file. The corresponding test case has been added to `overload_expr`.