### PR TITLE
RFC: Remove same-file-overload-set logic completely

### DIFF
--- a/tests/cxx/badinc.cc
+++ b/tests/cxx/badinc.cc
@@ -341,10 +341,7 @@ template <class T, class U> struct Cc_PTS<T U::*> {
 
 template<class T,int> class Cc_TemplateSubclass : public H_TemplateTypedef { };
 
-// Let's test that we detect overloaded functions correctly when all
-// overloads are in the same file, and then when they're in different files.
 template<typename T> void CallOverloadedFunctionSameFile(T t) {
-  // IWYU: I1_OverloadedFunction is...*badinc-i1.h
   I1_OverloadedFunction(t);
 }
 
@@ -355,10 +352,6 @@ template<typename T> void CallOverloadedFunctionDifferentFiles(T t) {
 }
 
 template<typename T> void CallOverloadWithUsingShadowDecl(T t) {
-  // This is only defined in one place, but because we get to it via
-  // a using expression, it generates a UsingShadowExpr.  Make sure we
-  // "see through" that properly.
-  // IWYU: i1_ns::I1_NamespaceTemplateFn is...*badinc-i1.h
   I1_NamespaceTemplateFn(t);
 }
 
@@ -1119,18 +1112,16 @@ int main() {
   // IWYU: I1_PtrDereferenceClass is...*badinc-i1.h
   local_i1_ptrdereference_class->a();
 
-  // Calling an overloaded function.  In the first two cases,
-  // CallOverloadedFunctionSameFile() is responsible for the call,
-  // since it's just a single file.  In the second two cases, we
-  // can't know the file required until now (when the templated
-  // function is instantiated).
+  // Calling an overloaded function.
+  // IWYU: I1_OverloadedFunction is...*badinc-i1.h
   CallOverloadedFunctionSameFile(5);
+  // IWYU: I1_OverloadedFunction is...*badinc-i1.h
   CallOverloadedFunctionSameFile(5.0f);
   // IWYU: I1_And_I2_OverloadedFunction is...*badinc-i1.h
   CallOverloadedFunctionDifferentFiles(5);
   // IWYU: I1_And_I2_OverloadedFunction is...*badinc-i2.h
   CallOverloadedFunctionDifferentFiles(5.0f);
-  // This should not be an IWYU violation either: the iwyu use is in the fn.
+  // IWYU: i1_ns::I1_NamespaceTemplateFn is...*badinc-i1.h
   CallOverloadWithUsingShadowDecl(5);
 
   // Calling operator<< when the first argument is a macro.  We should

--- a/tests/cxx/overload_expr-d2.h
+++ b/tests/cxx/overload_expr-d2.h
@@ -25,6 +25,11 @@ void TplFn3() {
   return OverloadedFn(T{});
 }
 
+template <typename T>
+void TplFn4() {
+  OverloadedFn2(T{});
+}
+
 /**** IWYU_SUMMARY
 
 tests/cxx/overload_expr-d2.h should add these lines:

--- a/tests/cxx/overload_expr-i1.h
+++ b/tests/cxx/overload_expr-i1.h
@@ -11,3 +11,4 @@
 #include "tests/cxx/overload_expr-float.h"
 #include "tests/cxx/overload_expr-i2.h"
 #include "tests/cxx/overload_expr-i3.h"
+#include "tests/cxx/overload_expr-i4.h"

--- a/tests/cxx/overload_expr-i4.h
+++ b/tests/cxx/overload_expr-i4.h
@@ -1,4 +1,4 @@
-//===--- overload_expr-i2.h - test input file for iwyu --------------------===//
+//===--- overload_expr-i4.h - test input file for iwyu --------------------===//
 //
 //                     The LLVM Compiler Infrastructure
 //
@@ -7,12 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-struct A;
+// All the OverloadedFn2 overloads visible without ADL are in the same file.
 
-void OverloadedFn(A);
-
-namespace ns {
-struct B;
-
-void OverloadedFn2(B);
-}  // namespace ns
+void OverloadedFn2(int);
+void OverloadedFn2(char);

--- a/tests/cxx/overload_expr.cc
+++ b/tests/cxx/overload_expr.cc
@@ -18,10 +18,16 @@
 
 struct A {};
 
+namespace ns {
+struct B {};
+}  // namespace ns
+
 int main() {
   TplFn1<int>();
   // IWYU: OverloadedFn is...*overload_expr-i2.h
   TplFn3<A>();
+  // IWYU: OverloadedFn2 is...*overload_expr-i2.h
+  TplFn4<ns::B>();
 }
 
 /**** IWYU_SUMMARY
@@ -33,7 +39,7 @@ tests/cxx/overload_expr.cc should remove these lines:
 
 The full include-list for tests/cxx/overload_expr.cc:
 #include "tests/cxx/overload_expr-d1.h"  // for TplFn1
-#include "tests/cxx/overload_expr-d2.h"  // for TplFn3
-#include "tests/cxx/overload_expr-i2.h"  // for OverloadedFn
+#include "tests/cxx/overload_expr-d2.h"  // for TplFn3, TplFn4
+#include "tests/cxx/overload_expr-i2.h"  // for OverloadedFn, OverloadedFn2
 
 ***** IWYU_SUMMARY */

--- a/tests/cxx/placement_new.cc
+++ b/tests/cxx/placement_new.cc
@@ -153,7 +153,6 @@ void TaggedNewInTemplate() {
 template <typename T>
 void Reconstruct(T& ref) {
   // IWYU: operator new is...*<new>
-  // IWYU: AddressOf is...*placement_new-i2.h
   new (AddressOf(ref)) T();
 }
 
@@ -163,7 +162,6 @@ tests/cxx/placement_new.cc should add these lines:
 #include <new>
 #include "tests/cxx/indirect.h"
 #include "tests/cxx/placement_new-i1.h"
-#include "tests/cxx/placement_new-i2.h"
 
 tests/cxx/placement_new.cc should remove these lines:
 - #include "tests/cxx/direct.h"  // lines XX-XX
@@ -173,6 +171,5 @@ The full include-list for tests/cxx/placement_new.cc:
 #include <new>  // for align_val_t, nothrow, operator new
 #include "tests/cxx/indirect.h"  // for IndirectClass
 #include "tests/cxx/placement_new-i1.h"  // for ClassTemplate
-#include "tests/cxx/placement_new-i2.h"  // for AddressOf
 
 ***** IWYU_SUMMARY */


### PR DESCRIPTION
See discussion in #1525.

Besides, this fixes reporting ADL-found function declarations when all the non-ADL declarations are in a single file. The corresponding test case has been added to `overload_expr`.

Besides, this fixes #966, #792, #1335, and #1516.