### PR TITLE
[iwyu_tool] Default to -j=0 and infer the core count in that case

### DIFF
--- a/iwyu_tool.py
+++ b/iwyu_tool.py
@@ -497,7 +497,10 @@ def _bootstrap(sys_argv):
                         choices=FORMATTERS.keys(), default=DEFAULT_FORMAT,
                         help='Output format (default: %s)' % DEFAULT_FORMAT)
     parser.add_argument('-j', '--jobs', type=int, default=1,
-                        help='Number of concurrent subprocesses')
+                        nargs='?', const=0,
+                        help=('Number of concurrent subprocesses. If zero, '
+                              'will try to match the logical cores of the '
+                              'system.'))
     parser.add_argument('-l', '--load', type=float, default=0,
                         help='Do not start new jobs if the 1min load average is greater than the provided value')
     parser.add_argument('-p', metavar='<build-path>', required=True,
@@ -517,8 +520,12 @@ def _bootstrap(sys_argv):
     argv, extra_args = partition_args(sys_argv[1:])
     args = parser.parse_args(argv)
 
+    jobs = args.jobs
+    if jobs == 0:
+        jobs = os.cpu_count() or 1
+
     return main(args.dbpath, args.source, args.verbose,
-                FORMATTERS[args.output_format], args.jobs, args.load, extra_args)
+                FORMATTERS[args.output_format], jobs, args.load, extra_args)
 
 
 if __name__ == '__main__':

--- a/iwyu_tool.py
+++ b/iwyu_tool.py
@@ -502,7 +502,8 @@ def _bootstrap(sys_argv):
                               'will try to match the logical cores of the '
                               'system.'))
     parser.add_argument('-l', '--load', type=float, default=0,
-                        help='Do not start new jobs if the 1min load average is greater than the provided value')
+                        help=('Do not start new jobs if the 1min load average '
+                              'is greater than the provided value'))
     parser.add_argument('-p', metavar='<build-path>', required=True,
                         help='Compilation database path', dest='dbpath')
     parser.add_argument('source', nargs='*',

--- a/iwyu_tool_test.py
+++ b/iwyu_tool_test.py
@@ -363,6 +363,35 @@ class BootstrapTests(unittest.TestCase):
         self.assertEqual(['arg1', '--', 'another_arg1'],
                          self.main.call_args['extra_args'])
 
+    def test_jobs_normal(self):
+        """ Nonzero values for -j are forwarded as they are. """
+        argv = ['iwyu_tool.py', '-p', '.', '-j', '4']
+        iwyu_tool._bootstrap(argv)
+        self.assertEqual(4, self.main.call_args['jobs'])
+
+
+    def test_jobs_zero(self):
+        """ -j=0 is translated to a nonzero job count. """
+        argv = ['iwyu_tool.py', '-p', '.', '-j', '0']
+        iwyu_tool._bootstrap(argv)
+        self.assertIsNotNone(self.main.call_args['jobs'])
+        self.assertLess(0, self.main.call_args['jobs'],
+                        'The automatically chosen job count should be >0.')
+
+    def test_jobs_novalue(self):
+        """ It is allowed to use -j without a value. """
+        argv = ['iwyu_tool.py', '-j', '-p', '.']
+        iwyu_tool._bootstrap(argv)
+        self.assertIsNotNone(self.main.call_args['jobs'])
+        self.assertLess(0, self.main.call_args['jobs'],
+                        'The automatically chosen job count should be >0.')
+
+    def test_jobs_default(self):
+        """ By default, we run singlethreaded. """
+        argv = ['iwyu_tool.py', '-p', '.']
+        iwyu_tool._bootstrap(argv)
+        self.assertEqual(1, self.main.call_args['jobs'])
+
 
 class CompilationDBTests(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Make the behavior of the -j argument more similar to other tools which offer it. Instead of hanging forever when "zero jobs" are requested, attempt to automatically pick a job count suitable for the current system. Default to this behavior if the user has not explicitly specified some other job count.