### PR TITLE
Take most basic method for author-intent analysis

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -1458,6 +1458,9 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
     if (!fn_decl)     // TODO(csilvers): what to do for fn ptrs and the like?
       return set<const Type*>();
 
+    if (const auto* method = dyn_cast<CXXMethodDecl>(fn_decl))
+      fn_decl = GetFromLeastDerived(method);
+
     // Collect the non-explicit, one-arg constructor ('autocast') types.
     set<const Type*> autocast_types;
     for (FunctionDecl::param_const_iterator param = fn_decl->param_begin();
@@ -1494,8 +1497,11 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
   }
 
   set<const Type*> GetProvidedTypesForFnReturn(const FunctionDecl* decl) const {
-    const Type* return_type = decl->getReturnType().getTypePtr();
-    return GetProvidedTypes(return_type, GetLocation(decl));
+    const FunctionDecl* providing_decl = decl;
+    if (const auto* method = dyn_cast<CXXMethodDecl>(decl))
+      providing_decl = GetFromLeastDerived(method);
+    const Type* return_type = providing_decl->getReturnType().getTypePtr();
+    return GetProvidedTypes(return_type, GetLocation(providing_decl));
   }
 
   //------------------------------------------------------------

--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -1310,6 +1310,12 @@ bool IsImplicitlyInstantiatedDfn(const FunctionDecl* decl) {
              clang::TSK_ImplicitInstantiation;
 }
 
+const CXXMethodDecl* GetFromLeastDerived(const CXXMethodDecl* decl) {
+  while (decl->size_overridden_methods())
+    decl = *decl->begin_overridden_methods();
+  return decl;
+}
+
 // --- Utilities for Type.
 
 const Type* GetTypeOf(const Expr* expr) {

--- a/iwyu_ast_util.h
+++ b/iwyu_ast_util.h
@@ -717,6 +717,11 @@ bool IsBuiltinFunction(const clang::NamedDecl* decl);
 // (in particular, not just a declaration).
 bool IsImplicitlyInstantiatedDfn(const clang::FunctionDecl*);
 
+// If the given method overrides base class methods, returns the overridden
+// method declaration from the least derived class, otherwise returns the given
+// argument.
+const clang::CXXMethodDecl* GetFromLeastDerived(const clang::CXXMethodDecl*);
+
 // --- Utilities for Type.
 
 const clang::Type* GetTypeOf(const clang::Expr* expr);

--- a/tests/cxx/reexport_overridden-d1.h
+++ b/tests/cxx/reexport_overridden-d1.h
@@ -1,0 +1,29 @@
+//===--- reexport_overridden-d1.h - test input file for iwyu --------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/reexport_overridden-i1.h"
+
+class Derived1 : public Base {
+ public:
+  // Return type fully defined in Base.
+  IndirectClass GetIndirect() override;
+
+  // Return types forward-declared in Base.
+  FwdRetType ReturnType() override;
+
+  // Parameter with implicit conversion forward-declared in Base.
+  void TakeFwdAutoconvParam(FwdAutoconvParam) override;
+};
+
+class Derived2 : public Derived1 {
+ public:
+  IndirectClass GetIndirect() override;
+  FwdRetType ReturnType() override;
+  void TakeFwdAutoconvParam(FwdAutoconvParam) override;
+};

--- a/tests/cxx/reexport_overridden-d2.h
+++ b/tests/cxx/reexport_overridden-d2.h
@@ -1,0 +1,10 @@
+//===--- reexport_overridden-d2.h - test input file for iwyu --------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/reexport_overridden-i2.h"

--- a/tests/cxx/reexport_overridden-i1.h
+++ b/tests/cxx/reexport_overridden-i1.h
@@ -1,0 +1,21 @@
+//===--- reexport_overridden-i1.h - test input file for iwyu --------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/indirect.h"
+
+// From reexport_overridden-i2.h
+class FwdAutoconvParam;
+class FwdRetType;
+
+class Base {
+ public:
+  virtual IndirectClass GetIndirect();
+  virtual FwdRetType ReturnType();
+  virtual void TakeFwdAutoconvParam(FwdAutoconvParam);
+};

--- a/tests/cxx/reexport_overridden-i2.h
+++ b/tests/cxx/reexport_overridden-i2.h
@@ -1,0 +1,14 @@
+//===--- reexport_overridden-i2.h - test input file for iwyu --------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+class FwdRetType {};
+
+struct FwdAutoconvParam {
+  FwdAutoconvParam(int);
+};

--- a/tests/cxx/reexport_overridden.cc
+++ b/tests/cxx/reexport_overridden.cc
@@ -1,0 +1,45 @@
+//===--- reexport_overridden.cc - test input file for iwyu ----------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_ARGS: -I .
+
+// Tests handling overriding method signatures.
+
+#include "tests/cxx/direct.h"
+#include "tests/cxx/reexport_overridden-d1.h"
+#include "tests/cxx/reexport_overridden-d2.h"
+
+void Fn() {
+  // Test that IWYU uses the most basic method declarations for
+  // the author-intent analysis. None of the used types are forward-declared
+  // in the file defining Derived1 and Derived2, hence they might be erroneously
+  // considered as (if should be) provided, but the Base provides only
+  // the GetIndirect return type.
+  Derived2 d;
+  d.GetIndirect();
+  // IWYU: FwdRetType is...*reexport_overridden-i2.h
+  d.ReturnType();
+  // IWYU: FwdAutoconvParam is...*reexport_overridden-i2.h
+  d.TakeFwdAutoconvParam(1);
+}
+
+/**** IWYU_SUMMARY
+
+tests/cxx/reexport_overridden.cc should add these lines:
+#include "tests/cxx/reexport_overridden-i2.h"
+
+tests/cxx/reexport_overridden.cc should remove these lines:
+- #include "tests/cxx/direct.h"  // lines XX-XX
+- #include "tests/cxx/reexport_overridden-d2.h"  // lines XX-XX
+
+The full include-list for tests/cxx/reexport_overridden.cc:
+#include "tests/cxx/reexport_overridden-d1.h"  // for Derived2
+#include "tests/cxx/reexport_overridden-i2.h"  // for FwdAutoconvParam, FwdRetType
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
Because overriding method prototypes need generally neither the full info nor the forward-declaration for the return type and for the parameter types, the author intent analysis should be performed only for the original declaration from the upmost class in the hierarchy. This change does that at the call site.

This is a step towards fixing #105.

The test case has been partially taken from #675.