### PR TITLE
[clang compat] Fix explicit instantiation handling

### DIFF
--- a/iwyu_ast_util.h
+++ b/iwyu_ast_util.h
@@ -51,6 +51,11 @@ class TypeDecl;
 class ValueDecl;
 }  // namespace clang
 
+namespace llvm {
+template <typename>
+class ArrayRef;
+}  // namespace llvm
+
 namespace include_what_you_use {
 
 using std::map;
@@ -613,7 +618,7 @@ TemplateInstantiationData GetTplInstDataForFunction(
 // return the template decl, which provides the actual class body.
 // We try to return a decl that's also a definition, when possible.
 const clang::NamedDecl* GetInstantiatedFromDecl(
-    const clang::CXXRecordDecl* class_decl);
+    const clang::NamedDecl* class_decl);
 
 // For an implicitly instantiated templated c++ class -- that is, a
 // class like vector<int> that isn't explicitly written in the source
@@ -835,6 +840,11 @@ bool HasImplicitConversionConstructor(const clang::Type* type);
 // result for any input that's not a template specialization type.
 TemplateInstantiationData GetTplInstDataForClass(
     const clang::Type* type,
+    std::function<set<const clang::Type*>(const clang::Type*)> provided_getter);
+
+TemplateInstantiationData GetTplInstDataForClass(
+    llvm::ArrayRef<clang::TemplateArgument> written_tpl_args,
+    const clang::ClassTemplateSpecializationDecl* cls_tpl_decl,
     std::function<set<const clang::Type*>(const clang::Type*)> provided_getter);
 
 // Like GetTplInstDataForClass, but if a type has

--- a/tests/cxx/expl_inst_select.cc
+++ b/tests/cxx/expl_inst_select.cc
@@ -15,7 +15,6 @@
 
 // An explicit instantiation definition anchors a prior declaration.
 // IWYU: Template is...*expl_inst_select-i1.h
-// IWYU: Template is...*expl_inst_select-i2.h.*for explicit instantiation
 template class Template<char>;
 
 // An explicit instantiation declaration for later use.

--- a/tests/cxx/explicit_instantiation-template.h
+++ b/tests/cxx/explicit_instantiation-template.h
@@ -35,6 +35,16 @@ class ClassWithMethodUsingPtr {
   }
 };
 
+template <typename, typename = void>
+class TplWithDefArg {};
+
+template <typename T>
+class TplWithDefArg<int, T> {};
+
+constexpr int getInt() {
+  return 1;
+}
+
 #endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_EXPLICIT_INSTANTIATION_TEMPLATE_H_
 
 /**** IWYU_SUMMARY

--- a/tests/cxx/explicit_instantiation.cc
+++ b/tests/cxx/explicit_instantiation.cc
@@ -94,6 +94,23 @@ template class ClassWithMethodUsingPtr<IndirectClass>;
 // IWYU: IndirectClass is...*indirect.h
 template class ClassWithUsingMethod2<IndirectClass>;
 
+// IWYU should not forward-declare templates with default args. Test that
+// an explicit instantiation after the template spec reference doesn't muss
+// the tool.
+// IWYU: TplWithDefArg is...*explicit_instantiation-template.h
+TplWithDefArg<int>* p = nullptr;
+// IWYU: TplWithDefArg is...*explicit_instantiation-template.h
+extern template class TplWithDefArg<int>;
+
+template <typename>
+class TplUsingNondependentDecl {
+  // IWYU: getInt is...*explicit_instantiation-template.h
+  static constexpr int i = getInt();
+};
+
+// No reporting getInt here.
+template class TplUsingNondependentDecl<void>;
+
 /**** IWYU_SUMMARY
 
 tests/cxx/explicit_instantiation.cc should add these lines:
@@ -105,7 +122,7 @@ tests/cxx/explicit_instantiation.cc should remove these lines:
 
 The full include-list for tests/cxx/explicit_instantiation.cc:
 #include "tests/cxx/explicit_instantiation-spec.h"  // for Template
-#include "tests/cxx/explicit_instantiation-template.h"  // for ClassWithMethodUsingPtr, ClassWithUsingMethod, Template
+#include "tests/cxx/explicit_instantiation-template.h"  // for ClassWithMethodUsingPtr, ClassWithUsingMethod, Template, TplWithDefArg, getInt
 #include "tests/cxx/explicit_instantiation-template2.h"  // for ClassWithUsingMethod2
 #include "tests/cxx/indirect.h"  // for IndirectClass, IndirectTemplate
 

--- a/tests/cxx/explicit_instantiation2.cc
+++ b/tests/cxx/explicit_instantiation2.cc
@@ -19,7 +19,6 @@
 // Positive scenarios:
 // 1a/1b: Implicit instantiation before and after an explicit instantiation
 //        definition (2), as it affects the semantics.
-// 2: Explicit instantiation definition.
 // 3: Full use in a template, provided as an explicit parameter.
 // 5: Full use in a template, provided as an default parameter.
 // 7: Full use in a template, provided as a template template parameter.
@@ -27,6 +26,7 @@
 //
 // Negative scenarios, where the dependent template specialization is not
 // required, or it does not provide an explicit instantiation:
+// 2: Explicit instantiation definition.
 // 4: Fwd-decl use in a template, provided as an explicit parameter.
 // 6: Fwd-decl use in a template, provided as a default parameter.
 // 9: Implicit instantiation of Template<int>
@@ -40,7 +40,6 @@
 Template<bool> t1a; // 1a
 
 // IWYU: Template is...*explicit_instantiation-template.h
-// IWYU: Template is...*template_bool.h.*for explicit instantiation
 template class Template<bool>;  // 2
 
 // Included explicit instantiation no longer reported here as a local definition


### PR DESCRIPTION
llvm/llvm-project@12028373020739b388eb2b8141742509f1764e3c removed `TemplateSpecializationType` child node from
`ClassTemplateSpecializationDecl`, replacing it just with template arguments.

To maintain instantiation scanning, the new `InstantiatedTemplateVisitor` interface and other functions have been introduced which don't require `TemplateSpecializationType`. They may be further reused for handling the cases then a specific `TemplateSpecializationType` is lost.

The comment in `VisitClassTemplateSpecializationDecl` was wrong: it is not clang but IWYU `GetLocation` function which attributes `ClassTemplateSpecializationDecl` to the original template location. An exception for explicit instantiations has been added to it. However, method declarations should still be attributed to the class template definition, hence the change for them to maintain the old behavior.

Because `GetLocation` doesn't "canonicalize" explicit instantiation locations now, the change in `VisitTemplateSpecializationType` is needed to handle the cases when the instantiation is explicit (as opposed to implicit ones). Besides, it looks more straightforward to report template declarations directly, not through
`ClassTemplateSpecializationDecl`.

A couple of new test cases added to make sure that the work has been done properly.

One functional change: explicit instantiation definitions don't require explicit instantiation declarations. [I think it was just useless](https://github.com/include-what-you-use/include-what-you-use/pull/1202#discussion_r1639933032).