### PR TITLE
Map bits/chrono.h to chrono

### DIFF
--- a/gcc.stl.headers.imp
+++ b/gcc.stl.headers.imp
@@ -21,6 +21,7 @@
   { "include": ["<bits/c++0x_warning.h>", "private", "<iosfwd>", "public"] },
   { "include": ["<bits/charconv.h>", "private", "<charconv>", "public"] },
   { "include": ["<bits/char_traits.h>", "private", "<string>", "public"] },
+  { "include": ["<bits/chrono.h>", "private", "<chrono>", "public"] },
   { "include": ["<bits/codecvt.h>", "private", "<locale>", "public"] },
   { "include": ["<bits/concept_check.h>", "private", "<iterator>", "public"] },
   { "include": ["<bits/cpp_type_traits.h>", "private", "<ext/type_traits>", "public"] },

--- a/iwyu_include_picker.cc
+++ b/iwyu_include_picker.cc
@@ -830,6 +830,7 @@ const IncludeMapEntry libstdcpp_include_map[] = {
   { "<bits/c++allocator.h>", kPrivate, "<memory>", kPublic },
   { "<bits/c++io.h>", kPrivate, "<ios>", kPublic },
   { "<bits/c++locale.h>", kPrivate, "<locale>", kPublic },
+  { "<bits/chrono.h>", kPrivate, "<chrono>", kPublic },
   { "<bits/cpu_defines.h>", kPrivate, "<iosfwd>", kPublic },
   { "<bits/ctype_base.h>", kPrivate, "<locale>", kPublic },
   { "<bits/ctype_inline.h>", kPrivate, "<locale>", kPublic },


### PR DESCRIPTION
As discussed in https://github.com/include-what-you-use/include-what-you-use/issues/1552

Not sure if `@` is needed