### PR TITLE
Use HeaderSearch for include name lookup instead of @file

### DIFF
--- a/tests/cxx/comment_pragmas-d10.h
+++ b/tests/cxx/comment_pragmas-d10.h
@@ -12,7 +12,7 @@
 /** @file tests/cxx/comment_pragmas-d10.h
  *  This is an internal header file, included by other library headers
  *  Do not attempt to use it directly.
- *  @headername{some_system_header_file, some_other_sytem_header_file}
+ *  @headername{some_public_header_file, some_other_public_header_file}
  */
 
 #ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_COMMENT_PRAGMAS_D10_H_

--- a/tests/cxx/comment_pragmas-d8.h
+++ b/tests/cxx/comment_pragmas-d8.h
@@ -11,7 +11,7 @@
 
 /** @file tests/cxx/comment_pragmas-d8.h
  *  This is an internal header file, included by other library headers
- *  Do not attempt to use it directly. @headername{some_system_header_file}
+ *  Do not attempt to use it directly. @headername{some_public_header_file}
  */
 
 #ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_COMMENT_PRAGMAS_D8_H_

--- a/tests/cxx/comment_pragmas-d9.h
+++ b/tests/cxx/comment_pragmas-d9.h
@@ -12,7 +12,7 @@
 /** @file tests/cxx/comment_pragmas-d9.h
  *  This is an internal header file, included by other library headers
  *  Do not attempt to use it directly.
- *  @headername{some_system_header_file, some_other_system_header_file}
+ *  @headername{some_public_header_file, some_other_public_header_file}
  */
 
 #ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_COMMENT_PRAGMAS_D9_H_

--- a/tests/cxx/comment_pragmas.cc
+++ b/tests/cxx/comment_pragmas.cc
@@ -42,10 +42,10 @@
 // 12. Unknown pragma => warning
 //     d7.h
 // 13. @headername{foo} directive (gcc and ?) => include <foo>.
-//     cp8 defined in d8.h which has @headername{some_system_header_file}
+//     cp8 defined in d8.h which has @headername{some_public_header_file}
 // 14. @headername{foo, bar} directive (gcc and ?) => include <foo>.
 //     cp9 defined in d9.h which has
-//     @headername{some_system_header_file, some_other_header_file}
+//     @headername{some_public_header_file, some_other_public_header_file}
 // 15. Malformed @headername -> warning
 //     d7.h
 // 16. "no_include" pragma: Don't suggest include.
@@ -145,10 +145,10 @@ CommentPragmasI8 cpi8;
 // IWYU: IndirectClass is ...*indirect.h
 IndirectClass ic;
 
-// IWYU: CommentPragmasD8 is...*<some_system_header_file>
+// IWYU: CommentPragmasD8 is...*"some_public_header_file"
 CommentPragmasD8 cpd8;
 
-// IWYU: CommentPragmasD9 is...*<some_system_header_file>
+// IWYU: CommentPragmasD9 is...*"some_public_header_file"
 CommentPragmasD9 cpd9;
 
 // Note: IWYU will emit the diagnostic but suppress the include
@@ -203,7 +203,7 @@ class CommentPragmasTest21a {};
 /**** IWYU_SUMMARY
 
 tests/cxx/comment_pragmas.cc should add these lines:
-#include <some_system_header_file>
+#include "some_public_header_file"
 #include "tests/cxx/comment_pragmas-i1.h"
 #include "tests/cxx/comment_pragmas-i6.h"
 #include "tests/cxx/comment_pragmas-i7.h"
@@ -224,7 +224,7 @@ tests/cxx/comment_pragmas.cc should remove these lines:
 - class CommentPragmasTest21a;  // lines XX-XX
 
 The full include-list for tests/cxx/comment_pragmas.cc:
-#include <some_system_header_file>  // for CommentPragmasD8, CommentPragmasD9
+#include "some_public_header_file"  // for CommentPragmasD8, CommentPragmasD9
 #include "tests/cxx/comment_pragmas-d11.h"  // for CommentPragmasD11
 #include "tests/cxx/comment_pragmas-d12.h"  // for CommentPragmasD12
 #include "tests/cxx/comment_pragmas-d13.h"  // for CommentPragmasI10


### PR DESCRIPTION
The @headername directive is a Doxygen alias used in libstdc++, but other projects have also picked up the convention. When generating implicit mappings for @headername, we used to use the Doxygen @file directive to get the from-name and @headername to get the preferred to-names.

There were a couple of problems with our interpretation of these pragmas:

* @file is manually maintained, and may be empty, incorrect or ambiguous
* Doxygen requires that @file contains enough of the file path in the build tree to be unique, so the name spelled out there is not necessarily the include-name we should use (e.g. many files are prefixed with "include/" for disambiguation)
* We used to assume all @headername names were system headers. This is true for libstdc++, but not necessarily for other projects.

Change this to use the private header FileEntry instead, and use the Clang preprocessor to get the actual include-name that brought the file into the source manager in the first place.

Move the include-name handling to after a @headername has been found to avoid the work if there's no mapping information anyway.

Change quoting for the to-name so it's not hard-coded to angle quotes, but rather use the same quote style as the private header (figuring out the quote style for an arbitrary public header string is non-trivial). Update a test to use the right quoting.

This fixes a bunch of mis-mappings for libstdc++.