### PR TITLE
Add AddQuotes utility function

### DIFF
--- a/iwyu_path_util.cc
+++ b/iwyu_path_util.cc
@@ -192,10 +192,7 @@ string ConvertToQuotedInclude(const string& filepath,
     // quoted include by just stripping the prefix.
 
     if (StripPathPrefix(&path, entry.path)) {
-      if (entry.path_type == HeaderSearchPath::kSystemPath)
-        return "<" + path + ">";
-      else
-        return "\"" + path + "\"";
+      return AddQuotes(path, entry.path_type == HeaderSearchPath::kSystemPath);
     }
   }
 
@@ -203,7 +200,7 @@ string ConvertToQuotedInclude(const string& filepath,
   // Uses the implicit "-I <basename current file>" entry on the search path.
   if (!includer_path.empty())
     StripPathPrefix(&path, NormalizeDirPath(includer_path));
-  return "\"" + path + "\"";
+  return AddQuotes(path, /*angled=*/false);
 }
 
 bool IsQuotedInclude(const string& s) {
@@ -217,6 +214,13 @@ bool IsQuotedInclude(const string& s) {
 // based on where it lives.
 bool IsSystemIncludeFile(const string& filepath) {
   return ConvertToQuotedInclude(filepath)[0] == '<';
+}
+
+string AddQuotes(string include_name, bool angled) {
+  if (angled) {
+      return "<" + include_name + ">";
+  }
+  return "\"" + include_name + "\"";
 }
 
 }  // namespace include_what_you_use

--- a/iwyu_path_util.h
+++ b/iwyu_path_util.h
@@ -95,6 +95,11 @@ inline bool IsSpecialFilename(llvm::StringRef name) {
           name == "<scratch space>" || name == "<inline asm>");
 }
 
+// Returns include name enclosed in double quotes or angle quotes, depending on
+// the angled flag. An include name is the unquoted relative name that would be
+// used on an include line, e.g. lib/mytype.h or stdio.h.
+string AddQuotes(string include_name, bool angled);
+
 }  // namespace include_what_you_use
 
 #endif  // INCLUDE_WHAT_YOU_USE_IWYU_PATH_UTIL_H_

--- a/iwyu_preprocessor.cc
+++ b/iwyu_preprocessor.cc
@@ -380,11 +380,8 @@ void IwyuPreprocessorInfo::ProcessHeadernameDirectivesInFile(
     const string filename = GetSourceTextUntilEndOfLine(current_loc,
                                                         DefaultDataGetter()).str();
     // Use "" or <> based on where the file lives.
-    string quoted_private_include;
-    if (IsSystemIncludeFile(GetFilePath(current_loc)))
-      quoted_private_include = "<" + filename + ">";
-    else
-      quoted_private_include = "\"" + filename + "\"";
+    string quoted_private_include =
+        AddQuotes(filename, IsSystemIncludeFile(GetFilePath(current_loc)));
 
     // TODO(dsturtevant): Maybe place restrictions on the
     // placement. E.g., in a comment, before any code, or perhaps only
@@ -408,7 +405,8 @@ void IwyuPreprocessorInfo::ProcessHeadernameDirectivesInFile(
 
     for (string& public_include : public_includes) {
       StripWhiteSpace(&public_include);
-      const string quoted_header_name = "<" + public_include + ">";
+      const string quoted_header_name =
+          AddQuotes(public_include, /*angled=*/true);
 
       VERRS(8) << "Adding dynamic mapping for @headername\n";
       MutableGlobalIncludePicker()->AddMapping(


### PR DESCRIPTION
The if-system-then-use-angles-otherwise-quotes dance takes more attention than it deserves.

Add an AddQuotes function to convert an include name (e.g. lib/foo.h) to a quoted include (e.g. "lib/foo.h" or <lib/foo.h> depending on the angled flag).

No functional change.