### PR TITLE
[clang compat] Fix alias template handling

### DIFF
--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -148,6 +148,7 @@ using llvm::errs;
 using llvm::isa;
 using llvm::raw_string_ostream;
 using std::function;
+using std::vector;
 
 namespace include_what_you_use {
 
@@ -1615,6 +1616,17 @@ TemplateInstantiationData GetTplInstDataForClass(
 
 bool CanBeOpaqueDeclared(const EnumType* type) {
   return type->getDecl()->isFixed();
+}
+
+vector<const Type*> GetCanonicalArgComponents(
+    const TemplateSpecializationType* type) {
+  vector<const Type*> res;
+  SugaredTypeEnumerator enumerator;
+  for (const TemplateArgument& arg : type->template_arguments()) {
+    for (const Type* component : enumerator.Enumerate(arg))
+      res.push_back(GetCanonicalType(component));
+  }
+  return res;
 }
 
 // --- Utilities for Stmt.

--- a/iwyu_ast_util.h
+++ b/iwyu_ast_util.h
@@ -16,6 +16,7 @@
 #include <map>                          // for map
 #include <set>                          // for set
 #include <string>                       // for string
+#include <vector>                       // for vector
 
 #include "clang/AST/NestedNameSpecifier.h"
 #include "clang/AST/TemplateBase.h"
@@ -857,6 +858,11 @@ TemplateInstantiationData GetTplInstDataForClassNoComponentTypes(
 // either scoped or unscoped with explicitly stated underlying type,
 // according to the standard.
 bool CanBeOpaqueDeclared(const clang::EnumType* type);
+
+// Collects template argument type components and returns them desugared.
+// The result may contain duplicates.
+std::vector<const clang::Type*> GetCanonicalArgComponents(
+    const clang::TemplateSpecializationType*);
 
 // --- Utilities for Stmt.
 

--- a/tests/cxx/typedef_chain_in_template-d5.h
+++ b/tests/cxx/typedef_chain_in_template-d5.h
@@ -28,3 +28,8 @@ struct Tpl {
 
 using TplWithNonProvidedAliased1 = Tpl<NonProvidingAlias>;
 using TplWithNonProvidedAliased2 = Tpl<NonProvidingAliasTpl<1>>;
+
+class TypedefChainClass;
+
+template <int>
+using NonProvidingAliasByOther = IdentityAlias2<TypedefChainClass>;

--- a/tests/cxx/typedef_chain_in_template-i1.h
+++ b/tests/cxx/typedef_chain_in_template-i1.h
@@ -18,4 +18,7 @@ struct TypedefWrapper {
   typedef value_type& reference;
 };
 
+template <typename T>
+using IdentityAlias2 = T;
+
 #endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_TYPEDEF_CHAIN_IN_TEMPLATE_I1_H_

--- a/tests/cxx/typedef_chain_in_template.cc
+++ b/tests/cxx/typedef_chain_in_template.cc
@@ -74,6 +74,11 @@ void Fn() {
   (void)sizeof(TplWithNonProvidedAliased1);
   // IWYU: TypedefChainClass is...*typedef_chain_class.h
   (void)sizeof(TplWithNonProvidedAliased2);
+
+  // IWYU: TypedefChainClass is...*typedef_chain_class.h
+  NonProvidingAliasByOther<1> npabo;
+  // IWYU: TypedefChainClass is...*typedef_chain_class.h
+  npabo.Method();
 }
 
 /**** IWYU_SUMMARY
@@ -89,6 +94,6 @@ The full include-list for tests/cxx/typedef_chain_in_template.cc:
 #include "tests/cxx/typedef_chain_in_template-d2.h"  // for ContainerAsLibcpp
 #include "tests/cxx/typedef_chain_in_template-d3.h"  // for ContainerShortTypedefChain
 #include "tests/cxx/typedef_chain_in_template-d4.h"  // for ContainerLongTypedefChain
-#include "tests/cxx/typedef_chain_in_template-d5.h"  // for IdentityAliasComplex, IdentityStructComplex, TplWithNonProvidedAliased1, TplWithNonProvidedAliased2
+#include "tests/cxx/typedef_chain_in_template-d5.h"  // for IdentityAliasComplex, IdentityStructComplex, NonProvidingAliasByOther, TplWithNonProvidedAliased1, TplWithNonProvidedAliased2
 
 ***** IWYU_SUMMARY */


### PR DESCRIPTION
llvm/llvm-project@7f78f99fe5af82361d37adcbd2daa4d04afba13d removed `SubstTemplateTypeParmType` nodes from an instantiated alias template type. `GetProvidedTypes` function relied on them to filter out substituted argument types. Now, it is done "manually" inside the added `GetAliasTemplateProvidedTypes` function, as discussed in https://github.com/llvm/llvm-project/pull/101858.

When traversing instantiated type alias internals, bare `RecordType` nodes appear now instead of ones wrapped in `SubstTemplateTypeParmType`, hence the new visiting method added into `InstantiatedTemplateVisitor`. (Enum types are not expected to need handling there, hence `VisitRecordType` instead of `VisitTagType`.)

A test case added to cover the change inside `GetProvidedTypes` function (i.e. correct handling of intermediate alias templates in a chain).