### PR TITLE
Scan destructors of aliased type class members

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -610,9 +610,8 @@ class BaseAstVisitor : public RecursiveASTVisitor<Derived> {
       member_types.insert(it->getType().getTypePtr());
     }
     for (const Type* type : member_types) {
-      const NamedDecl* member_decl = TypeToDeclAsWritten(type);
       // We only want those fields that are c++ classes.
-      if (const CXXRecordDecl* cxx_field_decl = DynCastFrom(member_decl)) {
+      if (const CXXRecordDecl* cxx_field_decl = type->getAsCXXRecordDecl()) {
         if (const CXXDestructorDecl* field_dtor =
                 cxx_field_decl->getDestructor()) {
           if (!this->getDerived().TraverseImplicitDestructorCall(

--- a/tests/cxx/template_member_functions.cc
+++ b/tests/cxx/template_member_functions.cc
@@ -20,8 +20,23 @@ struct Tpl {
   }
 };
 
+template <typename T>
+struct TplUsingInDtor {
+  ~TplUsingInDtor() {
+    T t;
+  }
+};
+
 class IndirectClass;
 using NonProviding = Tpl<IndirectClass>;
+using NonProvidingTplUsingInDtor = TplUsingInDtor<IndirectClass>;
+
+struct Struct {
+  // IWYU: IndirectClass is...*indirect.h
+  ~Struct() = default;
+
+  NonProvidingTplUsingInDtor member;
+};
 
 template <typename T>
 struct Outer {


### PR DESCRIPTION
`TypeToDeclAsWritten` returns `TypedefNameDecl` in that case instead of the original `CXXRecordDecl`. But `Type::getAsCXXRecordDecl` does the right thing.

Found while investigating #1499. The type of the `_Hashtable` member of `std::unordered_map` is a `typedef` at least in the libstdc++ implementation.