### PR TITLE
Don't redundantly traverse template methods

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -3253,8 +3253,7 @@ class InstantiatedTemplateVisitor
         VERRS(6) << "Recursively traversing " << PrintableDecl(cts_decl)
                  << " which was full-used and does not involve a known"
                  << " template param\n";
-        TraverseCXXRecordDecl(
-            const_cast<ClassTemplateSpecializationDecl*>(cts_decl));
+        TraverseDataAndTypeMembersOfClassHelper(cts_decl);
       }
     }
   }

--- a/tests/cxx/template_member_functions.cc
+++ b/tests/cxx/template_member_functions.cc
@@ -23,9 +23,24 @@ struct Tpl {
 class IndirectClass;
 using NonProviding = Tpl<IndirectClass>;
 
+template <typename T>
+struct Outer {
+  T t;
+};
+
+template <typename T>
+void FnUsingNestedTpl() {
+  Outer<Tpl<T>> o;
+}
+
 void Fn() {
   // IWYU: IndirectClass is...*indirect.h
   NonProviding::StaticFn();
+
+  // Test that IWYU doesn't scan Tpl::StaticFn when it is not used.
+  // IndirectClass is not fully used here. For this test case, it is important
+  // that StaticFn is used in the translation unit so as to be instantiated.
+  FnUsingNestedTpl<IndirectClass>();
 }
 
 /**** IWYU_SUMMARY


### PR DESCRIPTION
Otherwise, IWYU suggests the full type for `Class` for `std::map<int, std::unique_ptr<Class>>` even when none of its member functions, including the destructor, is actually used. C++ requires template member function instantiation only when used.

The bug was mentioned in https://github.com/include-what-you-use/include-what-you-use/issues/1499#issuecomment-2028095783.