### PR TITLE
Don't report overriding method signature types

### DIFF
--- a/iwyu_ast_util.h
+++ b/iwyu_ast_util.h
@@ -752,6 +752,9 @@ const clang::Type* Desugar(const clang::Type* type);
 // 'B' but not 'Tpl1<A, B>'.
 set<const clang::Type*> GetComponentsOfType(const clang::Type* type);
 
+// Almost the same except it returns canonical types.
+set<const clang::Type*> GetCanonicalComponentsOfType(const clang::Type* type);
+
 // Returns types for determination of their "provision" status. They are
 // canonicalized because intermediate sugar should be always provided already
 // according to language rules. Substituted template parameter types (and their

--- a/iwyu_preprocessor.cc
+++ b/iwyu_preprocessor.cc
@@ -31,11 +31,7 @@
 #include "iwyu_stl_util.h"
 #include "iwyu_string_util.h"
 #include "iwyu_verrs.h"
-
-namespace clang {
-class MacroArgs;
-class Module;
-}  // namespace clang
+#include "llvm/ADT/StringRef.h"
 
 // TODO: Clean out pragmas as IWYU improves.
 // IWYU pragma: no_include "clang/Basic/CustomizableOptional.h"

--- a/iwyu_preprocessor.h
+++ b/iwyu_preprocessor.h
@@ -72,15 +72,9 @@
 #include "clang/Lex/PPCallbacks.h"
 #include "clang/Lex/Preprocessor.h"
 #include "iwyu_output.h"
-#include "llvm/ADT/StringRef.h"
 
 namespace clang {
-class MacroArgs;
-class MacroDefinition;
-class MacroDirective;
-class Module;
 class NamedDecl;
-class Token;
 }  // namespace clang
 
 namespace include_what_you_use {

--- a/tests/cxx/reexport_overridden-d1.h
+++ b/tests/cxx/reexport_overridden-d1.h
@@ -7,7 +7,16 @@
 //
 //===----------------------------------------------------------------------===//
 
+// In order for a method to be overridden, its base class must already be
+// included, which must in itself be self-sufficient. Thus, the function
+// signature types should generally not trigger IWYU warnings here.
+
 #include "tests/cxx/reexport_overridden-i1.h"
+
+// IWYU should suggest to remove these fwd-decls:
+class FwdAutoconvParam;
+template <typename>
+class IndirectTemplate;
 
 class Derived1 : public Base {
  public:
@@ -16,14 +25,74 @@ class Derived1 : public Base {
 
   // Return types forward-declared in Base.
   FwdRetType ReturnType() override;
+  FwdRetType ReturnTypeUnusedInBody() override;
+
+  // No need to forward-declare the return type even when it is aliased in Base.
+  IndirectClass ReturnAliasedInBase() override;
+
+  IndirectTemplate<FwdRetType> ReturnTemplate() override;
+
+  // The using-declaration should be reported but the forward-declaration
+  // should not.
+  // IWYU: ns::FwdRetType is...*reexport_overridden-i3.h.*for using decl
+  ns::FwdRetType ReturnPulledInOtherNSInDerived() override;
+
+  // Unused argument available from Base.
+  void ArgumentUnused(const IndirectClass& x) override;
+
+  // Unused argument available from Base, in inline method.
+  void ArgumentUnusedInline(const IndirectClass& x) override {
+  }
+
+  // The types fully used by inline definitions should be reported.
+  // IWYU: Struct is...*reexport_overridden-i3.h
+  void ArgumentByValueInline(Struct) override {
+  }
 
   // Parameter with implicit conversion forward-declared in Base.
   void TakeFwdAutoconvParam(FwdAutoconvParam) override;
+
+  // Type alias declaration should be reported here (moreover, it is not used
+  // in the declaration from Base).
+  // IWYU: Alias is...*reexport_overridden-i3.h
+  void TakeNoConvParam(Alias) override;
+
+  // Despite the declaration in Base doesn't mention IndirectClass explicitly,
+  // its (forward-)declaration should nevertheless be already accessible.
+  void TakeAliasedInBaseParam(IndirectClass) override;
+
+  void TakeTemplate(IndirectTemplate<IndirectClass>) override;
+
+  // IWYU: TemplatePtrAlias is...*reexport_overridden-i3.h
+  void TakeAliasedTemplatePtr(TemplatePtrAlias) override;
+
+  // The using-declaration should be reported but the forward-declaration
+  // should not.
+  // IWYU: ns::IndirectClass is...*reexport_overridden-i3.h.*for using decl
+  void TakePulledInOtherNSInDerived(ns::IndirectClass) override;
 };
 
 class Derived2 : public Derived1 {
  public:
   IndirectClass GetIndirect() override;
   FwdRetType ReturnType() override;
+  // It's better to report Alias here so that it may be replaced
+  // by IndirectClass in Base without changing this file.
+  // IWYU: Alias is...*reexport_overridden-i3.h
+  Alias ReturnAliasedInBase() override;
   void TakeFwdAutoconvParam(FwdAutoconvParam) override;
+  void TakeNoConvParam(IndirectClass) override;
 };
+
+/**** IWYU_SUMMARY
+tests/cxx/reexport_overridden-d1.h should add these lines:
+#include "tests/cxx/reexport_overridden-i3.h"
+
+tests/cxx/reexport_overridden-d1.h should remove these lines:
+- class FwdAutoconvParam;  // lines XX-XX
+- template <typename> class IndirectTemplate;  // lines XX-XX+1
+
+The full include-list for tests/cxx/reexport_overridden-d1.h:
+#include "tests/cxx/reexport_overridden-i1.h"  // for Base
+#include "tests/cxx/reexport_overridden-i3.h"  // for Alias, FwdRetType, IndirectClass, Struct, TemplatePtrAlias
+***** IWYU_SUMMARY */

--- a/tests/cxx/reexport_overridden-i1.h
+++ b/tests/cxx/reexport_overridden-i1.h
@@ -8,6 +8,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "tests/cxx/indirect.h"
+#include "tests/cxx/reexport_overridden-i3.h"
 
 // From reexport_overridden-i2.h
 class FwdAutoconvParam;
@@ -17,5 +18,17 @@ class Base {
  public:
   virtual IndirectClass GetIndirect();
   virtual FwdRetType ReturnType();
+  virtual FwdRetType ReturnTypeUnusedInBody();
+  virtual Alias ReturnAliasedInBase();
+  virtual IndirectTemplate<FwdRetType> ReturnTemplate();
+  virtual FwdRetType ReturnPulledInOtherNSInDerived();
+  virtual void ArgumentUnused(const IndirectClass& x);
+  virtual void ArgumentUnusedInline(const IndirectClass&);
+  virtual void ArgumentByValueInline(Struct);
   virtual void TakeFwdAutoconvParam(FwdAutoconvParam);
+  virtual void TakeNoConvParam(IndirectClass);
+  virtual void TakeAliasedInBaseParam(Alias);
+  virtual void TakeTemplate(IndirectTemplate<IndirectClass>);
+  virtual void TakeAliasedTemplatePtr(TemplatePtrAlias);
+  virtual void TakePulledInOtherNSInDerived(IndirectClass);
 };

--- a/tests/cxx/reexport_overridden-i3.h
+++ b/tests/cxx/reexport_overridden-i3.h
@@ -1,0 +1,23 @@
+//===--- reexport_overridden-i3.h - test input file for iwyu --------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+class FwdRetType;
+class IndirectClass;
+template <typename>
+class IndirectTemplate;
+
+using Alias = IndirectClass;
+using TemplatePtrAlias = IndirectTemplate<IndirectClass>*;
+
+namespace ns {
+using ::FwdRetType;
+using ::IndirectClass;
+}  // namespace ns
+
+struct Struct {};

--- a/tests/cxx/reexport_overridden.cc
+++ b/tests/cxx/reexport_overridden.cc
@@ -7,13 +7,82 @@
 //
 //===----------------------------------------------------------------------===//
 
-// IWYU_ARGS: -I .
+// IWYU_ARGS: -I . -Xiwyu --check_also=tests/cxx/reexport_overridden-d1.h
 
 // Tests handling overriding method signatures.
 
 #include "tests/cxx/direct.h"
 #include "tests/cxx/reexport_overridden-d1.h"
 #include "tests/cxx/reexport_overridden-d2.h"
+
+// TODO(bolshakov): it is questionable whether types provided by the primary
+// declaration should be reported from an implementation.
+// IWYU: IndirectClass is...*indirect.h
+IndirectClass Derived1::GetIndirect() {
+  // No need to forward-declare a type used in the method signature.
+  IndirectClass* pi = nullptr;
+  // Other types shoud be reported.
+  // IWYU: FwdRetType needs a declaration
+  FwdRetType* pf = nullptr;
+  // IWYU: IndirectClass is...*indirect.h
+  return IndirectClass();
+}
+
+// Base reexports only the forward declaration of FwdRetType.
+// IWYU: FwdRetType is...*reexport_overridden-i2.h
+FwdRetType Derived1::ReturnType() {
+  // No need to forward-declare here.
+  FwdRetType* p = nullptr;
+  // IWYU: FwdRetType is...*reexport_overridden-i2.h
+  return FwdRetType();
+}
+
+// Even if the return type is not mentioned in the body, the compiler requires
+// the complete type for the method definition.
+
+// IWYU: FwdRetType is...*reexport_overridden-i2.h
+FwdRetType Derived1::ReturnTypeUnusedInBody() {
+  throw 1;
+}
+
+// Info: ReturnTemplate definition forces instantiation of the template
+// specialization which may affect the IWYU analysis of the method declaration.
+// IWYU: IndirectTemplate is...*indirect.h
+// IWYU: FwdRetType is...*reexport_overridden-i2.h
+IndirectTemplate<FwdRetType> Derived1::ReturnTemplate() {
+  // IWYU: IndirectTemplate is...*indirect.h
+  // IWYU: FwdRetType is...*reexport_overridden-i2.h
+  return {};
+}
+
+// No diagnostic expected for unused arguments.
+void Derived1::ArgumentUnused(const IndirectClass&) {
+  // The full use should still be reported.
+  // IWYU: IndirectClass is...*indirect.h
+  IndirectClass ic;
+}
+
+// IWYU: Alias is...*reexport_overridden-i3.h
+// IWYU: IndirectClass is...*indirect.h
+void Derived1::TakeNoConvParam(Alias arg) {
+  // No need to forward-declare IndirectClass.
+  IndirectClass* p = &arg;
+}
+
+// Info: taking the template specialization by value forces its instantiation
+// at the method definition which may affect the IWYU analysis of the method
+// declaration.
+// IWYU: IndirectTemplate is...*indirect.h
+// IWYU: IndirectClass is...*indirect.h
+void Derived1::TakeTemplate(IndirectTemplate<IndirectClass>) {
+}
+
+// IWYU: TemplatePtrAlias is...*reexport_overridden-i3.h
+void Derived1::TakeAliasedTemplatePtr(TemplatePtrAlias p1) {
+  // No need to forward-declare IndirectTemplate or IndirectClass.
+  IndirectTemplate<IndirectClass>* p2 = p1;
+  IndirectClass* p = nullptr;
+}
 
 void Fn() {
   // Test that IWYU uses the most basic method declarations for
@@ -32,14 +101,18 @@ void Fn() {
 /**** IWYU_SUMMARY
 
 tests/cxx/reexport_overridden.cc should add these lines:
+#include "tests/cxx/indirect.h"
 #include "tests/cxx/reexport_overridden-i2.h"
+#include "tests/cxx/reexport_overridden-i3.h"
 
 tests/cxx/reexport_overridden.cc should remove these lines:
 - #include "tests/cxx/direct.h"  // lines XX-XX
 - #include "tests/cxx/reexport_overridden-d2.h"  // lines XX-XX
 
 The full include-list for tests/cxx/reexport_overridden.cc:
-#include "tests/cxx/reexport_overridden-d1.h"  // for Derived2
+#include "tests/cxx/indirect.h"  // for IndirectClass, IndirectTemplate
+#include "tests/cxx/reexport_overridden-d1.h"  // for Derived1, Derived2
 #include "tests/cxx/reexport_overridden-i2.h"  // for FwdAutoconvParam, FwdRetType
+#include "tests/cxx/reexport_overridden-i3.h"  // for Alias, TemplatePtrAlias
 
 ***** IWYU_SUMMARY */


### PR DESCRIPTION
There is no need to include or fwd-declare parameter and return (except covariance) types for overriding method declarations because they should be available through the file declaring the primary (least derived) method. This has been achieved with two steps:

1) avoid suggestions to include the full type definitions to provide them (the change inside `CanBeProvidedTypeComponent`), and

2) block forward-declaration suggestions for the return type and all the parameter types and their components.

The latter has been done not only for signatures but also for bodies so as to avoid suggestions to add a fwd-decl for `Class` in cases like:
```cpp
void Derived::Method(std::vector<Class>& v) {
  for (Class& obj : v)
    TakeByRef(obj);
}
```
Fwd-declaration suggestions inside source files are annoying, and I don't want to increase their number. Fwd-decls are blocked even for components of complex aliased types, but I'm not sure if it is worth introducing `CanonicalTypeEnumerator`...

Any sugaring declarations (type aliases, using-declarations, and other) should still be reported because `Base` and `Derived` definitions may use them independently from each other.

There remains a question whether types provided by `Base` declarations should be reported for inclusion when fully used at `Derived` method implementation side or not. This change doesn't block them, hence it effectively pushes them out from `derived.h` to `derived.cpp` in many cases. But indeed, the fact that `Base` provides them may be considered as a `Base` "implementation" detail, likewise with sugaring. So it allows to change the author-intent without changing `derived.cpp`. If it will be desired, this behavior may be changed in a separate PR.

This fixes #105.

The test cases have been partially taken from #675.