### PR TITLE
Handle broken @file directives

### DIFF
--- a/iwyu_path_util.cc
+++ b/iwyu_path_util.cc
@@ -213,6 +213,12 @@ bool IsQuotedInclude(const string& s) {
           (StartsWith(s, "\"") && EndsWith(s, "\"")));
 }
 
+// Removes <> or "" from a quoted include.
+string StripQuotes(const string& quoted_include) {
+  CHECK_(IsQuotedInclude(quoted_include));
+  return quoted_include.substr(1, quoted_include.size() - 2);
+}
+
 // Returns whether this is a system (as opposed to user) include file,
 // based on where it lives.
 bool IsSystemIncludeFile(const string& filepath) {

--- a/iwyu_path_util.h
+++ b/iwyu_path_util.h
@@ -84,6 +84,9 @@ string ConvertToQuotedInclude(const string& filepath,
 // Returns true if the string is a quoted include.
 bool IsQuotedInclude(const string& s);
 
+// Removes <> or "" from a quoted include.
+string StripQuotes(const string& quoted_include);
+
 // Returns whether this is a system (as opposed to user) include
 // file, based on where it lives.
 bool IsSystemIncludeFile(const string& filepath);

--- a/tests/cxx/comment_pragmas-d23.h
+++ b/tests/cxx/comment_pragmas-d23.h
@@ -1,0 +1,23 @@
+//===--- comment_pragmas-d23.h - test input file for iwyu -----------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// Test libstdc++'s file directive with empty filename. We should map correctly
+// even if filename is missing.
+
+/** @file
+ *  This is an internal header file, included by other library headers
+ *  Do not attempt to use it directly. @headername{some_system_header_file}
+ */
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_COMMENT_PRAGMAS_D23_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_COMMENT_PRAGMAS_D23_H_
+
+class CommentPragmasD23 {};
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_COMMENT_PRAGMAS_D23_H_

--- a/tests/cxx/comment_pragmas-d24.h
+++ b/tests/cxx/comment_pragmas-d24.h
@@ -1,0 +1,23 @@
+//===--- comment_pragmas-d24.h - test input file for iwyu -----------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// Test libstdc++'s file directive with leading 'include/'. We should map
+// correctly even if filename is strictly wrong.
+
+/** @file include/tests/cxx/comment_pragmas-d24.h
+ *  This is an internal header file, included by other library headers
+ *  Do not attempt to use it directly. @headername{some_system_header_file}
+ */
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_COMMENT_PRAGMAS_D24_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_COMMENT_PRAGMAS_D24_H_
+
+class CommentPragmasD24 {};
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_COMMENT_PRAGMAS_D24_H_

--- a/tests/cxx/comment_pragmas.cc
+++ b/tests/cxx/comment_pragmas.cc
@@ -72,6 +72,12 @@
 //     internally IWYU wants a full-use which it downgrades to a forward-decl.
 // 22. "no_forward_declare" pragma: cpd20a and cpd20b are defined inside an
 //     anonymous namespace.
+// 23. @file without filename should synthesize a filename and map to
+//     @headername. cp23 defined in d23, which has
+//     @headername{some_system_header_file}
+// 24. @file with spurious leading include/ in filename.
+//     cp24 defined in d24, which has @headername{some_system_header_file}
+
 #include "tests/cxx/comment_pragmas-d1.h"
 #include "tests/cxx/comment_pragmas-d10.h"
 #include "tests/cxx/comment_pragmas-d11.h"
@@ -107,6 +113,9 @@
 
 #include "tests/cxx/comment_pragmas-d22.h" // IWYU pragma: keep
 #include "tests/cxx/comment_pragmas-d22.h"
+
+#include "tests/cxx/comment_pragmas-d23.h"
+#include "tests/cxx/comment_pragmas-d24.h"
 
 class CommentPragmasD19;  // Needed, but removed due to no_forward_declare.
 class CommentPragmasTest21a;  // Needed but removed due to no_forward_declare.
@@ -200,6 +209,12 @@ CommentPragmasD20c* cpd20c;
 typedef CommentPragmasTest21a CommentPragmasTest21b;
 class CommentPragmasTest21a {};
 
+// IWYU: CommentPragmasD23 is...*<some_system_header_file>
+CommentPragmasD23 cpd23;
+
+// IWYU: CommentPragmasD24 is...*<some_system_header_file>
+CommentPragmasD24 cpd24;
+
 /**** IWYU_SUMMARY
 
 tests/cxx/comment_pragmas.cc should add these lines:
@@ -215,6 +230,8 @@ tests/cxx/comment_pragmas.cc should remove these lines:
 - #include "tests/cxx/comment_pragmas-d1.h"  // lines XX-XX
 - #include "tests/cxx/comment_pragmas-d10.h"  // lines XX-XX
 - #include "tests/cxx/comment_pragmas-d2.h"  // lines XX-XX
+- #include "tests/cxx/comment_pragmas-d23.h"  // lines XX-XX
+- #include "tests/cxx/comment_pragmas-d24.h"  // lines XX-XX
 - #include "tests/cxx/comment_pragmas-d3.h"  // lines XX-XX
 - #include "tests/cxx/comment_pragmas-d4.h"  // lines XX-XX
 - #include "tests/cxx/comment_pragmas-d7.h"  // lines XX-XX
@@ -224,7 +241,7 @@ tests/cxx/comment_pragmas.cc should remove these lines:
 - class CommentPragmasTest21a;  // lines XX-XX
 
 The full include-list for tests/cxx/comment_pragmas.cc:
-#include <some_system_header_file>  // for CommentPragmasD8, CommentPragmasD9
+#include <some_system_header_file>  // for CommentPragmasD23, CommentPragmasD24, CommentPragmasD8, CommentPragmasD9
 #include "tests/cxx/comment_pragmas-d11.h"  // for CommentPragmasD11
 #include "tests/cxx/comment_pragmas-d12.h"  // for CommentPragmasD12
 #include "tests/cxx/comment_pragmas-d13.h"  // for CommentPragmasI10


### PR DESCRIPTION
Looking closer at libstdc++'s @file directives (used for @headername auto-mapping), I noticed some irregularities:

* bits/shared_ptr.h has @file without a name
* bits/std_abs.h (and many others) has @file with a leading 'include/', which doesn't match the file's actual include-name

These are strictly speaking bugs in libstdc++, but we can't fix them and wait for users to upgrade. Instead, be helpful and use some heuristics to normalize the names:

* If name is empty, synthesize a best-effort name from full file path
* If name starts with 'include/', simply strip the prefix

Fixes issue #1000, and should improve the automatic @headername mappings in general.