### PR TITLE
Consider associated header desired includes

### DIFF
--- a/tests/cxx/associated_include-d1.h
+++ b/tests/cxx/associated_include-d1.h
@@ -1,0 +1,12 @@
+//===--- associated_include-d1.h - test input file for iwyu ---------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/associated_include-i2.h"  // IWYU pragma: export
+
+class ClassFromD1 {};

--- a/tests/cxx/associated_include-d2.h
+++ b/tests/cxx/associated_include-d2.h
@@ -1,0 +1,10 @@
+//===--- associated_include-d2.h - test input file for iwyu ---------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/associated_include-i3.h"  // IWYU pragma: export

--- a/tests/cxx/associated_include-i2.h
+++ b/tests/cxx/associated_include-i2.h
@@ -1,0 +1,17 @@
+//===--- associated_include-i2.h - test input file for iwyu ---------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_ASSOCIATED_INCLUDE_I2_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_ASSOCIATED_INCLUDE_I2_H_
+
+#include "tests/cxx/associated_include-i3.h"
+
+class ClassExportedThroughD1 {};
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_ASSOCIATED_INCLUDE_I2_H_

--- a/tests/cxx/associated_include-i3.h
+++ b/tests/cxx/associated_include-i3.h
@@ -1,0 +1,15 @@
+//===--- associated_include-i3.h - test input file for iwyu ---------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_ASSOCIATED_INCLUDE_I3_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_ASSOCIATED_INCLUDE_I3_H_
+
+class ClassFromI3 {};
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_ASSOCIATED_INCLUDE_I3_H_

--- a/tests/cxx/associated_include.cc
+++ b/tests/cxx/associated_include.cc
@@ -14,10 +14,22 @@
 // 'associated' .h file, we don't try to add it to the .cc file.
 
 #include "tests/cxx/associated_include.h"
+#include "tests/cxx/associated_include-d1.h"
+#include "tests/cxx/associated_include-d2.h"
 
 IndirectClass ic;
 AssociatedIncludeClass aic;
 
+// IWYU should not consider "*-i2.h" as being present in the associated header
+// (because it should be removed from that), hence the following two types
+// should be attributed to "*-d1.h".
+ClassExportedThroughD1 aic2;
+ClassFromD1 aic3;
+
+// Despite "*-d2.h" reexports ClassFromI3, IWYU should suggest to remove it
+// because it should also suggest to add "*-i3.h" in the associated header.
+// IWYU: ClassFromI3 is...*associated_include-i3.h
+ClassFromI3 cfi3;
 
 /**** IWYU_SUMMARY
 
@@ -25,9 +37,11 @@ tests/cxx/associated_include.cc should add these lines:
 #include "tests/cxx/indirect.h"
 
 tests/cxx/associated_include.cc should remove these lines:
+- #include "tests/cxx/associated_include-d2.h"  // lines XX-XX
 
 The full include-list for tests/cxx/associated_include.cc:
 #include "tests/cxx/associated_include.h"
+#include "tests/cxx/associated_include-d1.h"  // for ClassExportedThroughD1, ClassFromD1
 #include "tests/cxx/indirect.h"  // for IndirectClass
 
 ***** IWYU_SUMMARY */

--- a/tests/cxx/associated_include.h
+++ b/tests/cxx/associated_include.h
@@ -9,19 +9,25 @@
 
 #include "tests/cxx/indirect.h"
 #include "tests/cxx/associated_include-i1.h"
+#include "tests/cxx/associated_include-i2.h"
 
 namespace hfile {
 AssociatedIncludeClass aic;
+// IWYU: ClassFromI3 is...*associated_include-i3.h
+ClassFromI3 cfi3;
 }
 
 /**** IWYU_SUMMARY
 
 tests/cxx/associated_include.h should add these lines:
+#include "tests/cxx/associated_include-i3.h"
 
 tests/cxx/associated_include.h should remove these lines:
+- #include "tests/cxx/associated_include-i2.h"  // lines XX-XX
 - #include "tests/cxx/indirect.h"  // lines XX-XX
 
 The full include-list for tests/cxx/associated_include.h:
 #include "tests/cxx/associated_include-i1.h"  // for AssociatedIncludeClass
+#include "tests/cxx/associated_include-i3.h"  // for ClassFromI3
 
 ***** IWYU_SUMMARY */


### PR DESCRIPTION
The statement that IWYU doesn't change associated headers is clearly wrong. When handling a main file, it should take into account what it suggests to do with its associated headers, not what those headers look like at the moment of the analysis.

It is assumed that the desired `#include`s of the associated headers have been calculated before handling the main file, as it was already assumed in the code.

This fixes #1142.