### PR TITLE
Reduce 'timespec' mappings to just the canonical header

### DIFF
--- a/gcc.symbols.imp
+++ b/gcc.symbols.imp
@@ -88,7 +88,6 @@
   { "symbol": [ "time_t", "private", "<sys/types.h>", "public"] },
   { "symbol": [ "timer_t", "private", "<sys/types.h>", "public"] },
   { "symbol": [ "timespec", "private", "<time.h>", "public"] },
-  { "symbol": [ "timespec", "private", "<signal.h>", "public"] },
   { "symbol": [ "timeval", "private", "<sys/time.h>", "public"] },
   { "symbol": [ "tm", "private", "<time.h>", "public"] },
   { "symbol": [ "u_char", "private", "<sys/types.h>", "public"] },

--- a/iwyu_include_picker.cc
+++ b/iwyu_include_picker.cc
@@ -172,7 +172,6 @@ const IncludeMapEntry libc_symbol_map[] = {
   { "time_t", kPrivate, "<sys/types.h>", kPublic },
   { "timer_t", kPrivate, "<sys/types.h>", kPublic },
   { "timespec", kPrivate, "<time.h>", kPublic },
-  { "timespec", kPrivate, "<signal.h>", kPublic },
   { "timeval", kPrivate, "<sys/time.h>", kPublic },
   { "tm", kPrivate, "<time.h>", kPublic },
   { "u_char", kPrivate, "<sys/types.h>", kPublic },


### PR DESCRIPTION
<signal.h> is guaranteed by the relevant standards, but is not the canonical include for timespec.
To be strict with IWYU guidelines, remove that mapping.