### PR TITLE
Collect types provided by class template alias

### DIFF
--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -1594,6 +1594,7 @@ TemplateInstantiationData GetTplInstDataForClass(
     const Type* type, function<set<const Type*>(const Type*)> provided_getter) {
   TemplateInstantiationData result =
       GetTplInstDataForClassNoComponentTypes(type, provided_getter);
+  InsertAllInto(provided_getter(type), &result.provided_types);
   return TemplateInstantiationData{
       ResugarTypeComponents(
           result.resugar_map),  // add in the decomposition of retval

--- a/tests/cxx/typedef_in_template-i1.h
+++ b/tests/cxx/typedef_in_template-i1.h
@@ -16,4 +16,8 @@ class Class1 {};
 class IndirectClass;
 using NonProviding = IndirectClass;
 
+template <typename>
+struct Identity;
+using NonProvidingNested = Identity<IndirectClass>;
+
 #endif // INCLUDE_WHAT_YOU_USE_TESTS_CXX_TYPEDEF_IN_TEMPLATE_I1_H_

--- a/tests/cxx/typedef_in_template.cc
+++ b/tests/cxx/typedef_in_template.cc
@@ -143,6 +143,9 @@ struct Outer {
 // IWYU: IndirectClass is...*indirect.h
 using Providing = IndirectClass;
 
+// IWYU: IndirectClass is...*indirect.h
+using ProvidingNested = Identity<IndirectClass>;
+
 void ArgumentTypeProvision() {
   Identity<Providing>::Type p1;
   (void)sizeof(p1);
@@ -182,6 +185,11 @@ void ArgumentTypeProvision() {
   // IWYU: NonProviding is...*typedef_in_template-i1.h
   // IWYU: IndirectClass is...*indirect.h
   (void)sizeof(Identity<NonProviding>::AliasTemplate<1>);
+
+  ProvidingNested::Type pnt;
+  // IWYU: NonProvidingNested is...*typedef_in_template-i1.h
+  // IWYU: IndirectClass is...*indirect.h
+  NonProvidingNested::Type nnt;
 }
 
 // IWYU: IndirectClass needs a declaration
@@ -202,7 +210,7 @@ tests/cxx/typedef_in_template.cc should remove these lines:
 
 The full include-list for tests/cxx/typedef_in_template.cc:
 #include "tests/cxx/indirect.h"  // for IndirectClass
-#include "tests/cxx/typedef_in_template-i1.h"  // for Class1, NonProviding
+#include "tests/cxx/typedef_in_template-i1.h"  // for Class1, NonProviding, NonProvidingNested
 #include "tests/cxx/typedef_in_template-i2.h"  // for Class2, Pair
 
 ***** IWYU_SUMMARY */


### PR DESCRIPTION
Prior to this, provided types were harvested only from template specialization type components. Types provided by an alias of the whole template specialization type were not taken into account.

Currently, it works with nested aliases (through `GetProvidedByTplArg` -> `GetTplInstData` -> `GetTplInstDataForClass` call chain), but may further be used for class template member function calls (analysis of which doesn't currently work when the class type is aliased).

A test case added. (`NonProvidingNested` case worked already and has been added only for symmetry.)