### PR TITLE
Add mappings for <stdarg.h> macros

### DIFF
--- a/gcc.symbols.imp
+++ b/gcc.symbols.imp
@@ -121,9 +121,13 @@
   { "symbol": [ "MAXHOSTNAMELEN", "private", "<protocols/timed.h>", "public"] },
   { "symbol": [ "SIGABRT", "private", "<signal.h>", "public"] },
   { "symbol": [ "SIGCHLD", "private", "<signal.h>", "public"] },
+  { "symbol": [ "va_arg", "private", "<stdarg.h>", "public"] },
+  { "symbol": [ "va_copy", "private", "<stdarg.h>", "public"] },
+  { "symbol": [ "va_end", "private", "<stdarg.h>", "public"] },
   { "symbol": [ "va_list", "private", "<stdarg.h>", "public"] },
   { "symbol": [ "va_list", "private", "<stdio.h>", "public"] },
   { "symbol": [ "va_list", "private", "<wchar.h>", "public"] },
+  { "symbol": [ "va_start", "private", "<stdarg.h>", "public"] },
   # These are symbols that could be defined in either stdlib.h or
   # malloc.h, but we always want the stdlib location.
   { "symbol": [ "malloc", "private", "<stdlib.h>", "public"] },

--- a/iwyu_include_picker.cc
+++ b/iwyu_include_picker.cc
@@ -206,9 +206,13 @@ const IncludeMapEntry libc_symbol_map[] = {
   { "MAXHOSTNAMELEN", kPrivate, "<protocols/timed.h>", kPublic },
   { "SIGABRT", kPrivate, "<signal.h>", kPublic },
   { "SIGCHLD", kPrivate, "<signal.h>", kPublic },
+  { "va_arg", kPrivate, "<stdarg.h>", kPublic },
+  { "va_copy", kPrivate, "<stdarg.h>", kPublic },
+  { "va_end", kPrivate, "<stdarg.h>", kPublic },
   { "va_list", kPrivate, "<stdarg.h>", kPublic },
   { "va_list", kPrivate, "<stdio.h>", kPublic },
   { "va_list", kPrivate, "<wchar.h>", kPublic },
+  { "va_start", kPrivate, "<stdarg.h>", kPublic },
   // These are symbols that could be defined in either stdlib.h or
   // malloc.h, but we always want the stdlib location.
   { "malloc", kPrivate, "<stdlib.h>", kPublic },


### PR DESCRIPTION
As documented in stdarg(3):

```
stdarg(3)                   Library Functions Manual                  stdarg(3)

NAME
     stdarg, va_start, va_arg, va_end, va_copy - variable argument lists

LIBRARY
     Standard C library (libc, -lc)

SYNOPSIS
     #include <stdarg.h>

     void va_start(va_list ap, last);
     type va_arg(va_list ap, type);
     void va_end(va_list ap);
     void va_copy(va_list dest, va_list src);

...
```

---

Revisions:

<details>
<summary>v2</summary>
v2 changes:

-  sort

```
$ git range-diff --creation-factor=99 master gh/stdarg stdarg 
1:  64ce106 ! 1:  a1244c8 Add mappings for <stdarg.h> macros
    @@ gcc.symbols.imp
        { "symbol": [ "MAXHOSTNAMELEN", "private", "<protocols/timed.h>", "public"] },
        { "symbol": [ "SIGABRT", "private", "<signal.h>", "public"] },
        { "symbol": [ "SIGCHLD", "private", "<signal.h>", "public"] },
    -+  { "symbol": [ "va_start", "private", "<stdarg.h>", "public"] },
     +  { "symbol": [ "va_arg", "private", "<stdarg.h>", "public"] },
    -+  { "symbol": [ "va_end", "private", "<stdarg.h>", "public"] },
     +  { "symbol": [ "va_copy", "private", "<stdarg.h>", "public"] },
    ++  { "symbol": [ "va_end", "private", "<stdarg.h>", "public"] },
        { "symbol": [ "va_list", "private", "<stdarg.h>", "public"] },
        { "symbol": [ "va_list", "private", "<stdio.h>", "public"] },
        { "symbol": [ "va_list", "private", "<wchar.h>", "public"] },
    ++  { "symbol": [ "va_start", "private", "<stdarg.h>", "public"] },
    +   # These are symbols that could be defined in either stdlib.h or
    +   # malloc.h, but we always want the stdlib location.
    +   { "symbol": [ "malloc", "private", "<stdlib.h>", "public"] },
     
      ## iwyu_include_picker.cc ##
     @@ iwyu_include_picker.cc: const IncludeMapEntry libc_symbol_map[] = {
        { "MAXHOSTNAMELEN", kPrivate, "<protocols/timed.h>", kPublic },
        { "SIGABRT", kPrivate, "<signal.h>", kPublic },
        { "SIGCHLD", kPrivate, "<signal.h>", kPublic },
    -+  { "va_start", kPrivate, "<stdarg.h>", kPublic },
     +  { "va_arg", kPrivate, "<stdarg.h>", kPublic },
    -+  { "va_end", kPrivate, "<stdarg.h>", kPublic },
     +  { "va_copy", kPrivate, "<stdarg.h>", kPublic },
    ++  { "va_end", kPrivate, "<stdarg.h>", kPublic },
        { "va_list", kPrivate, "<stdarg.h>", kPublic },
        { "va_list", kPrivate, "<stdio.h>", kPublic },
        { "va_list", kPrivate, "<wchar.h>", kPublic },
    ++  { "va_start", kPrivate, "<stdarg.h>", kPublic },
    +   // These are symbols that could be defined in either stdlib.h or
    +   // malloc.h, but we always want the stdlib location.
    +   { "malloc", kPrivate, "<stdlib.h>", kPublic },
```
</details>