### PR TITLE
Reduce 'FILE' mappings to just the canonical header

### DIFF
--- a/gcc.symbols.imp
+++ b/gcc.symbols.imp
@@ -30,7 +30,6 @@
   { "symbol": [ "fenv_t", "private", "<fenv.h>", "public"] },
   { "symbol": [ "fexcept_t", "private", "<fenv.h>", "public"] },
   { "symbol": [ "FILE", "private", "<stdio.h>", "public"] },
-  { "symbol": [ "FILE", "private", "<wchar.h>", "public"] },
   { "symbol": [ "float_t", "private", "<math.h>", "public"] },
   { "symbol": [ "fsblkcnt_t", "private", "<sys/types.h>", "public"] },
   { "symbol": [ "fsfilcnt_t", "private", "<sys/types.h>", "public"] },

--- a/iwyu_include_picker.cc
+++ b/iwyu_include_picker.cc
@@ -113,7 +113,6 @@ const IncludeMapEntry libc_symbol_map[] = {
   { "fenv_t", kPrivate, "<fenv.h>", kPublic },
   { "fexcept_t", kPrivate, "<fenv.h>", kPublic },
   { "FILE", kPrivate, "<stdio.h>", kPublic },
-  { "FILE", kPrivate, "<wchar.h>", kPublic },
   { "float_t", kPrivate, "<math.h>", kPublic },
   { "fsblkcnt_t", kPrivate, "<sys/types.h>", kPublic },
   { "fsfilcnt_t", kPrivate, "<sys/types.h>", kPublic },


### PR DESCRIPTION
<wchar.h> is guaranteed by the relevant standards, but is not the canonical include for FILE.
To be strict with IWYU guidelines, remove that mapping.

Link: <https://github.com/include-what-you-use/include-what-you-use/issues/1531>
Link: <https://github.com/include-what-you-use/include-what-you-use/issues/1286>
Link: <https://github.com/include-what-you-use/include-what-you-use/issues/1278>
Link: <https://github.com/include-what-you-use/include-what-you-use/pull/1344>
Link: <https://github.com/include-what-you-use/include-what-you-use/pull/1283>
Reported-by: @firewave
Cc: @kimgr 