### PR TITLE
[clang compat] Update getExternLoc to getExternKeywordLoc

### DIFF
--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -1131,7 +1131,7 @@ bool IsExplicitInstantiationDefinitionAsWritten(
   // the 'extern' keyword location info.
   return decl->getSpecializationKind() ==
              clang::TSK_ExplicitInstantiationDefinition &&
-         decl->getExternLoc().isInvalid();
+         decl->getExternKeywordLoc().isInvalid();
 }
 
 bool IsInInlineNamespace(const Decl* decl) {


### PR DESCRIPTION
llvm/llvm-project@12028373020739b388eb2b8141742509f1764e3c renamed ClassTemplateSpecializationDecl::getExternLoc to getExternKeywordLoc.

Update our only use.