### PR TITLE
[clang compat] Use StringRef::operator==

### DIFF
--- a/iwyu_path_util.h
+++ b/iwyu_path_util.h
@@ -91,8 +91,8 @@ bool IsSystemIncludeFile(const string& filepath);
 // Returns true if argument is one of the special filenames used by Clang for
 // implicit buffers ("<built-in>", "<command-line>", etc).
 inline bool IsSpecialFilename(llvm::StringRef name) {
-  return (name.equals("<built-in>") || name.equals("<command line>") ||
-          name.equals("<scratch space>") || name.equals("<inline asm>"));
+  return (name == "<built-in>" || name == "<command line>" ||
+          name == "<scratch space>" || name == "<inline asm>");
 }
 
 }  // namespace include_what_you_use


### PR DESCRIPTION
llvm/llvm-project@de483ad513895c0adf7f21c7001c30f031998ea3 marked StringRef::equals deprecated.

Update our only use to overloaded operator==.