### PR TITLE
Report unresolved references to variable templates

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -2242,8 +2242,7 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
       }
       return true;
     }
-    // For now, we're only worried about function calls.
-    // TODO(csilvers): are there other kinds of overloads we need to check?
+
     const FunctionDecl* arbitrary_fn_decl = nullptr;
     for (const NamedDecl* decl : expr->decls()) {
       // Sometimes a UsingShadowDecl comes between us and the 'real' decl.
@@ -2263,8 +2262,8 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
     // end up being the built-in form of the operator.  (Even if the
     // only operator==() we see is in foo.h, we don't need to #include
     // foo.h if the only call to operator== we see is on two integers.)
-    if (arbitrary_fn_decl && !arbitrary_fn_decl->isOverloadedOperator())
-      ReportDeclUse(CurrentLoc(), arbitrary_fn_decl);
+    if (!arbitrary_fn_decl || !arbitrary_fn_decl->isOverloadedOperator())
+      ReportDeclUse(CurrentLoc(), first_decl);
     return true;
   }
 

--- a/tests/cxx/badinc.cc
+++ b/tests/cxx/badinc.cc
@@ -137,7 +137,6 @@ using namespace i1_ns2;
 using i1_ns3::i1_int_global3;
 namespace cc_ns_alias = i1_ns4;
 using i1_ns::I1_NamespaceStruct;
-// IWYU: i1_ns::I1_NamespaceTemplateFn is...*badinc-i1.h
 using i1_ns::I1_NamespaceTemplateFn;
 // TODO(csilvers): mark this using declaration as redundant and remove it?
 // IWYU: i1_ns::I1_UnusedNamespaceStruct needs a declaration

--- a/tests/cxx/overload_expr-d1.h
+++ b/tests/cxx/overload_expr-d1.h
@@ -18,14 +18,22 @@ T TplFn1() {
   return ns::add(T{}, T{});
 }
 
+template <typename T>
+void TplFnReferringVarTpl() {
+  // IWYU: var_tpl is...*overload_expr-i4.h
+  (void)var_tpl<T>;
+}
+
 /**** IWYU_SUMMARY
 
 tests/cxx/overload_expr-d1.h should add these lines:
+#include "tests/cxx/overload_expr-i4.h"
 
 tests/cxx/overload_expr-d1.h should remove these lines:
 - #include "tests/cxx/overload_expr-i1.h"  // lines XX-XX
 
 The full include-list for tests/cxx/overload_expr-d1.h:
+#include "tests/cxx/overload_expr-i4.h"  // for var_tpl
 #include "tests/cxx/overload_expr-int.h"  // for add
 
 ***** IWYU_SUMMARY */

--- a/tests/cxx/overload_expr-i4.h
+++ b/tests/cxx/overload_expr-i4.h
@@ -7,7 +7,16 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_OVERLOAD_EXPR_I4_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_OVERLOAD_EXPR_I4_H_
+
 // All the OverloadedFn2 overloads visible without ADL are in the same file.
 
 void OverloadedFn2(int);
 void OverloadedFn2(char);
+
+// Variable template.
+template <typename>
+int var_tpl;
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_OVERLOAD_EXPR_I4_H_


### PR DESCRIPTION
The change in `badinc.cc` is because `I1_NamespaceTemplateFn` shadow decl is now reported on `CallOverloadWithUsingShadowDecl` scanning, hence using-declaration is considered as being used and may not require `#include` by itself (as for the other using-decls). If its reference is removed from `CallOverloadWithUsingShadowDecl`, the suggestion comes back, as it should be.

This fixes #792, #966, #1335, #1516, and #1558.