### PR TITLE
Add mappings for wint_t

### DIFF
--- a/gcc.symbols.imp
+++ b/gcc.symbols.imp
@@ -97,6 +97,7 @@
   { "symbol": [ "useconds_t", "private", "<sys/types.h>", "public"] },
   { "symbol": [ "wchar_t", "private", "<stddef.h>", "public"] },
   { "symbol": [ "wchar_t", "private", "<stdlib.h>", "public"] },
+  { "symbol": [ "wint_t", "private", "<wchar.h>", "public"] },
   { "symbol": [ "sig_atomic_t", "private", "<signal.h>", "public"] },
   { "symbol": [ "size_t", "private", "<stddef.h>", "public"] },
   { "symbol": [ "size_t", "private", "<signal.h>", "public"] },

--- a/iwyu_include_picker.cc
+++ b/iwyu_include_picker.cc
@@ -181,6 +181,7 @@ const IncludeMapEntry libc_symbol_map[] = {
   { "useconds_t", kPrivate, "<sys/types.h>", kPublic },
   { "wchar_t", kPrivate, "<stddef.h>", kPublic },
   { "wchar_t", kPrivate, "<stdlib.h>", kPublic },
+  { "wint_t", kPrivate, "<wchar.h>", kPublic },
   // It is unspecified if the cname headers provide ::size_t.
   // <locale.h> is the one header which defines NULL but not size_t.
   { "size_t", kPrivate, "<stddef.h>", kPublic },  // 'canonical' location for size_t


### PR DESCRIPTION
And I've documented the type in a new manual page:

```
wint_t(3type)                                                     wint_t(3type)

NAME
     wint_t, WEOF - integer type capable of storing any wchar_t of WEOF

LIBRARY
     Standard C library (libc)

SYNOPSIS
     #include <wchar.h>

     typedef /* ... */ wint_t;

     #define WEOF        /* ... */

     #include <stdint.h>

     #define WINT_WIDTH  /* ... */
     #define WINT_MAX    /* ... */
     #define WINT_MIN    /* ... */

DESCRIPTION
     wint_t  is a type used in functions that work with wide characters.  It is
     capable of storing any valid wchar_t or WEOF.  It is an integer type.

     WEOF is used by wide‐character functions to indicate the end of  an  input
     file or an error.  It is of type wint_t.

STANDARDS
     C11, POSIX.1‐2008.

HISTORY
     C99, POSIX.1‐2001.

     The WINT_WIDTH macro was added in C23.

NOTES
     The following header also provides wint_t and WEOF: <wctype.h>.

SEE ALSO
     wchar_t(3type), fputwc(3)

Linux man‐pages 6.7‐85‐gbaa3a65e1  2024‐05‐02                     wint_t(3type)
```