### PR TITLE
Reduce 'wchar_t' mappings to just the canonical header

### DIFF
--- a/gcc.symbols.imp
+++ b/gcc.symbols.imp
@@ -94,7 +94,6 @@
   { "symbol": [ "uid_t", "private", "<sys/types.h>", "public"] },
   { "symbol": [ "useconds_t", "private", "<sys/types.h>", "public"] },
   { "symbol": [ "wchar_t", "private", "<stddef.h>", "public"] },
-  { "symbol": [ "wchar_t", "private", "<stdlib.h>", "public"] },
   { "symbol": [ "wint_t", "private", "<wchar.h>", "public"] },
   { "symbol": [ "sig_atomic_t", "private", "<signal.h>", "public"] },
   { "symbol": [ "size_t", "private", "<stddef.h>", "public"] },

--- a/iwyu_include_picker.cc
+++ b/iwyu_include_picker.cc
@@ -178,7 +178,6 @@ const IncludeMapEntry libc_symbol_map[] = {
   { "uid_t", kPrivate, "<sys/types.h>", kPublic },
   { "useconds_t", kPrivate, "<sys/types.h>", kPublic },
   { "wchar_t", kPrivate, "<stddef.h>", kPublic },
-  { "wchar_t", kPrivate, "<stdlib.h>", kPublic },
   { "wint_t", kPrivate, "<wchar.h>", kPublic },
   // It is unspecified if the cname headers provide ::size_t.
   // <locale.h> is the one header which defines NULL but not size_t.


### PR DESCRIPTION
<stdlib.h> is guaranteed by the relevant standards, but is not the canonical include for wchar_t.
To be strict with IWYU guidelines, remove that mapping.