### PR TITLE
Scan aliased class template member functions

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -4412,7 +4412,7 @@ class IwyuAstConsumer
                                                         data.provided_types);
   }
 
-  set<const Type*> GetProvidedByTplArg(const Type* type) {
+  set<const Type*> GetProvidedByTplArg(const Type* type) const {
     set<const Type*> res;
     if (!type)
       return res;
@@ -4464,15 +4464,17 @@ class IwyuAstConsumer
 
  private:
   set<const Type*> GetProvidedTypeComponents(const Type* type) const {
+    set<const Type*> res;
     const Type* desugared_until_typedef = Desugar(type);
     if (const auto* typedef_type =
             dyn_cast_or_null<TypedefType>(desugared_until_typedef)) {
       const TypedefNameDecl* decl = typedef_type->getDecl();
-      return GetProvidedTypes(decl->getUnderlyingType().getTypePtr(),
-                              GetLocation(decl));
+      res = GetProvidedTypes(decl->getUnderlyingType().getTypePtr(),
+                             GetLocation(decl));
+      InsertAllInto(GetProvidedByTplArg(type), &res);
     }
     // TODO(bolshakov): handle alias templates.
-    return set<const Type*>();
+    return res;
   }
 
   TemplateInstantiationData GetTplInstData(const Type* type) const {

--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -1375,7 +1375,7 @@ const Type* Desugar(const Type* type) {
 }
 
 bool IsTemplatizedType(const Type* type) {
-  return (type && isa<TemplateSpecializationType>(Desugar(type)));
+  return type && type->getAs<TemplateSpecializationType>();
 }
 
 bool InvolvesTypeForWhich(const Type* type, function<bool(const Type*)> pred) {

--- a/tests/cxx/badinc.cc
+++ b/tests/cxx/badinc.cc
@@ -193,6 +193,9 @@ typedef I1_Class Cc_typedef_array[kI1ConstInt];
 typedef I1_TemplateClass<I1_TemplateClass<I1_Class,I2_Class> > Cc_tpl_typedef;
 // TODO(csilvers): it would be nice to be able to take this line out and
 // still have the above tests pass:
+// TODO(bolshakov): figure out how to determine at the use site that a typedef
+// provides not only the types but also the member functions.
+// IWYU: I2_Class::~I2_Class is...*badinc-i2-inl.h
 Cc_tpl_typedef cc_tpl_typedef;
 // IWYU: I2_Class is...*badinc-i2.h
 // IWYU: I2_Class::I2_Class is...*badinc-i2-inl.h

--- a/tests/cxx/template_member_functions.cc
+++ b/tests/cxx/template_member_functions.cc
@@ -1,0 +1,43 @@
+//===--- template_member_functions.cc - test input file for iwyu ----------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_ARGS: -I .
+
+// Tests scanning class template member functions.
+
+#include "tests/cxx/direct.h"
+
+template <typename T>
+struct Tpl {
+  static void StaticFn() {
+    T t;
+  }
+};
+
+class IndirectClass;
+using NonProviding = Tpl<IndirectClass>;
+
+void Fn() {
+  // IWYU: IndirectClass is...*indirect.h
+  NonProviding::StaticFn();
+}
+
+/**** IWYU_SUMMARY
+
+tests/cxx/template_member_functions.cc should add these lines:
+#include "tests/cxx/indirect.h"
+
+tests/cxx/template_member_functions.cc should remove these lines:
+- #include "tests/cxx/direct.h"  // lines XX-XX
+- class IndirectClass;  // lines XX-XX
+
+The full include-list for tests/cxx/template_member_functions.cc:
+#include "tests/cxx/indirect.h"  // for IndirectClass
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
The main change is in `iwyu_ast_util.h`. It allows not to short-circuit aliased template specialization types inside
`TraverseFunctionIfInstantiatedTpl` method.

The change in `iwyu.cc` is to avoid regression with cases like
```cpp
Outer<Providing>::Inner<Providing>::AliasedTpl pp;
```
(see `tests/cxx/typedef_in_template.cc`). It facilitates collecting provided types from member function (ctor or dtor in that case) base type qualifiers.