### PR TITLE
Work around mis-mapping in libstdc++ @headername

### DIFF
--- a/iwyu_preprocessor.cc
+++ b/iwyu_preprocessor.cc
@@ -416,6 +416,14 @@ void IwyuPreprocessorInfo::ProcessHeadernameDirectivesInFile(
     for (string& public_include : public_includes) {
       StripWhiteSpace(&public_include);
 
+      // HACK: work around known inconsistency in libstdc++ headers.
+      // Upstream fix proposed:
+      // https://gcc.gnu.org/pipermail/libstdc++/2024-August/059430.html
+      if (quoted_private_include == "<bits/cpp_type_traits.h>" &&
+          public_include == "ext/type_traits") {
+        public_include = "ext/type_traits.h";
+      }
+
       // Use the same angle/quote policy as for the private file.
       const string quoted_header_name = AddQuotes(public_include, is_angled);
 


### PR DESCRIPTION
The libstdc++ file bits/cpp_type_traits.h contains @headername{ext/type_traits}, but there is no public header called ext/type_traits. There is, however, an ext/type_traits.h.

Simply detect exactly the broken header pair and auto-correct it.

This testcase:

    #include <ext/type_traits.h>
    std::__true_type v;

before this patch produces:

    t.cc should add these lines:
    #include <ext/type_traits>  // for __true_type

    t.cc should remove these lines:
    - #include <ext/type_traits.h>  // lines 1-1

    The full include-list for t.cc:
    #include <ext/type_traits>  // for __true_type

... and after:

    (t.cc has correct #includes/fwd-decls)