### PR TITLE
Add mapping for glibc's <bits/signum-arch.h>

### DIFF
--- a/gcc.libc.imp
+++ b/gcc.libc.imp
@@ -67,6 +67,7 @@
   { "include": [ "<bits/sigcontext.h>", "private", "<signal.h>", "public"] },
   { "include": [ "<bits/siginfo.h>", "private", "<signal.h>", "public"] },
   { "include": [ "<bits/signum.h>", "private", "<signal.h>", "public"] },
+  { "include": [ "<bits/signum-arch.h>", "private", "<signal.h>", "public"] },
   { "include": [ "<bits/sigset.h>", "private", "<signal.h>", "public"] },
   { "include": [ "<bits/sigstack.h>", "private", "<signal.h>", "public"] },
   { "include": [ "<bits/sigthread.h>", "private", "<signal.h>", "public"] },

--- a/iwyu_include_picker.cc
+++ b/iwyu_include_picker.cc
@@ -347,6 +347,7 @@ const IncludeMapEntry libc_include_map[] = {
   { "<bits/sigcontext.h>", kPrivate, "<signal.h>", kPublic },
   { "<bits/siginfo.h>", kPrivate, "<signal.h>", kPublic },
   { "<bits/signum.h>", kPrivate, "<signal.h>", kPublic },
+  { "<bits/signum-arch.h>", kPrivate, "<signal.h>", kPublic },
   { "<bits/sigset.h>", kPrivate, "<signal.h>", kPublic },
   { "<bits/sigstack.h>", kPrivate, "<signal.h>", kPublic },
   { "<bits/sigthread.h>", kPrivate, "<signal.h>", kPublic },


### PR DESCRIPTION
$ grep Never /usr/include/x86_64-linux-gnu/bits/signum-arch.h
#error "Never include <bits/signum-arch.h> directly; use <signal.h> instead."

---

Revisions:

<details>
<summary>v2</summary>
v2 changes:

-  gcc.libc.imp

```
$ git range-diff master gh/signum-arch signum-arch 
1:  dc616bf ! 1:  e955d94 Add mapping for glibc's <bits/signum-arch.h>
    @@ Commit message
     
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
    + ## gcc.libc.imp ##
    +@@
    +   { "include": [ "<bits/sigcontext.h>", "private", "<signal.h>", "public"] },
    +   { "include": [ "<bits/siginfo.h>", "private", "<signal.h>", "public"] },
    +   { "include": [ "<bits/signum.h>", "private", "<signal.h>", "public"] },
    ++  { "include": [ "<bits/signum-arch.h>", "private", "<signal.h>", "public"] },
    +   { "include": [ "<bits/sigset.h>", "private", "<signal.h>", "public"] },
    +   { "include": [ "<bits/sigstack.h>", "private", "<signal.h>", "public"] },
    +   { "include": [ "<bits/sigthread.h>", "private", "<signal.h>", "public"] },
    +
      ## iwyu_include_picker.cc ##
     @@ iwyu_include_picker.cc: const IncludeMapEntry libc_include_map[] = {
        { "<bits/sigcontext.h>", kPrivate, "<signal.h>", kPublic },
```
</details>