### PR TITLE
Fix IWYU for -xc++-header

### DIFF
--- a/iwyu_driver.cc
+++ b/iwyu_driver.cc
@@ -211,6 +211,7 @@ std::vector<const Command*> FilterJobs(const JobList& jobs) {
   for (const Command& job : jobs) {
     const Action& action = job.getSource();
     if (action.getKind() != Action::CompileJobClass &&
+        action.getKind() != Action::PrecompileJobClass &&
         action.getKind() != Action::PreprocessJobClass) {
       VERRS(2) << "warning: ignoring unsupported job type: "
                << action.getClassName() << "\n";
@@ -330,6 +331,7 @@ bool ExecuteAction(int argc, const char** argv,
       break;
 
     case Action::CompileJobClass:
+    case Action::PrecompileJobClass:
       // Drop compiler job and run IWYU instead.
       action = make_iwyu_action(compilation->getDefaultToolChain());
       break;

--- a/tests/driver/generate_pch.c
+++ b/tests/driver/generate_pch.c
@@ -7,17 +7,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-// Check that IWYU ignores the 'precompile' job produced by a PCH-generating
-// command. Since that's the only job, it proceeds to fail because there's no
-// compiler job to replace.
+// Check that IWYU uses the 'precompile' job produced by a PCH-generating
+// command.
 
 // IWYU_ARGS: -o generate_pch.c.pch -xc-header
 
-// IWYU~: ignoring unsupported job type.*precompile
-// IWYU~: expected exactly one compiler job
+/**** IWYU_SUMMARY(0)
 
-/**** IWYU_SUMMARY(1)
-
-// No IWYU summary expected.
+(tests/driver/generate_pch.c has correct #includes/fwd-decls)
 
 ***** IWYU_SUMMARY */

--- a/tests/driver/use_pch_msvc.c
+++ b/tests/driver/use_pch_msvc.c
@@ -9,13 +9,11 @@
 
 // Check that IWYU fails for MSVC spelling of PCH args.
 
-// IWYU_ARGS: --driver-mode=cl /I . /Yu tests/driver/use_pch_msvc.h
-
-// Clang for some reason creates a precompiler job when /Yu (use PCH) is
-// present. We filter it out, but warn, so expect that warning.
-// IWYU~: ignoring unsupported job type: precompiler
+// IWYU_ARGS: --driver-mode=cl /I . /Yutests/driver/use_pch_msvc.h
 
 // IWYU~: include-what-you-use does not support PCH
+
+#include "tests/driver/use_pch_msvc.h"
 
 /**** IWYU_SUMMARY(1)
 


### PR DESCRIPTION
The following used to work properly:
  $ echo 'void foo() {}' > test.h
  $ include-what-you-use -xc++-header test.h

It's now failing with the error:
  error: unable to handle compilation, expected exactly one compiler job

For c++ headers, clang emits a precompile job action, which IWYU
ignores. Treating this action type the same as a compile job seems to
fix the issue.
