### PR TITLE
[doc] Reformat docs to more consistent form

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,25 +4,47 @@
 
 For more in-depth documentation, see [docs](docs).
 
+
 ## Instructions for users ##
 
-"Include what you use" means this: for every symbol (type, function, variable, or macro) that you use in `foo.cc` (or `foo.cpp`), either `foo.cc` or `foo.h` should include a .h file that exports the declaration of that symbol. (Similarly, for `foo_test.cc`, either `foo_test.cc` or `foo.h` should do the including.)  Obviously symbols defined in `foo.cc` itself are excluded from this requirement.
+"Include what you use" means this: for every symbol (type, function, variable,
+or macro) that you use in `foo.cc` (or `foo.cpp`), either `foo.cc` or `foo.h`
+should include a .h file that exports the declaration of that
+symbol. (Similarly, for `foo_test.cc`, either `foo_test.cc` or `foo.h` should do
+the including.)  Obviously symbols defined in `foo.cc` itself are excluded from
+this requirement.
 
-This puts us in a state where every file includes the headers it needs to declare the symbols that it uses.  When every file includes what it uses, then it is possible to edit any file and remove unused headers, without fear of accidentally breaking the upwards dependencies of that file.  It also becomes easy to automatically track and update dependencies in the source code.
+This puts us in a state where every file includes the headers it needs to
+declare the symbols that it uses.  When every file includes what it uses, then
+it is possible to edit any file and remove unused headers, without fear of
+accidentally breaking the upwards dependencies of that file.  It also becomes
+easy to automatically track and update dependencies in the source code.
+
 
 ### CAVEAT ###
 
-This is experimental software, as of June 2024.  It was originally written to work specifically in the Google source tree, and may make assumptions, or have gaps, that are immediately and embarrassingly evident in other types of code.
+This is experimental software, as of June 2024.  It was originally written to
+work specifically in the Google source tree, and may make assumptions, or have
+gaps, that are immediately and embarrassingly evident in other types of code.
 
-While we work to get IWYU quality up, we will be stinting new features, and will prioritize reported bugs along with the many existing, known bugs.  The best chance of getting a problem fixed is to submit a patch that fixes it (along with a test case that verifies the fix)!
+While we work to get IWYU quality up, we will be stinting new features, and will
+prioritize reported bugs along with the many existing, known bugs.  The best
+chance of getting a problem fixed is to submit a patch that fixes it (along with
+a test case that verifies the fix)!
+
 
 ### Clang compatibility ###
 
-Include-what-you-use makes heavy use of Clang internals, and will occasionally break when Clang is updated. We build IWYU regularly against Clang mainline to detect and fix such compatibility breaks as soon as possible.
+Include-what-you-use makes heavy use of Clang internals, and will occasionally
+break when Clang is updated. We build IWYU regularly against Clang mainline to
+detect and fix such compatibility breaks as soon as possible.
 
 NOTE: the IWYU master branch follows Clang main branch.
 
-We also have convenience tags and branches for released versions of Clang (called `clang_<version>`, e.g. `clang_5.0`). To build against a Clang release, check out the corresponding branch in IWYU before configuring the build. You can use this mapping table to combine Clang and IWYU versions correctly:
+We also have convenience tags and branches for released versions of Clang
+(called `clang_<version>`, e.g. `clang_5.0`). To build against a Clang release,
+check out the corresponding branch in IWYU before configuring the build. You can
+use this mapping table to combine Clang and IWYU versions correctly:
 
 | Clang | IWYU version | IWYU branch    |
 |-------|--------------|----------------|
@@ -48,7 +70,8 @@ We also have convenience tags and branches for released versions of Clang (calle
 | ...   | ...          | ...            |
 | main  |              | `master`       |
 
-> NOTE: If you use the Debian/Ubuntu packaging available from <https://apt.llvm.org>, you'll need the following packages installed:
+> NOTE: If you use the Debian/Ubuntu packaging available from
+> <https://apt.llvm.org>, you'll need the following packages installed:
 >
 > * `llvm-<version>-dev`
 > * `libclang-<version>-dev`
@@ -56,152 +79,233 @@ We also have convenience tags and branches for released versions of Clang (calle
 >
 > Packaging for other platforms will likely be subtly different.
 
+
 ### How to build standalone ###
 
-This build mode assumes you already have compiled LLVM and Clang libraries on your system, either via packages for your platform or built from source. To set up an environment for building IWYU:
+This build mode assumes you already have compiled LLVM and Clang libraries on
+your system, either via packages for your platform or built from source. To set
+up an environment for building IWYU:
 
 * Create a directory for IWYU development, e.g. `iwyu`
 
 * Clone the IWYU Git repo:
+  ```
+  iwyu$ git clone https://github.com/include-what-you-use/include-what-you-use.git
+  ```
+* Presumably, you'll be building IWYU with a released version of LLVM and Clang,
+  so check out the corresponding branch. For example, if you have Clang 6.0
+  installed, use the `clang_6.0` branch. IWYU `master` tracks LLVM & Clang
+  `main`:
+  ```
+  iwyu$ cd include-what-you-use
+  iwyu/include-what-you-use$ git checkout clang_6.0
+  ```
 
-      iwyu$ git clone https://github.com/include-what-you-use/include-what-you-use.git
+* Create a build root and use CMake to generate a build system linked with
+  LLVM/Clang prebuilts:
+  ```
+  # This example uses the Makefile generator, but anything should work.
+  iwyu/include-what-you-use$ cd ..
+  iwyu$ mkdir build && cd build
 
-* Presumably, you'll be building IWYU with a released version of LLVM and Clang, so check out the corresponding branch. For example, if you have Clang 6.0 installed, use the `clang_6.0` branch. IWYU `master` tracks LLVM & Clang `main`:
+  # For IWYU 0.10/Clang 6 and earlier
+  iwyu/build$ cmake -G "Unix Makefiles" -DIWYU_LLVM_ROOT_PATH=/usr/lib/llvm-6.0 ../include-what-you-use
 
-      iwyu$ cd include-what-you-use
-      iwyu/include-what-you-use$ git checkout clang_6.0
+  # For IWYU 0.11/Clang 7 and later
+  iwyu/build$ cmake -G "Unix Makefiles" -DCMAKE_PREFIX_PATH=/usr/lib/llvm-7 ../include-what-you-use
+  ```
+  (substitute the `llvm-6.0` or `llvm-7` suffixes with the actual version
+  compatible with your IWYU branch)
 
-* Create a build root and use CMake to generate a build system linked with LLVM/Clang prebuilts:
+  or, if you have a local LLVM and Clang build tree, you can specify that as
+  `CMAKE_PREFIX_PATH` for IWYU 0.11 and later:
+  ```
+  iwyu/build$ cmake -G "Unix Makefiles" -DCMAKE_PREFIX_PATH=~/llvm-project/build ../include-what-you-use
+  ```
 
-      # This example uses the Makefile generator, but anything should work.
-      iwyu/include-what-you-use$ cd ..
-      iwyu$ mkdir build && cd build
-
-      # For IWYU 0.10/Clang 6 and earlier
-      iwyu/build$ cmake -G "Unix Makefiles" -DIWYU_LLVM_ROOT_PATH=/usr/lib/llvm-6.0 ../include-what-you-use
-
-      # For IWYU 0.11/Clang 7 and later
-      iwyu/build$ cmake -G "Unix Makefiles" -DCMAKE_PREFIX_PATH=/usr/lib/llvm-7 ../include-what-you-use
-
-  (substitute the `llvm-6.0` or `llvm-7` suffixes with the actual version compatible with your IWYU branch)
-
-  or, if you have a local LLVM and Clang build tree, you can specify that as `CMAKE_PREFIX_PATH` for IWYU 0.11 and later:
-
-      iwyu/build$ cmake -G "Unix Makefiles" -DCMAKE_PREFIX_PATH=~/llvm-project/build ../include-what-you-use
-
-* Once CMake has generated a build system, you can invoke it directly from `build`, e.g.
-
-      iwyu/build$ make
+* Once CMake has generated a build system, you can invoke it directly from
+  `build`, e.g.
+  ```
+  iwyu/build$ make
+  ```
 
 ### How to build as part of LLVM ###
 
-Instructions for building LLVM and Clang are available at <https://clang.llvm.org/get_started.html>.
+Instructions for building LLVM and Clang are available at
+<https://clang.llvm.org/get_started.html>.
 
-To include IWYU in the LLVM build, use the `LLVM_EXTERNAL_PROJECTS` and `LLVM_EXTERNAL_*_SOURCE_DIR` CMake variables when configuring LLVM:
-
-      llvm-project/build$ cmake -G "Unix Makefiles" -DLLVM_ENABLE_PROJECTS=clang -DLLVM_EXTERNAL_PROJECTS=iwyu -DLLVM_EXTERNAL_IWYU_SOURCE_DIR=/path/to/iwyu /path/to/llvm-project/llvm
-      llvm-project/build$ make
-
+To include IWYU in the LLVM build, use the `LLVM_EXTERNAL_PROJECTS` and
+`LLVM_EXTERNAL_*_SOURCE_DIR` CMake variables when configuring LLVM:
+```
+llvm-project/build$ cmake -G "Unix Makefiles" -DLLVM_ENABLE_PROJECTS=clang \
+    -DLLVM_EXTERNAL_PROJECTS=iwyu -DLLVM_EXTERNAL_IWYU_SOURCE_DIR=/path/to/iwyu\
+    /path/to/llvm-project/llvm
+llvm-project/build$ make
+```
 This builds all of LLVM, Clang and IWYU in a single tree.
+
 
 ### How to install ###
 
-If you're building IWYU out-of-tree or installing pre-built binaries, you need to make sure it can find Clang built-in headers (`stdarg.h` and friends.)
+If you're building IWYU out-of-tree or installing pre-built binaries, you need
+to make sure it can find Clang built-in headers (`stdarg.h` and friends.)
 
-Clang's default policy is to look in `path/to/clang-executable/../lib/clang/<clang ver>/include`. So if Clang 3.5.0 is installed in `/usr/bin`, it will search for built-ins in `/usr/lib/clang/3.5.0/include`.
+Clang's default policy is to look in
+`path/to/clang-executable/../lib/clang/<clang ver>/include`. So if Clang 3.5.0
+is installed in `/usr/bin`, it will search for built-ins in
+`/usr/lib/clang/3.5.0/include`.
 
-Clang tools have the same policy by default, so in order for IWYU to analyze any non-trivial code, it needs to find Clang's built-ins in `path/to/iwyu/../lib/clang/3.5.0/include` where `3.5.0` is a stand-in for the version of Clang your IWYU was built against.
+Clang tools have the same policy by default, so in order for IWYU to analyze any
+non-trivial code, it needs to find Clang's built-ins in
+`path/to/iwyu/../lib/clang/3.5.0/include` where `3.5.0` is a stand-in for the
+version of Clang your IWYU was built against.
 
-Note that some distributions/packages may have different defaults, you can use `clang -print-resource-dir` to find the base path of the built-in headers on your system.
+Note that some distributions/packages may have different defaults, you can use
+`clang -print-resource-dir` to find the base path of the built-in headers on
+your system.
 
-So for IWYU to function correctly, you need to copy the Clang `include` directory to the expected location before running (similarly, use `include-what-you-use -print-resource-dir` to learn exactly where IWYU wants the headers).
+So for IWYU to function correctly, you need to copy the Clang `include`
+directory to the expected location before running (similarly, use
+`include-what-you-use -print-resource-dir` to learn exactly where IWYU wants the
+headers).
 
-This weirdness is tracked in [issue 100](https://github.com/include-what-you-use/include-what-you-use/issues/100), hopefully we can make this more transparent over time.
+This weirdness is tracked in [issue
+100](https://github.com/include-what-you-use/include-what-you-use/issues/100),
+hopefully we can make this more transparent over time.
+
 
 ### How to run ###
 
-The original design was built for Make, but a number of alternative run modes have come up over the years.
+The original design was built for Make, but a number of alternative run modes
+have come up over the years.
+
 
 #### Running on single source file ####
 
 The simplest way to use IWYU is to run it against a single source file:
-
-      include-what-you-use $CXXFLAGS myfile.cc
-
+```
+include-what-you-use $CXXFLAGS myfile.cc
+```
 where `$CXXFLAGS` are the flags you would normally pass to the compiler.
+
 
 #### Plugging into existing build system ####
 
-Typically there is already a build system containing the relevant compiler flags for all source files. Replace your compiler with `include-what-you-use` to generate a large batch of IWYU advice. Depending on your build system/build tools, this can take many forms, but for a simple GNU Make system it might look like this:
+Typically there is already a build system containing the relevant compiler flags
+for all source files. Replace your compiler with `include-what-you-use` to
+generate a large batch of IWYU advice. Depending on your build system/build
+tools, this can take many forms, but for a simple GNU Make system it might look
+like this:
+```
+make -k CXX=include-what-you-use CXXFLAGS="-Xiwyu --error_always"
+```
+(The additional `-Xiwyu --error_always` switch makes `include-what-you-use`
+always exit with an error code, so the build system knows it didn't build a .o
+file.  Hence the need for `-k`.)
 
-      make -k CXX=include-what-you-use CXXFLAGS="-Xiwyu --error_always"
+In this mode `include-what-you-use` only analyzes the .cc (or .cpp) files known
+to your build system, along with their corresponding .h files.  If your project
+has a .h file with no corresponding .cc file, IWYU will ignore it unless you use
+the `--check_also` switch to add it for analysis together with a .cc file. It is
+possible to run IWYU against individual header files, provided the compiler
+flags are carefully constructed to match all includers.
 
-(The additional `-Xiwyu --error_always` switch makes `include-what-you-use` always exit with an error code, so the build system knows it didn't build a .o file.  Hence the need for `-k`.)
-
-In this mode `include-what-you-use` only analyzes the .cc (or .cpp) files known to your build system, along with their corresponding .h files.  If your project has a .h file with no corresponding .cc file, IWYU will ignore it unless you use the `--check_also` switch to add it for analysis together with a .cc file. It is possible to run IWYU against individual header files, provided the compiler flags are carefully constructed to match all includers.
 
 #### Using with CMake ####
 
-CMake has grown native support for IWYU as of version 3.3. See [their documentation](https://cmake.org/cmake/help/latest/prop_tgt/LANG_INCLUDE_WHAT_YOU_USE.html) for CMake-side details.
+CMake has grown native support for IWYU as of version 3.3. See [their
+documentation](https://cmake.org/cmake/help/latest/prop_tgt/LANG_INCLUDE_WHAT_YOU_USE.html)
+for CMake-side details.
 
-The `CMAKE_CXX_INCLUDE_WHAT_YOU_USE` option enables a mode where CMake first compiles a source file, and then runs IWYU on it.
+The `CMAKE_CXX_INCLUDE_WHAT_YOU_USE` option enables a mode where CMake first
+compiles a source file, and then runs IWYU on it.
 
 Use it like this:
-
-      mkdir build && cd build
-      CC="clang" CXX="clang++" cmake -DCMAKE_CXX_INCLUDE_WHAT_YOU_USE=include-what-you-use ...
+```
+mkdir build && cd build
+CC="clang" CXX="clang++" cmake -DCMAKE_CXX_INCLUDE_WHAT_YOU_USE=include-what-you-use ...
+```
 
 or, on Windows systems:
+```
+mkdir build && cd build
+cmake -DCMAKE_CXX_COMPILER="%VCINSTALLDIR%/bin/cl.exe" -DCMAKE_CXX_INCLUDE_WHAT_YOU_USE=include-what-you-use -G Ninja ...
+```
 
-      mkdir build && cd build
-      cmake -DCMAKE_CXX_COMPILER="%VCINSTALLDIR%/bin/cl.exe" -DCMAKE_CXX_INCLUDE_WHAT_YOU_USE=include-what-you-use -G Ninja ...
+These examples assume that `include-what-you-use` is in the `PATH`. If it isn't,
+consider changing the value to an absolute path. Arguments to IWYU can be added
+using CMake's semicolon-separated list syntax, e.g.:
+```
+... cmake -DCMAKE_CXX_INCLUDE_WHAT_YOU_USE="include-what-you-use;-w;-Xiwyu;--verbose=7" ...
+```
 
-These examples assume that `include-what-you-use` is in the `PATH`. If it isn't, consider changing the value to an absolute path. Arguments to IWYU can be added using CMake's semicolon-separated list syntax, e.g.:
+The option appears to be separately supported for both C and C++, so use
+`CMAKE_C_INCLUDE_WHAT_YOU_USE` for C code.
 
-      ... cmake -DCMAKE_CXX_INCLUDE_WHAT_YOU_USE="include-what-you-use;-w;-Xiwyu;--verbose=7" ...
+Note that with Microsoft's Visual C++ compiler, IWYU needs the
+`--driver-mode=cl` argument to understand the MSVC options from CMake.
 
-The option appears to be separately supported for both C and C++, so use `CMAKE_C_INCLUDE_WHAT_YOU_USE` for C code.
-
-Note that with Microsoft's Visual C++ compiler, IWYU needs the `--driver-mode=cl` argument to understand the MSVC options from CMake.
 
 #### Using with a compilation database ####
 
-The `iwyu_tool.py` script pre-dates the native CMake support, and works off the [compilation database format](https://clang.llvm.org/docs/JSONCompilationDatabase.html). For example, CMake generates such a database named `compile_commands.json` with the `CMAKE_EXPORT_COMPILE_COMMANDS` option enabled.
+The `iwyu_tool.py` script pre-dates the native CMake support, and works off the
+[compilation database
+format](https://clang.llvm.org/docs/JSONCompilationDatabase.html). For example,
+CMake generates such a database named `compile_commands.json` with the
+`CMAKE_EXPORT_COMPILE_COMMANDS` option enabled.
 
-The script's command-line syntax is designed to mimic Clang's LibTooling, but they are otherwise unrelated. It can be used like this:
-
-      mkdir build && cd build
-      CC="clang" CXX="clang++" cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ...
-      iwyu_tool.py -p .
+The script's command-line syntax is designed to mimic Clang's LibTooling, but
+they are otherwise unrelated. It can be used like this:
+```
+mkdir build && cd build
+CC="clang" CXX="clang++" cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ...
+iwyu_tool.py -p .
+```
 
 or, on Windows systems:
-
-      mkdir build && cd build
-      cmake -DCMAKE_CXX_COMPILER="%VCINSTALLDIR%/bin/cl.exe" -DCMAKE_C_COMPILER="%VCINSTALLDIR%/VC/bin/cl.exe" -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -G Ninja ...
-      python3 iwyu_tool.py -p .
+```
+mkdir build && cd build
+cmake -DCMAKE_CXX_COMPILER="%VCINSTALLDIR%/bin/cl.exe" -DCMAKE_C_COMPILER="%VCINSTALLDIR%/VC/bin/cl.exe" -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -G Ninja ...
+python3 iwyu_tool.py -p .
+```
 
 Unless a source filename is provided, all files in the project will be analyzed.
 
 See `iwyu_tool.py --help` for more options.
 
+
 #### Applying fixes ####
 
-We also include a tool that automatically fixes up your source files based on the IWYU recommendations.  This is also alpha-quality software!  Here's how to use it (requires python3):
+We also include a tool that automatically fixes up your source files based on
+the IWYU recommendations.  This is also alpha-quality software!  Here's how to
+use it (requires python3):
+```
+make -k CXX=include-what-you-use CXXFLAGS="-Xiwyu --error_always" 2> /tmp/iwyu.out
+python3 fix_includes.py < /tmp/iwyu.out
+```
 
-      make -k CXX=include-what-you-use CXXFLAGS="-Xiwyu --error_always" 2> /tmp/iwyu.out
-      python3 fix_includes.py < /tmp/iwyu.out
-
-If you don't like the way `fix_includes.py` munges your `#include` lines, you can control its behavior via flags. `fix_includes.py --help` will give a full list, but these are some common ones:
+If you don't like the way `fix_includes.py` munges your `#include` lines, you
+can control its behavior via flags. `fix_includes.py --help` will give a full
+list, but these are some common ones:
 
 * `-b`: Put blank lines between system and Google includes
 * `--nocomments`: Don't add the 'why' comments next to includes
 
+
 ### How to correct IWYU mistakes ###
 
-* If `fix_includes.py` has removed an `#include` you actually need, add it back in with the comment '`// IWYU pragma: keep`' at the end of the `#include` line.  Note that the comment is case-sensitive.
-* If `fix_includes.py` has added an `#include` you don't need, just take it out.  We hope to come up with a more permanent way of fixing later.
-* If `fix_includes.py` has wrongly added or removed a forward-declare, just fix it up manually.
-* If `fix_includes.py` has suggested a private header file (such as `<bits/stl_vector.h>`) instead of the proper public header file (`<vector>`), you can fix this by inserting a specially crafted comment near top of the private file (assuming you can write to it): '`// IWYU pragma: private, include "the/public/file.h"`'.
+* If `fix_includes.py` has removed an `#include` you actually need, add it back
+  in with the comment '`// IWYU pragma: keep`' at the end of the `#include`
+  line.  Note that the comment is case-sensitive.
+* If `fix_includes.py` has added an `#include` you don't need, just take it out.
+  We hope to come up with a more permanent way of fixing later.
+* If `fix_includes.py` has wrongly added or removed a forward-declare, just fix
+  it up manually.
+* If `fix_includes.py` has suggested a private header file (such as
+  `<bits/stl_vector.h>`) instead of the proper public header file (`<vector>`),
+  you can fix this by inserting a specially crafted comment near top of the
+  private file (assuming you can write to it): '`// IWYU pragma: private,
+  include "the/public/file.h"`'.
 
 Current IWYU pragmas are described in [IWYUPragmas](docs/IWYUPragmas.md).
 

--- a/docs/IWYUMappings.md
+++ b/docs/IWYUMappings.md
@@ -1,24 +1,44 @@
 # IWYU mappings #
 
-One of the difficult problems for IWYU is distinguishing between which header contains a symbol definition and which header is the actual documented header to include for that symbol.
+One of the difficult problems for IWYU is distinguishing between which header
+contains a symbol definition and which header is the actual documented header to
+include for that symbol.
 
-For example, in GCC's libstdc++, `std::unique_ptr<T>` is defined in `<bits/unique_ptr.h>`, but the documented way to get it is to `#include <memory>`.
+For example, in GCC's libstdc++, `std::unique_ptr<T>` is defined in
+`<bits/unique_ptr.h>`, but the documented way to get it is to `#include
+<memory>`.
 
-Another example is `NULL`. Its authoritative header is `<cstddef>`, but for practical purposes `NULL` is more of a keyword, and according to the standard it's acceptable to assume it comes with `<cstring>`, `<clocale>`, `<cwchar>`, `<ctime>`, `<cstdio>` or `<cstdlib>`. In fact, almost every standard library header pulls in `NULL` one way or another, and we probably shouldn't force people to `#include <cstddef>`.
+Another example is `NULL`. Its authoritative header is `<cstddef>`, but for
+practical purposes `NULL` is more of a keyword, and according to the standard
+it's acceptable to assume it comes with `<cstring>`, `<clocale>`, `<cwchar>`,
+`<ctime>`, `<cstdio>` or `<cstdlib>`. In fact, almost every standard library
+header pulls in `NULL` one way or another, and we probably shouldn't force
+people to `#include <cstddef>`.
 
-To simplify IWYU deployment and command-line interface, many of these mappings are compiled into the executable. These constitute the *default mappings*.
+To simplify IWYU deployment and command-line interface, many of these mappings
+are compiled into the executable. These constitute the *default mappings*.
 
-However, many mappings are toolchain- and version-dependent. Symbol homes and `#include` dependencies change between releases of GCC and are dramatically different for the standard libraries shipped with Microsoft Visual C++. Also, mappings such as these are usually necessary for third-party libraries (e.g. Boost, Qt) or even project-local symbols and headers as well.
+However, many mappings are toolchain- and version-dependent. Symbol homes and
+`#include` dependencies change between releases of GCC and are dramatically
+different for the standard libraries shipped with Microsoft Visual C++. Also,
+mappings such as these are usually necessary for third-party libraries
+(e.g. Boost, Qt) or even project-local symbols and headers as well.
 
-Any mappings outside of the default set can therefore be specified as external *mapping files*.
+Any mappings outside of the default set can therefore be specified as external
+*mapping files*.
+
 
 ## Default mappings ##
 
-IWYU's default mappings are hard-coded in `iwyu_include_picker.cc`, and are very GCC-centric. There are both symbol- and include mappings for GNU libstdc++ and libc.
+IWYU's default mappings are hard-coded in `iwyu_include_picker.cc`, and are very
+GCC-centric. There are both symbol- and include mappings for GNU libstdc++ and
+libc.
+
 
 ## Mapping files ##
 
-The mapping files conventionally use the `.imp` file extension, for "Iwyu MaPping" (terrible, I know). They have the following general form:
+The mapping files conventionally use the `.imp` file extension, for "Iwyu
+MaPping" (terrible, I know). They have the following general form:
 
     [
       { <directive>: <data> },
@@ -33,15 +53,24 @@ Directives can be one of the literal strings:
 
 and data varies between the directives, see below.
 
-Note that you can mix directives of different kinds within the same mapping file.
+Note that you can mix directives of different kinds within the same mapping
+file.
 
-The `.imp` format looks like [JSON](http://json.org/), but IWYU actually uses LLVM's [YAML](https://yaml.org/) parser to interpret the mapping files, which technically allows a richer syntax. We try to use a minimum of YAML features to get basic functionality (trailing comma syntax, `#` comments), but please be conservative to keep it easy to do machine rewrites.
+The `.imp` format looks like [JSON](http://json.org/), but IWYU actually uses
+LLVM's [YAML](https://yaml.org/) parser to interpret the mapping files, which
+technically allows a richer syntax. We try to use a minimum of YAML features to
+get basic functionality (trailing comma syntax, `#` comments), but please be
+conservative to keep it easy to do machine rewrites.
+
 
 ### Include mappings ###
 
-The `include` directive specifies a mapping between two include names (relative path, including quotes or angle brackets.)
+The `include` directive specifies a mapping between two include names (relative
+path, including quotes or angle brackets.)
 
-This is typically used to map from a private implementation detail header to a public facade header, such as our `<bits/unique_ptr.h>` to `<memory>` example above.
+This is typically used to map from a private implementation detail header to a
+public facade header, such as our `<bits/unique_ptr.h>` to `<memory>` example
+above.
 
 Data for this directive is a list of four strings containing:
 
@@ -54,24 +83,34 @@ For example;
 
     { "include": ["<bits/unique_ptr.h>", "private", "<memory>", "public"] }
 
-Most of the original mappings were generated with shell scripts (as evident from the embedded comments) so there are several multi-step mappings from one private header to another, to a third and finally to a public header. This reflects the `#include` chain in the actual library headers. A hand-written mapping could be reduced to one mapping per private header to its corresponding public header.
+Most of the original mappings were generated with shell scripts (as evident from
+the embedded comments) so there are several multi-step mappings from one private
+header to another, to a third and finally to a public header. This reflects the
+`#include` chain in the actual library headers. A hand-written mapping could be
+reduced to one mapping per private header to its corresponding public header.
 
 Include mappings support a special wildcard syntax for the first entry:
 
     { "include": ["@<internal/.*>", "private", "<public>", "public"] }
 
-The `@` prefix is a signal that the remaining content is a regex, and can be used to re-map a whole subdirectory of private headers to a public facade header.
+The `@` prefix is a signal that the remaining content is a regex, and can be
+used to re-map a whole subdirectory of private headers to a public facade
+header.
 
 The `include-what-you-use` program has a `--regex` argument to select dialect;
 
 * `llvm`: a basic, fast implementation (default)
-* `ecmascript`: a more capable, slower implementation with support for e.g. negative lookaround
+* `ecmascript`: a more capable, slower implementation with support for
+  e.g. negative lookaround
 
-The performance hit of `ecmascript` can be quite significant for large mapping files with many regex patterns, so mind your step.
+The performance hit of `ecmascript` can be quite significant for large mapping
+files with many regex patterns, so mind your step.
+
 
 ### Symbol mappings ###
 
-The `symbol` directive maps from a qualified symbol name to its authoritative header.
+The `symbol` directive maps from a qualified symbol name to its authoritative
+header.
 
 Data for this directive is a list of four strings containing:
 
@@ -84,33 +123,53 @@ For example;
 
     { "symbol": ["NULL", "private", "<cstddef>", "public"] }
 
-The symbol visibility is largely redundant -- it must always be `private`. It isn't entirely clear why symbol visibility needs to be specified, and it might be removed moving forward.
+The symbol visibility is largely redundant -- it must always be `private`. It
+isn't entirely clear why symbol visibility needs to be specified, and it might
+be removed moving forward.
 
-Unlike `include`, `symbol` directives do not support the `@`-prefixed regex syntax in the first entry. Track the [following bug](https://github.com/include-what-you-use/include-what-you-use/issues/233) for updates.
+Unlike `include`, `symbol` directives do not support the `@`-prefixed regex
+syntax in the first entry. Track the [following
+bug](https://github.com/include-what-you-use/include-what-you-use/issues/233)
+for updates.
+
 
 ### Mapping refs ###
 
-The last kind of directive, `ref`, is used to pull in another mapping file, much like the C preprocessor's `#include` directive. Data for this directive is a single string: the filename to include.
+The last kind of directive, `ref`, is used to pull in another mapping file, much
+like the C preprocessor's `#include` directive. Data for this directive is a
+single string: the filename to include.
 
 For example;
 
     { "ref": "more.symbols.imp" },
     { "ref": "/usr/lib/other.includes.imp" }
 
-The rationale for the `ref` directive was to make it easier to compose project-specific mappings from a set of library-oriented mapping files. For example, IWYU might ship with mapping files for [Boost](http://www.boost.org), the SCL, various C standard libraries, the Windows API, the [Poco Library](http://pocoproject.org), etc. Depending on what your specific project uses, you could easily create an aggregate mapping file with refs to the relevant mappings.
+The rationale for the `ref` directive was to make it easier to compose
+project-specific mappings from a set of library-oriented mapping files. For
+example, IWYU might ship with mapping files for [Boost](http://www.boost.org),
+the SCL, various C standard libraries, the Windows API, the [Poco
+Library](http://pocoproject.org), etc. Depending on what your specific project
+uses, you could easily create an aggregate mapping file with refs to the
+relevant mappings.
+
 
 ### Command-line switches for mapping files ###
 
-Mapping files are specified on the command-line using the `--mapping_file` switch:
+Mapping files are specified on the command-line using the `--mapping_file`
+switch:
 
     $ include-what-you-use -Xiwyu --mapping_file=foo.imp some_file.cc
 
 The switch can be added multiple times to add more than one mapping file.
 
-If the mapping filename is relative, it will be looked up relative to the current directory.
+If the mapping filename is relative, it will be looked up relative to the
+current directory.
 
-`ref` directives are first looked up relative to the current directory and if not found, relative to the referring mapping file.
+`ref` directives are first looked up relative to the current directory and if
+not found, relative to the referring mapping file.
 
-The default mappings can be turned off (e.g. for baremetal projects like an OS kernel) using the `--no_default_mappings` switch:
+The default mappings can be turned off (e.g. for baremetal projects like an OS
+kernel) using the `--no_default_mappings` switch:
 
-    $ include-what-you-use -Xiwyu --no_default_mappings --mapping_file=kernel_libc.imp kernel/main.c
+    $ include-what-you-use -Xiwyu --no_default_mappings \
+        --mapping_file=kernel_libc.imp kernel/main.c

--- a/docs/IWYUPragmas.md
+++ b/docs/IWYUPragmas.md
@@ -1,23 +1,33 @@
 # IWYU pragmas #
 
-IWYU pragmas are used to give IWYU information that isn't obvious from the source code, such as how different files relate to each other and which includes to never remove or include.
+IWYU pragmas are used to give IWYU information that isn't obvious from the
+source code, such as how different files relate to each other and which includes
+to never remove or include.
 
-All pragmas start with `// IWYU pragma: ` or `/* IWYU pragma: `. They are case-sensitive and spaces are significant.
+All pragmas start with `// IWYU pragma: ` or `/* IWYU pragma: `. They are
+case-sensitive and spaces are significant.
+
 
 ## IWYU pragma: keep ##
 
-This pragma applies to a single `#include` directive or forward declaration. It forces IWYU to keep an inclusion even if it is deemed unnecessary.
+This pragma applies to a single `#include` directive or forward declaration. It
+forces IWYU to keep an inclusion even if it is deemed unnecessary.
 
     main.cc:
       #include <vector> // IWYU pragma: keep
 
       class ForwardDeclaration; // IWYU pragma: keep
 
-In this case, `std::vector` isn't used, so `<vector>` would normally be discarded, but the pragma instructs IWYU to leave it. Similarly the class `ForwardDeclaration` isn't used but is kept because of the pragma on it.
+In this case, `std::vector` isn't used, so `<vector>` would normally be
+discarded, but the pragma instructs IWYU to leave it. Similarly the class
+`ForwardDeclaration` isn't used but is kept because of the pragma on it.
+
 
 ## IWYU pragma: begin_keep/end_keep ##
 
-This pragma applies to a set of `#include` directives and forward declarations. It declares that the headers and forward declarations in between are to be left alone by IWYU.
+This pragma applies to a set of `#include` directives and forward
+declarations. It declares that the headers and forward declarations in between
+are to be left alone by IWYU.
 
     main.cc:
       // IWYU pragma: begin_keep
@@ -27,11 +37,15 @@ This pragma applies to a set of `#include` directives and forward declarations. 
       class MyClass;
       // IWYU pragma: end_keep
 
-In the provided case nothing within the bounds of `begin_keep` and `end_keep` will be discarded.
+In the provided case nothing within the bounds of `begin_keep` and `end_keep`
+will be discarded.
+
 
 ## IWYU pragma: export ##
 
-This pragma applies to a single `#include` directive or forward declaration. It says that the current file is to be considered the provider of any symbol from the included file or declaration.
+This pragma applies to a single `#include` directive or forward declaration. It
+says that the current file is to be considered the provider of any symbol from
+the included file or declaration.
 
     facade.h:
       #include "detail/constants.h" // IWYU pragma: export
@@ -43,19 +57,27 @@ This pragma applies to a single `#include` directive or forward declaration. It 
     main.cc:
       #include "facade.h"
 
-      // Assuming Thing comes from detail/types.h and MAX_THINGS from detail/constants.h
+      // Assuming Thing comes from detail/types.h and MAX_THINGS from
+      // detail/constants.h
       std::vector<Thing> things(MAX_THINGS);
 
       // Satisfied with forward-declaration from facade.h
       void foo(Other* thing);
 
-Here, since `detail/constants.h`, `detail/types.h` and `Other` have all been exported, IWYU is happy with the `facade.h` include for `Thing` and `MAX_THINGS` and does not suggest a local forward declaration for `Other`.
+Here, since `detail/constants.h`, `detail/types.h` and `Other` have all been
+exported, IWYU is happy with the `facade.h` include for `Thing` and `MAX_THINGS`
+and does not suggest a local forward declaration for `Other`.
 
-In contrast, since `<vector>` has not been exported from `facade.h`, it will be suggested as an additional include.
+In contrast, since `<vector>` has not been exported from `facade.h`, it will be
+suggested as an additional include.
+
 
 ## IWYU pragma: begin_exports/end_exports ##
 
-This pragma applies to a set of `#include` directives or forward declarations. It declares that the including file is to be considered the provider any symbol from contained included files or declarations. This is the same as decorating every line with `IWYU pragma: export`.
+This pragma applies to a set of `#include` directives or forward
+declarations. It declares that the including file is to be considered the
+provider any symbol from contained included files or declarations. This is the
+same as decorating every line with `IWYU pragma: export`.
 
     facade.h:
       // IWYU pragma: begin_exports
@@ -66,9 +88,11 @@ This pragma applies to a set of `#include` directives or forward declarations. I
 
       #include <vector> // don't export stuff from <vector>
 
+
 ## IWYU pragma: private ##
 
-This pragma applies to the current header file. It says that any symbol from this file will be provided by another, optionally named, file.
+This pragma applies to the current header file. It says that any symbol from
+this file will be provided by another, optionally named, file.
 
     private.h:
       // IWYU pragma: private, include "public.h"
@@ -89,13 +113,18 @@ This pragma applies to the current header file. It says that any symbol from thi
       Private p;
       Private2 i;
 
-Using the type `Private` in `main.cc` will cause IWYU to suggest that you include `public.h`.
+Using the type `Private` in `main.cc` will cause IWYU to suggest that you
+include `public.h`.
 
-Using the type `Private2` in `main.cc`  will cause IWYU to suggest that you include `private2.h`, but will also result in a warning that there's no public header for `private2.h`.
+Using the type `Private2` in `main.cc` will cause IWYU to suggest that you
+include `private2.h`, but will also result in a warning that there's no public
+header for `private2.h`.
+
 
 ## IWYU pragma: no_include ##
 
-This pragma applies to the current source file. It declares that the named file should not be suggested for inclusion by IWYU.
+This pragma applies to the current source file. It declares that the named file
+should not be suggested for inclusion by IWYU.
 
     private.h:
       struct Private {};
@@ -110,15 +139,22 @@ This pragma applies to the current source file. It declares that the named file 
 
       Private i;
 
-The use of `Private` requires including `private.h`, but due to the `no_include` pragma IWYU will not suggest `private.h` for inclusion. Note also that if you had included `private.h` in `main.cc`, IWYU would suggest that the `#include` be removed.
+The use of `Private` requires including `private.h`, but due to the `no_include`
+pragma IWYU will not suggest `private.h` for inclusion. Note also that if you
+had included `private.h` in `main.cc`, IWYU would suggest that the `#include` be
+removed.
 
-This is useful when you know a symbol definition is already available via some unrelated header, and you want to preserve that implicit dependency.
+This is useful when you know a symbol definition is already available via some
+unrelated header, and you want to preserve that implicit dependency.
 
-The `no_include` pragma is somewhat similar to `private`, but is employed at point of use rather than at point of declaration.
+The `no_include` pragma is somewhat similar to `private`, but is employed at
+point of use rather than at point of declaration.
+
 
 ## IWYU pragma: no_forward_declare ##
 
-This pragma applies to the current source file. It says that the named symbol should not be suggested for forward-declaration by IWYU.
+This pragma applies to the current source file. It says that the named symbol
+should not be suggested for forward-declaration by IWYU.
 
     public.h:
       struct Public {};
@@ -133,13 +169,22 @@ This pragma applies to the current source file. It says that the named symbol sh
 
       Public* i;
 
-IWYU would normally suggest forward-declaring `Public` directly in `main.cc`, but `no_forward_declare` suppresses that suggestion. A forward-declaration for `Public` is already available from `unrelated.h`.
+IWYU would normally suggest forward-declaring `Public` directly in `main.cc`,
+but `no_forward_declare` suppresses that suggestion. A forward-declaration for
+`Public` is already available from `unrelated.h`.
 
-This is useful when you know a symbol declaration is already available in a source file via some unrelated header and you want to preserve that implicit dependency, or when IWYU does not correctly understand that the definition is necessary.
+This is useful when you know a symbol declaration is already available in a
+source file via some unrelated header and you want to preserve that implicit
+dependency, or when IWYU does not correctly understand that the definition is
+necessary.
+
 
 ## IWYU pragma: friend ##
 
-This pragma applies to the current header file. It says that any file matching the given regular expression will be considered a friend, and is allowed to include this header even if it's private. Conceptually similar to `friend` in C++.
+This pragma applies to the current header file. It says that any file matching
+the given regular expression will be considered a friend, and is allowed to
+include this header even if it's private. Conceptually similar to `friend` in
+C++.
 
 If the expression contains spaces, it must be enclosed in quotes.
 
@@ -160,13 +205,19 @@ If the expression contains spaces, it must be enclosed in quotes.
 
       AlsoPrivate p;
 
+
 ## IWYU pragma: associated ##
 
-Associated headers have special significance in IWYU, they're analyzed together with their .cpp file to give an optimal result for the whole component.
+Associated headers have special significance in IWYU, they're analyzed together
+with their .cpp file to give an optimal result for the whole component.
 
-By default, IWYU uses the .cpp file's stem (filename without extension) to automatically detect which is the associated header, but sometimes local conventions don't allow a component's .cpp and header file to share a stem, which makes life harder for IWYU.
+By default, IWYU uses the .cpp file's stem (filename without extension) to
+automatically detect which is the associated header, but sometimes local
+conventions don't allow a component's .cpp and header file to share a stem,
+which makes life harder for IWYU.
 
-You can explicitly mark an arbitrary `#include` directive as denoting the associated header with `IWYU pragma: associated`:
+You can explicitly mark an arbitrary `#include` directive as denoting the
+associated header with `IWYU pragma: associated`:
 
     component/public.h:
       struct Foo {
@@ -179,11 +230,14 @@ You can explicitly mark an arbitrary `#include` directive as denoting the associ
       void Foo::Bar() {
       }
 
-You can mark multiple `#include` directives as associated and they will all be considered as such.
+You can mark multiple `#include` directives as associated and they will all be
+considered as such.
+
 
 ## IWYU pragma: always_keep ##
 
-This pragma applies to the current header file. It says that any include of this file will be preserved by all includers.
+This pragma applies to the current header file. It says that any include of this
+file will be preserved by all includers.
 
     header.h:
       // IWYU pragma: always_keep
@@ -192,31 +246,58 @@ This pragma applies to the current header file. It says that any include of this
     main.cc:
       #include "header.h"
 
-Even if no symbols from `header.h` are used in `main.cc`, it will not be suggested for removal.
+Even if no symbols from `header.h` are used in `main.cc`, it will not be
+suggested for removal.
 
-This is useful for headers that provide additional type traits that aren't possible for IWYU to track (e.g. hash functions for a type, to be used by STL containers).
+This is useful for headers that provide additional type traits that aren't
+possible for IWYU to track (e.g. hash functions for a type, to be used by STL
+containers).
+
 
 ## Which pragma should I use? ##
 
-Ideally, IWYU should be smart enough to understand your intentions (and intentions of the authors of libraries you use), so the first answer should always be: none.
+Ideally, IWYU should be smart enough to understand your intentions (and
+intentions of the authors of libraries you use), so the first answer should
+always be: none.
 
-In practice, intentions are not so clear -- it might be ambiguous whether an `#include` is there by clever design or by mistake, whether an `#include` serves to export symbols from a private header through a public facade or if it's just a left-over after some clean-up. Even when intent is obvious, IWYU can make mistakes due to bugs or not-yet-implemented policies.
+In practice, intentions are not so clear -- it might be ambiguous whether an
+`#include` is there by clever design or by mistake, whether an `#include` serves
+to export symbols from a private header through a public facade or if it's just
+a left-over after some clean-up. Even when intent is obvious, IWYU can make
+mistakes due to bugs or not-yet-implemented policies.
 
-IWYU pragmas have some overlap, so it can sometimes be hard to choose one over the other. Here's a guide based on how I understand them at the moment:
+IWYU pragmas have some overlap, so it can sometimes be hard to choose one over
+the other. Here's a guide based on how I understand them at the moment:
 
-* Use `IWYU pragma: keep` to force IWYU to keep any `#include` directive that would be discarded under its normal policies.
-* Use `IWYU pragma: always_keep` to force IWYU to keep a header in all includers, whether they contribute any used symbols or not.
-* Use `IWYU pragma: export` to tell IWYU that one header serves as the provider for all symbols in another, included header (e.g. facade headers). Use `IWYU pragma: begin_exports/end_exports` for a whole group of included headers.
-* Use `IWYU pragma: no_include` to tell IWYU that the file in which the pragma is defined should never `#include` a specific header (the header may already be included via some other `#include`.)
-* Use `IWYU pragma: no_forward_declare` to tell IWYU that the file in which the pragma is defined should never forward-declare a specific symbol (a forward declaration may already be available via some other `#include`.)
-* Use `IWYU pragma: private` to tell IWYU that the header in which the pragma is defined is private, and should not be included directly.
-* Use `IWYU pragma: private, include "public.h"` to tell IWYU that the header in which the pragma is defined is private, and `public.h` should always be included instead.
-* Use `IWYU pragma: friend ".*favorites.*"` to override `IWYU pragma: private` selectively, so that a set of files identified by a regex can include the file even if it's private.
+* Use `IWYU pragma: keep` to force IWYU to keep any `#include` directive that
+  would be discarded under its normal policies.
+* Use `IWYU pragma: always_keep` to force IWYU to keep a header in all
+  includers, whether they contribute any used symbols or not.
+* Use `IWYU pragma: export` to tell IWYU that one header serves as the provider
+  for all symbols in another, included header (e.g. facade headers). Use `IWYU
+  pragma: begin_exports/end_exports` for a whole group of included headers.
+* Use `IWYU pragma: no_include` to tell IWYU that the file in which the pragma
+  is defined should never `#include` a specific header (the header may already
+  be included via some other `#include`.)
+* Use `IWYU pragma: no_forward_declare` to tell IWYU that the file in which the
+  pragma is defined should never forward-declare a specific symbol (a forward
+  declaration may already be available via some other `#include`.)
+* Use `IWYU pragma: private` to tell IWYU that the header in which the pragma is
+  defined is private, and should not be included directly.
+* Use `IWYU pragma: private, include "public.h"` to tell IWYU that the header in
+  which the pragma is defined is private, and `public.h` should always be
+  included instead.
+* Use `IWYU pragma: friend ".*favorites.*"` to override `IWYU pragma: private`
+  selectively, so that a set of files identified by a regex can include the file
+  even if it's private.
 
 The pragmas come in three different classes;
 
   1. Ones that apply to a single `#include` directive (`keep`, `export`)
-  2. Ones that apply to a file being included (`private`, `friend`, `always_keep`)
-  3. Ones that apply to a file including other headers (`no_include`, `no_forward_declare`)
+  2. Ones that apply to a file being included (`private`, `friend`,
+     `always_keep`)
+  3. Ones that apply to a file including other headers (`no_include`,
+     `no_forward_declare`)
 
-Some files are both included and include others, so it can make sense to mix and match.
+Some files are both included and include others, so it can make sense to mix and
+match.

--- a/docs/WhatIsAUse.md
+++ b/docs/WhatIsAUse.md
@@ -1,12 +1,27 @@
 # What is a use? #
 
-(*Disclaimer:* the information here is accurate as of 12 May 2011, when it was written.  Specifics of IWYU's policy, and even philosophy, may have changed since then.  We'll try to remember to update this file as that happens, but may occasionally forget.  The further we are from May 2011, the more you should take the below with a grain of salt.)
+(*Disclaimer:* the information here is accurate as of 12 May 2011, when it was
+written.  Specifics of IWYU's policy, and even philosophy, may have changed
+since then.  We'll try to remember to update this file as that happens, but may
+occasionally forget.  The further we are from May 2011, the more you should take
+the below with a grain of salt.)
 
-IWYU has the policy that you should `#include` a declaration for every symbol you "use" in a file, or forward-declare it if possible.  But what does it mean to "use" a symbol?
+IWYU has the policy that you should `#include` a declaration for every symbol
+you "use" in a file, or forward-declare it if possible.  But what does it mean
+to "use" a symbol?
 
-For the most part, IWYU considers a "use" the same as the compiler does: if you get a compiler error saying "Unknown symbol 'foo'", then you are using `foo`.  Whether the use is a 'full' use, that needs the definition of the symbol, or a 'forward-declare' use, that can get by with just a declaration of the symbol, likewise matches what the compiler allows.
+For the most part, IWYU considers a "use" the same as the compiler does: if you
+get a compiler error saying "Unknown symbol 'foo'", then you are using `foo`.
+Whether the use is a 'full' use, that needs the definition of the symbol, or a
+'forward-declare' use, that can get by with just a declaration of the symbol,
+likewise matches what the compiler allows.
 
-This makes it sound like IWYU does the moral equivalent of taking a source file, removing `#include` lines from it, seeing what the compiler complains about, and marking uses as appropriate.  This is not what IWYU does.  Instead, IWYU does a thought experiment: if the definition (or declaration) of a given type were not available, would the code compile?  Here is an example illustrating the difference:
+This makes it sound like IWYU does the moral equivalent of taking a source file,
+removing `#include` lines from it, seeing what the compiler complains about, and
+marking uses as appropriate.  This is not what IWYU does.  Instead, IWYU does a
+thought experiment: if the definition (or declaration) of a given type were not
+available, would the code compile?  Here is an example illustrating the
+difference:
 
     foo.h:
       #include <ostream>
@@ -17,56 +32,103 @@ This makes it sound like IWYU does the moral equivalent of taking a source file,
       OutputEmitter oe;
       oe << 5;
 
-Does `bar.cc` "use" `std::ostream`, such that it should `#include <ostream>`?  You'd hope the answer would be no: the whole point of the `OutputEmitter` typedef, presumably, is to hide the fact the type is an `std::ostream`.  Having to have clients `#include <ostream>` rather defeats that purpose.  But IWYU sees that you're calling `operator<<(std::ostream&, int)`, which is defined in `<ostream>`, so naively, it should say that you need that header.
+Does `bar.cc` "use" `std::ostream`, such that it should `#include <ostream>`?
+You'd hope the answer would be no: the whole point of the `OutputEmitter`
+typedef, presumably, is to hide the fact the type is an `std::ostream`.  Having
+to have clients `#include <ostream>` rather defeats that purpose.  But IWYU sees
+that you're calling `operator<<(std::ostream&, int)`, which is defined in
+`<ostream>`, so naively, it should say that you need that header.
 
-But IWYU doesn't (at least, modulo bugs).  This is because of its attempt to analyze "author intent".
+But IWYU doesn't (at least, modulo bugs).  This is because of its attempt to
+analyze "author intent".
 
 ## Author intent ##
 
-If code has `typedef Foo MyTypedef`, and you write `MyTypedef var;`, you are using `MyTypedef`, but are you also using `Foo`?  The answer depends on the _intent_ of the person who wrote the typedef.
+If code has `typedef Foo MyTypedef`, and you write `MyTypedef var;`, you are
+using `MyTypedef`, but are you also using `Foo`?  The answer depends on the
+_intent_ of the person who wrote the typedef.
 
-In the `OutputEmitter` example above, while we don't know for sure, we can guess that the intent of the author was that clients should not be considered to use the underlying type -- and thus they shouldn't have to `#include <ostream>` themselves.  In that case, the typedef author takes responsibility for the underlying type, promising to provide all the definitions needed to make code compile.  The philosophy here is: "As long as you `#include "foo.h"`, you can use `OutputEmitter` however you want, without worry of compilation errors."
+In the `OutputEmitter` example above, while we don't know for sure, we can guess
+that the intent of the author was that clients should not be considered to use
+the underlying type -- and thus they shouldn't have to `#include <ostream>`
+themselves.  In that case, the typedef author takes responsibility for the
+underlying type, promising to provide all the definitions needed to make code
+compile.  The philosophy here is: "As long as you `#include "foo.h"`, you can
+use `OutputEmitter` however you want, without worry of compilation errors."
 
 Some typedef authors have a different intent.  `<iosfwd>` has the line
 
     typedef basic_ostream<char> ostream;
 
-but it does *not* promise "as long as you `#include <iosfwd>`, you can use `std::ostream` however you want, without worry of compilation errors."  For most uses of `std::ostream`, you'll get a compiler error unless you `#include <ostream>` as well.
+but it does *not* promise "as long as you `#include <iosfwd>`, you can use
+`std::ostream` however you want, without worry of compilation errors."  For most
+uses of `std::ostream`, you'll get a compiler error unless you `#include
+<ostream>` as well.
 
 So take a slightly modified version of the above `foo.h`:
 
     #include <iosfwd>
     typedef std::ostream OutputEmitter;
 
-This is a self-contained .h file: it's perfectly legal to typedef an incomplete type (that's what `iosfwd` itself does).  But now IWYU had better tell `bar.cc` to `#include <ostream>`, or it will break the build.  The difference is in the author intent with the typedef.
+This is a self-contained .h file: it's perfectly legal to typedef an incomplete
+type (that's what `iosfwd` itself does).  But now IWYU had better tell `bar.cc`
+to `#include <ostream>`, or it will break the build.  The difference is in the
+author intent with the typedef.
 
-Another case where author intent turns up is in function return types.  Consider this function declaration:
+Another case where author intent turns up is in function return types.  Consider
+this function declaration:
 
     Foo* GetSingletonObject();   // Foo is defined in foo.h
 
-If you write `GetSingletonObject()->methodOnFoo()`, are you "using" `Foo::methodOnFoo`, such that you should `#include "foo.h"`?  Or are you supposed to be able to operate on the results of `GetSingletonObject` without needing to include the definition of the returned type?  The answer is: it depends on the author intent.  Sometimes the author is willing to provide the definition of the return type, sometimes it is not.
+If you write `GetSingletonObject()->methodOnFoo()`, are you "using"
+`Foo::methodOnFoo`, such that you should `#include "foo.h"`?  Or are you
+supposed to be able to operate on the results of `GetSingletonObject` without
+needing to include the definition of the returned type?  The answer is: it
+depends on the author intent.  Sometimes the author is willing to provide the
+definition of the return type, sometimes it is not.
+
 
 ### Re-exporting ###
 
-When the author of a file is providing a definition of a symbol from somewhere else, we say that the file is "re-exporting" that symbol.  In the first `OutputEmitter` example, we say that `foo.h` is re-exporting `ostream`.  As a result, people who `#include "foo.h"` get a definition of `ostream` along for free, even if they don't directly `#include <ostream>` themselves.  Another way of thinking about it is: if file A re-exports symbol B, we can pretend that A defines B, even if it doesn't.
+When the author of a file is providing a definition of a symbol from somewhere
+else, we say that the file is "re-exporting" that symbol.  In the first
+`OutputEmitter` example, we say that `foo.h` is re-exporting `ostream`.  As a
+result, people who `#include "foo.h"` get a definition of `ostream` along for
+free, even if they don't directly `#include <ostream>` themselves.  Another way
+of thinking about it is: if file A re-exports symbol B, we can pretend that A
+defines B, even if it doesn't.
 
-(In an ideal world, we'd have a very fine-grained concept: "File A re-exports symbol S when it's used in the context of typedef T [or function F, or ...]," but in reality, we have the much looser concept "file A re-exports all symbols from file B.")
+(In an ideal world, we'd have a very fine-grained concept: "File A re-exports
+symbol S when it's used in the context of typedef T [or function F, or ...],"
+but in reality, we have the much looser concept "file A re-exports all symbols
+from file B.")
 
-A more accurate include-what-you-use rule is this: "If you use a symbol, you must either `#include` the definition of the symbol, or `#include` a file that re-exports the symbol."
+A more accurate include-what-you-use rule is this: "If you use a symbol, you
+must either `#include` the definition of the symbol, or `#include` a file that
+re-exports the symbol."
+
 
 ## Manual re-export identifiers ##
 
-You can mark that one file is re-exporting symbols from another via an IWYU pragma in your source code:
+You can mark that one file is re-exporting symbols from another via an IWYU
+pragma in your source code:
 
     #include "private.h"   // IWYU pragma: export
 
-This tells IWYU that if some other file uses symbols defined in `private.h`, they can `#include` you to get them, if they want.
+This tells IWYU that if some other file uses symbols defined in `private.h`,
+they can `#include` you to get them, if they want.
 
 The full list of IWYU pragmas is defined in [IWYUPragmas.md](IWYUPragmas.md).
 
+
 ## Automatic re-export ##
 
-In certain situations, IWYU will decide that one file is exporting a symbol from another even without the use of a pragma.  These are places where the author intent is usually to re-export, such as with the `typedef` example above.  In each of these cases, a simple technique can be used to override IWYU's decision to re-export.
+In certain situations, IWYU will decide that one file is exporting a symbol from
+another even without the use of a pragma.  These are places where the author
+intent is usually to re-export, such as with the `typedef` example above.  In
+each of these cases, a simple technique can be used to override IWYU's decision
+to re-export.
+
 
 ### Automatic re-export: typedefs ###
 
@@ -74,10 +136,14 @@ If you write
 
     typedef Foo MyTypedef;
 
-IWYU has to decide whether your file should re-export `Foo` or not.  Here is how it gauges author intent:
+IWYU has to decide whether your file should re-export `Foo` or not.  Here is how
+it gauges author intent:
 
-* If you (the typedef author), directly `#include` the definition of the underlying type, then IWYU assumes you mean to re-export it.
-* If you (the typedef author), explicitly provide a forward-declare of the underlying type, but do not directly `#include` its definition, then IWYU assumes you do not mean to re-export it.
+* If you (the typedef author), directly `#include` the definition of the
+  underlying type, then IWYU assumes you mean to re-export it.
+* If you (the typedef author), explicitly provide a forward-declare of the
+  underlying type, but do not directly `#include` its definition, then IWYU
+  assumes you do not mean to re-export it.
 * Otherwise, IWYU assumes you do not mean to re-export it.
 
 For example:
@@ -91,9 +157,16 @@ For example:
     #include "file_including_baz.h"   // does not define Baz itself
     typedef Baz Typedef3;   // IWYU says you do not intend to re-export Baz
 
-If IWYU says you intend to re-export the underlying type, then nobody who uses your typedef needs to `#include` the definition of the underlying type.  In contrast, if IWYU says you do not intend to re-export the underlying type, then everybody who uses your typedef needs to `#include` the definition of the underlying type.
+If IWYU says you intend to re-export the underlying type, then nobody who uses
+your typedef needs to `#include` the definition of the underlying type.  In
+contrast, if IWYU says you do not intend to re-export the underlying type, then
+everybody who uses your typedef needs to `#include` the definition of the
+underlying type.
 
-IWYU supports this in its analysis.  If you are using `Typedef1` in your code and `#include "foo.h"` anyway, IWYU will suggest you remove it, since you are getting the definition of `Foo` via the typedef.
+IWYU supports this in its analysis.  If you are using `Typedef1` in your code
+and `#include "foo.h"` anyway, IWYU will suggest you remove it, since you are
+getting the definition of `Foo` via the typedef.
+
 
 ### Automatic re-export: function return values ###
 
@@ -108,7 +181,8 @@ The same rule applies with the return value in a function declaration:
     #include "file_including_baz.h"
     Baz Func3();   // IWYU says you do not intend to re-export Baz
 
-(Note that C++ is perfectly happy with a forward-declaration of the return type, if the function is just being declared, and not defined.)
+(Note that C++ is perfectly happy with a forward-declaration of the return type,
+if the function is just being declared, and not defined.)
 
 As of May 2011, the rule does *not* apply when returning a pointer or reference:
 
@@ -118,7 +192,8 @@ As of May 2011, the rule does *not* apply when returning a pointer or reference:
     #include "bar.h"
     Bar& Func2();   // IWYU says you do *not* intend to re-export Bar
 
-This is considered a bug, and the behavior will likely change in the future to match the case where the functions return a class.
+This is considered a bug, and the behavior will likely change in the future to
+match the case where the functions return a class.
 
 Here is an example of the rule in action:
 
@@ -134,7 +209,9 @@ Here is an example of the rule in action:
       #include "bar.h"
       ConsumeFoo(CreateFoo());
 
-In this case, IWYU will say that `baz.cc` does not need to `#include "foo.h"`, since `bar.h` re-exports it.
+In this case, IWYU will say that `baz.cc` does not need to `#include "foo.h"`,
+since `bar.h` re-exports it.
+
 
 ### Automatic re-export: conversion constructors ###
 
@@ -154,7 +231,9 @@ Consider the following code:
       #include "bar.h"
       MyFunc(11);
 
-The above code does not compile, because the code to convert `11` to a `Foo` is not visible to `baz.cc`.  Either `baz.cc` or `bar.h` needs to `#include "foo.h"` to make the conversion constructor visible where `MyFunc` is being called.
+The above code does not compile, because the code to convert `11` to a `Foo` is
+not visible to `baz.cc`.  Either `baz.cc` or `bar.h` needs to `#include "foo.h"`
+to make the conversion constructor visible where `MyFunc` is being called.
 
 The same rule applies as before:
 
@@ -167,9 +246,11 @@ The same rule applies as before:
     #include "file_including_foo.h"
     void Func3(Foo foo);   // IWYU says you do not intend to re-export Foo
 
-As before, if IWYU decides you do not intend to re-export `Foo`, then all callers (in this case, `baz.cc`) need to.
+As before, if IWYU decides you do not intend to re-export `Foo`, then all
+callers (in this case, `baz.cc`) need to.
 
-The rule here applies even to const references (which can also be automatically converted):
+The rule here applies even to const references (which can also be automatically
+converted):
 
     #include "foo.h"
     void Func1(const Foo& foo);   // IWYU says you intend to re-export Foo

--- a/docs/WhyIWYU.md
+++ b/docs/WhyIWYU.md
@@ -1,51 +1,120 @@
 # Why include what you use? #
 
-Are there any concrete benefits to a strict include-what-you-use policy? We like to think so.
+Are there any concrete benefits to a strict include-what-you-use policy? We like
+to think so.
+
 
 ## Faster compiles ##
 
-Every .h file you bring in when compiling a source file lengthens the time to compile, as the bytes have to be read, preprocessed, and parsed.  If you're not actually using a .h file, you remove that cost.  With template code, where entire instantiations have to be in .h files, this can be hundreds of thousands of bytes of code.  In one case at Google, running include-what-you-use over a .cc file improved its compile time by 30%.
+Every .h file you bring in when compiling a source file lengthens the time to
+compile, as the bytes have to be read, preprocessed, and parsed.  If you're not
+actually using a .h file, you remove that cost.  With template code, where
+entire instantiations have to be in .h files, this can be hundreds of thousands
+of bytes of code.  In one case at Google, running include-what-you-use over a
+.cc file improved its compile time by 30%.
 
-Here, the main benefit of include-what-you-use comes from the flip side: "don't include what you don't use."
+Here, the main benefit of include-what-you-use comes from the flip side: "don't
+include what you don't use."
+
 
 ## Fewer recompiles ##
 
-Many build tools, such as `make`, provide a mechanism for automatically figuring out what .h files a .cc file depends on.  These mechanisms typically look at `#include` lines.  When unnecessary `#includes` are listed, the build system is more likely to recompile in cases where it's not necessary.
+Many build tools, such as `make`, provide a mechanism for automatically figuring
+out what .h files a .cc file depends on.  These mechanisms typically look at
+`#include` lines.  When unnecessary `#includes` are listed, the build system is
+more likely to recompile in cases where it's not necessary.
 
 Again, the main advantage here is from "don't include what you don't use."
 
+
 ## Allow refactoring ##
 
-Suppose you refactor `foo.h` so it no longer uses vectors.  You'd like to remove `#include <vector>` from `foo.h`, to reduce compile time -- template class files such as `vector` can include a lot of code.  But can you?  In theory yes, but in practice maybe not: some other file may be #including you and using vectors, and depending (probably unknowingly) on your `#include <vector>` to compile.  Your refactor could break code far away from you.
+Suppose you refactor `foo.h` so it no longer uses vectors.  You'd like to remove
+`#include <vector>` from `foo.h`, to reduce compile time -- template class files
+such as `vector` can include a lot of code.  But can you?  In theory yes, but in
+practice maybe not: some other file may be #including you and using vectors, and
+depending (probably unknowingly) on your `#include <vector>` to compile.  Your
+refactor could break code far away from you.
 
-This is most compelling for a very large codebase (such as Google's).  In a small codebase, it's practical to just compile everything after a refactor like this, and clean up any errors you see.  When your codebase contains hundreds of thousands of source files, identifying and cleaning up the errors can be a project in itself.  In practice, people are likely to just leave the `#include <vector>` line in there, even though it's unnecessary.
+This is most compelling for a very large codebase (such as Google's).  In a
+small codebase, it's practical to just compile everything after a refactor like
+this, and clean up any errors you see.  When your codebase contains hundreds of
+thousands of source files, identifying and cleaning up the errors can be a
+project in itself.  In practice, people are likely to just leave the `#include
+<vector>` line in there, even though it's unnecessary.
 
-Here, it's the actual 'include what you use' policy that saves the day.  If everyone who uses vector is #including `<vector>` themselves, then you can remove `<vector>` without fear of breaking anything.
+Here, it's the actual 'include what you use' policy that saves the day.  If
+everyone who uses vector is #including `<vector>` themselves, then you can
+remove `<vector>` without fear of breaking anything.
+
 
 ## Self-documentation ##
 
-When you can trust the `#include` lines to accurately reflect what is used in the file, you can use them to help you understand the code.  Looking at them, in itself, can help you understand what this file needs in order to do its work.  If you use the optional 'commenting' feature of `fix_includes.py`, you can see what symbols -- what functions and classes -- are used by this code.  It's like a pared-down version of doxygen markup, but totally automated and present where the code is (rather than in a separate web browser).
+When you can trust the `#include` lines to accurately reflect what is used in
+the file, you can use them to help you understand the code.  Looking at them, in
+itself, can help you understand what this file needs in order to do its work.
+If you use the optional 'commenting' feature of `fix_includes.py`, you can see
+what symbols -- what functions and classes -- are used by this code.  It's like
+a pared-down version of doxygen markup, but totally automated and present where
+the code is (rather than in a separate web browser).
 
-The 'commented' `#include` lines can also make it simpler to match function calls and classes to the files that define them, without depending on a particular IDE.
+The 'commented' `#include` lines can also make it simpler to match function
+calls and classes to the files that define them, without depending on a
+particular IDE.
 
-(The downside, of course, is the comments can get out of date as the code changes, so unless you run IWYU often, you still have to take the comments with a grain of salt.  Nothing is free. :-) )
+(The downside, of course, is the comments can get out of date as the code
+changes, so unless you run IWYU often, you still have to take the comments with
+a grain of salt.  Nothing is free. :-) )
+
 
 ## Dependency cutting ##
 
-Again, this makes the most sense for large code-bases.  Suppose your binaries are larger than you would expect, and upon closer examination use symbols that seem totally irrelevant.  Where do they come from?  Why are they there?  With include-what-you-use, you can easily determine this by seeing who includes the files that define these symbols: those includers, and those alone, are responsible for the use.
+Again, this makes the most sense for large code-bases.  Suppose your binaries
+are larger than you would expect, and upon closer examination use symbols that
+seem totally irrelevant.  Where do they come from?  Why are they there?  With
+include-what-you-use, you can easily determine this by seeing who includes the
+files that define these symbols: those includers, and those alone, are
+responsible for the use.
 
-Once you know where a symbol is used in your binary, you can see how practical it is to remove that use, perhaps by breaking up the relevant .h files into two parts, and fixing up all callers.  Again it's IWYU to the rescue: with include-what-you-use, figuring out the callers that need fixing is easy.
+Once you know where a symbol is used in your binary, you can see how practical
+it is to remove that use, perhaps by breaking up the relevant .h files into two
+parts, and fixing up all callers.  Again it's IWYU to the rescue: with
+include-what-you-use, figuring out the callers that need fixing is easy.
+
 
 ## Why forward-declare? ##
 
-Include-what-you-use tries very hard to figure out when a forward-declare can be used instead of an `#include` (IWYU would be about 90% less code if it didn't bother with trying to forward-declare).
+Include-what-you-use tries very hard to figure out when a forward-declare can be
+used instead of an `#include` (IWYU would be about 90% less code if it didn't
+bother with trying to forward-declare).
 
-The reason for this is simple: if you can replace an `#include` by a forward-declare, you reduce the code size, speeding up compiles as described above.  You also make it easier to break dependencies: not only do you not depend on that header file, you no longer depend on everything it brings in.
+The reason for this is simple: if you can replace an `#include` by a
+forward-declare, you reduce the code size, speeding up compiles as described
+above.  You also make it easier to break dependencies: not only do you not
+depend on that header file, you no longer depend on everything it brings in.
 
-There's a cost to forward-declaring as well: you lose the documentation features mentioned above, that come with `#include` lines.  (A future version of IWYU may mitigate this problem.)  And if a class changes -- for instance, it adds a new default template argument -- you need to change many callsites, not just one.  It is also easier to accidentally violate the [One Definition Rule](http://en.wikipedia.org/wiki/One_Definition_Rule) when all you expose is the name of a class (via a forward declare) rather than the full definition (via an `#include`).
+There's a cost to forward-declaring as well: you lose the documentation features
+mentioned above, that come with `#include` lines.  (A future version of IWYU may
+mitigate this problem.)  And if a class changes -- for instance, it adds a new
+default template argument -- you need to change many callsites, not just one.
+It is also easier to accidentally violate the [One Definition
+Rule](http://en.wikipedia.org/wiki/One_Definition_Rule) when all you expose is
+the name of a class (via a forward declare) rather than the full definition (via
+an `#include`).
 
-One compromise approach is to use 'forwarding headers', such as `<iosfwd>`.  These forwarding headers could have comments saying where the definition of each forward-declared class is.  Include-what-you-use does not currently support forwarding headers, but may in the future.
+One compromise approach is to use 'forwarding headers', such as `<iosfwd>`.
+These forwarding headers could have comments saying where the definition of each
+forward-declared class is.  Include-what-you-use does not currently support
+forwarding headers, but may in the future.
 
-Since some coding standards have taken to [discourage forward declarations](https://google.github.io/styleguide/cppguide.html#Forward_Declarations), IWYU has grown a `--no_fwd_decls` mode to embrace this alternative strategy. Where IWYU's default behavior is to minimize the number of include directives, IWYU with `--no_fwd_decls` will attempt to minimize the number of times each type is redeclared. The result is that include directives will always be preferred over local forward declarations, even if it means including a header just for a name-only type declaration.
+Since some coding standards have taken to [discourage forward
+declarations](https://google.github.io/styleguide/cppguide.html#Forward_Declarations),
+IWYU has grown a `--no_fwd_decls` mode to embrace this alternative
+strategy. Where IWYU's default behavior is to minimize the number of include
+directives, IWYU with `--no_fwd_decls` will attempt to minimize the number of
+times each type is redeclared. The result is that include directives will always
+be preferred over local forward declarations, even if it means including a
+header just for a name-only type declaration.
 
-We still think IWYU's normal policy is preferable for all the reasons above, but if your codebase has a no-forward-declare policy, so does IWYU.
+We still think IWYU's normal policy is preferable for all the reasons above, but
+if your codebase has a no-forward-declare policy, so does IWYU.

--- a/docs/WhyIWYUIsDifficult.md
+++ b/docs/WhyIWYUIsDifficult.md
@@ -1,25 +1,36 @@
 # Why include-what-you-use is difficult #
 
-This section is informational, for folks who are wondering why include-what-you-use requires so much code and yet still has so many errors.
+This section is informational, for folks who are wondering why
+include-what-you-use requires so much code and yet still has so many errors.
 
-Include-what-you-use has the most problems with templates and macros. If your code doesn't use either, IWYU will probably do great. And, you're probably not actually programming in C++...
+Include-what-you-use has the most problems with templates and macros. If your
+code doesn't use either, IWYU will probably do great. And, you're probably not
+actually programming in C++...
+
 
 ## Use versus forward declare ##
 
-Include-what-you-use has to be able to tell when a symbol is being used in a way that you can forward-declare it. Otherwise, if you wrote
+Include-what-you-use has to be able to tell when a symbol is being used in a way
+that you can forward-declare it. Otherwise, if you wrote
 
     vector<MyClass*> foo;
 
-IWYU would tell you to `#include "myclass.h"`, when perhaps the whole reason you're using a pointer here is to avoid the need for that `#include`.
+IWYU would tell you to `#include "myclass.h"`, when perhaps the whole reason
+you're using a pointer here is to avoid the need for that `#include`.
 
-In the above case, it's pretty easy for IWYU to tell that we can safely forward-declare `MyClass`. But now consider
+In the above case, it's pretty easy for IWYU to tell that we can safely
+forward-declare `MyClass`. But now consider
 
     vector<MyClass> foo;        // requires full definition of MyClass
     scoped_ptr<MyClass> foo;    // forward-declaring MyClass is often ok
 
-To distinguish these, clang has to instantiate the vector and scoped_ptr template classes, including analyzing all member variables and the bodies of the constructor and destructor (and recursively for superclasses).
+To distinguish these, clang has to instantiate the vector and scoped_ptr
+template classes, including analyzing all member variables and the bodies of the
+constructor and destructor (and recursively for superclasses).
 
-But that's not enough: when instantiating the templates, we need to keep track of which symbols come from template arguments and which don't. For instance, suppose you call `MyFunc<MyClass>()`, where `MyFunc` looks like this:
+But that's not enough: when instantiating the templates, we need to keep track
+of which symbols come from template arguments and which don't. For instance,
+suppose you call `MyFunc<MyClass>()`, where `MyFunc` looks like this:
 
     template<typename T> void MyFunc() {
       T* t;
@@ -27,11 +38,17 @@ But that's not enough: when instantiating the templates, we need to keep track o
       ...
     }
 
-In this case, the caller of `MyFunc` is not using the full type of `MyClass`, because the template parameter is only used as a pointer. On the other hand, the file that defines `MyFunc` is using the full type information for `MyClass`. The end result is that the caller can forward-declare `MyClass`, but the file defining `MyFunc` has to `#include "myclass.h"`.
+In this case, the caller of `MyFunc` is not using the full type of `MyClass`,
+because the template parameter is only used as a pointer. On the other hand, the
+file that defines `MyFunc` is using the full type information for `MyClass`. The
+end result is that the caller can forward-declare `MyClass`, but the file
+defining `MyFunc` has to `#include "myclass.h"`.
+
 
 ## Handling template arguments ##
 
-Even figuring out what types are 'used' with a template can be difficult. Consider the following two declarations:
+Even figuring out what types are 'used' with a template can be
+difficult. Consider the following two declarations:
 
     vector<MyClass> v;
     hash_set<MyClass> h;
@@ -41,22 +58,44 @@ These both have default template arguments, so are parsed like
     vector<MyClass, alloc<MyClass> > v;
     hash_set<MyClass, hash<MyClass>, equal_to<MyClass>, alloc<MyClass> > h;
 
-What symbols should we say are used? If we say `alloc<MyClass>` is used when you declare a vector, then every file that `#includes` `<vector>` will also need to `#include <memory>`.
+What symbols should we say are used? If we say `alloc<MyClass>` is used when you
+declare a vector, then every file that `#includes` `<vector>` will also need to
+`#include <memory>`.
 
-So it's tempting to just ignore default template arguments. But that's not right either. What if `hash<MyClass>` is defined in some local `myhash.h` file (as `hash<string>` often is)? Then we want to make sure IWYU says to `#include "myhash.h"` when you create the hash_set (otherwise the code won't compile). That requires paying attention to the default template argument. Figuring out how to handle default template arguments can get very complex.
+So it's tempting to just ignore default template arguments. But that's not right
+either. What if `hash<MyClass>` is defined in some local `myhash.h` file (as
+`hash<string>` often is)? Then we want to make sure IWYU says to `#include
+"myhash.h"` when you create the hash_set (otherwise the code won't
+compile). That requires paying attention to the default template
+argument. Figuring out how to handle default template arguments can get very
+complex.
 
-Even normal template arguments can be confusing. Consider this templated function:
+Even normal template arguments can be confusing. Consider this templated
+function:
 
     template<typename A, typename B, typename C> void MyFunc(A (*fn)(B,C))
     { ... }
 
-and you call `MyFunc(FunctionReturningAFunctionPointer())`. What types are being used where, in this case?
+and you call `MyFunc(FunctionReturningAFunctionPointer())`. What types are being
+used where, in this case?
+
 
 ## Who is responsible for dependent template types? ##
 
-If you say `vector<MyClass> v;`, it's clear that you, and not `vector.h` are responsible for the use of `MyClass`, even though all the functions that use `MyClass` are defined in `vector.h`. (OK, technically, these functions are not "defined" in a particular location, they're instantiated from template methods written in `vector.h`, but for us it works out the same.)
+If you say `vector<MyClass> v;`, it's clear that you, and not `vector.h` are
+responsible for the use of `MyClass`, even though all the functions that use
+`MyClass` are defined in `vector.h`. (OK, technically, these functions are not
+"defined" in a particular location, they're instantiated from template methods
+written in `vector.h`, but for us it works out the same.)
 
-When you say `hash_map<MyClass, int> h;`, you are likewise responsible for `MyClass` (and `int`), but are you responsible for `pair<MyClass, int>`? That is the type that hash_map uses to store your entries internally, and it depends on one of your template arguments, but even so  it shouldn't be your responsibility -- it's an implementation detail of hash_map. Of course, if you say `hash_map<pair<int, int>, int>`, then you are responsible for the use of `pair`. Distinguishing these two cases from each other, and from the vector case, can be difficult.
+When you say `hash_map<MyClass, int> h;`, you are likewise responsible for
+`MyClass` (and `int`), but are you responsible for `pair<MyClass, int>`? That is
+the type that hash_map uses to store your entries internally, and it depends on
+one of your template arguments, but even so it shouldn't be your responsibility
+-- it's an implementation detail of hash_map. Of course, if you say
+`hash_map<pair<int, int>, int>`, then you are responsible for the use of
+`pair`. Distinguishing these two cases from each other, and from the vector
+case, can be difficult.
 
 Now suppose there's a template function like this:
 
@@ -66,15 +105,31 @@ Now suppose there's a template function like this:
       cerr << t;
     }
 
-If you call `MyFunc(some_char_star)`, which of these symbols are you responsible for, and which is the author of `MyFunc` responsible for: `strcat`, `strchr`, `operator<<(ostream&, T)`?
+If you call `MyFunc(some_char_star)`, which of these symbols are you responsible
+for, and which is the author of `MyFunc` responsible for: `strcat`, `strchr`,
+`operator<<(ostream&, T)`?
 
-`strcat` is a normal function, and the author of `MyFunc` is responsible for its use. This is an easy case.
+`strcat` is a normal function, and the author of `MyFunc` is responsible for its
+use. This is an easy case.
 
-In C++, `strchr` is a templatized function (different impls for `char*` and `const char*`). Which version is called depends on the template argument. So, naively, we'd conclude that the caller is responsible for the use of `strchr`. However, that's ridiculous; we don't want caller of `MyFunc` to have to `#include <string.h>` just to call `MyFunc`. We have special code that (usually) handles this kind of case.
+In C++, `strchr` is a templatized function (different impls for `char*` and
+`const char*`). Which version is called depends on the template argument. So,
+naively, we'd conclude that the caller is responsible for the use of
+`strchr`. However, that's ridiculous; we don't want caller of `MyFunc` to have
+to `#include <string.h>` just to call `MyFunc`. We have special code that
+(usually) handles this kind of case.
 
-`operator<<` is also a templated function, but it's one that may be defined in lots of different files. It would be ridiculous in its own way if `MyFunc` was responsible for including every file that defines `operator<<(ostream&, T)` for all `T`. So, unlike the two cases above, the caller is the one responsible for the use of `operator<<`, and will have to `#include` the file that defines it. It's counter-intuitive, perhaps, but the alternatives are all worse.
+`operator<<` is also a templated function, but it's one that may be defined in
+lots of different files. It would be ridiculous in its own way if `MyFunc` was
+responsible for including every file that defines `operator<<(ostream&, T)` for
+all `T`. So, unlike the two cases above, the caller is the one responsible for
+the use of `operator<<`, and will have to `#include` the file that defines
+it. It's counter-intuitive, perhaps, but the alternatives are all worse.
 
-As you can imagine, distinguishing all these cases is extremely difficult. To get it exactly right would require re-implementing C++'s (byzantine) lookup rules, which we have not yet tackled.
+As you can imagine, distinguishing all these cases is extremely difficult. To
+get it exactly right would require re-implementing C++'s (byzantine) lookup
+rules, which we have not yet tackled.
+
 
 ## Template template types ##
 
@@ -84,32 +139,64 @@ Let's say you have a function
       T<string> t;
     }
 
-And you call `MyFunc<hash_set>`. Who is responsible for the 'use' of `hash<string>`, and thus needs to `#include "myhash.h"`? I think it has to be the caller, even if the  caller never uses the `string` type in its file at all. This is rather counter-intuitive. Luckily, it's also rather rare.
+And you call `MyFunc<hash_set>`. Who is responsible for the 'use' of
+`hash<string>`, and thus needs to `#include "myhash.h"`? I think it has to be
+the caller, even if the caller never uses the `string` type in its file at
+all. This is rather counter-intuitive. Luckily, it's also rather rare.
+
 
 ## Typedefs ##
 
-Suppose you `#include` a file `"foo.h"` that has typedef `hash_map<Foo, Bar> MyMap;`. And you have this code:
+Suppose you `#include` a file `"foo.h"` that has typedef `hash_map<Foo, Bar>
+MyMap;`. And you have this code:
 
     for (MyMap::iterator it = ...)
 
-Who, if anyone, is using the symbol `hash_map<Foo, Bar>::iterator`? If we say you, as the author of the for-loop, are the user, then you must `#include <hash_map>`, which undoubtedly goes against the goal of the typedef (you shouldn't even have to know you're using a hash_map). So we want to say the author of the typedef is responsible for the use. But how could the author of the typedef know that you were going to use `MyMap::iterator`? It can't predict that. That means it has to be responsible for every possible use of the typedef type. This can be complicated to figure out. It requires instantiating all methods of the underlying type, some of which might not even be legal C++ (if, say, the class uses SFINAE).
+Who, if anyone, is using the symbol `hash_map<Foo, Bar>::iterator`? If we say
+you, as the author of the for-loop, are the user, then you must `#include
+<hash_map>`, which undoubtedly goes against the goal of the typedef (you
+shouldn't even have to know you're using a hash_map). So we want to say the
+author of the typedef is responsible for the use. But how could the author of
+the typedef know that you were going to use `MyMap::iterator`? It can't predict
+that. That means it has to be responsible for every possible use of the typedef
+type. This can be complicated to figure out. It requires instantiating all
+methods of the underlying type, some of which might not even be legal C++ (if,
+say, the class uses SFINAE).
 
-Worse, when the language auto-derives template types, it loses typedef information. Suppose you wrote this:
+Worse, when the language auto-derives template types, it loses typedef
+information. Suppose you wrote this:
 
     MyMap m;
     find(m.begin(), m.end(), some_foo);
 
-The compiler sees this as syntactic sugar for `find<hash_map<Foo, Bar, hash<Foo>, equal_to<Foo>, alloc<Foo> >(m.begin(), m.end(), some_foo);`
+The compiler sees this as syntactic sugar for `find<hash_map<Foo, Bar,
+hash<Foo>, equal_to<Foo>, alloc<Foo> >(m.begin(), m.end(), some_foo);`
 
-Not only is the template argument `hash_map` instead of `MyMap`, it includes all the default template arguments, with no indication they're default arguments. All the tricks we used above to intelligently ignore default template arguments are worthless here. We have to jump through lots of hoops so this code doesn't require you to `#include` not only `<hash_map>`, but `<alloc>` and `<utility>` as well.
+Not only is the template argument `hash_map` instead of `MyMap`, it includes all
+the default template arguments, with no indication they're default
+arguments. All the tricks we used above to intelligently ignore default template
+arguments are worthless here. We have to jump through lots of hoops so this code
+doesn't require you to `#include` not only `<hash_map>`, but `<alloc>` and
+`<utility>` as well.
+
 
 ## Macros ##
 
-It's no surprise macros cause a huge problem for include-what-you-use. Basically, all the problems of templates also apply to macros, but worse: with templates you can analyze the uninstantiated template, but with macros, you can't analyze the uninstantiated macro -- it likely doesn't even parse cleanly in isolation. As a result, we have very few tools to distinguish when the author of a macro is responsible for a symbol used in a macro, and when the caller of the macro is responsible.
+It's no surprise macros cause a huge problem for
+include-what-you-use. Basically, all the problems of templates also apply to
+macros, but worse: with templates you can analyze the uninstantiated template,
+but with macros, you can't analyze the uninstantiated macro -- it likely doesn't
+even parse cleanly in isolation. As a result, we have very few tools to
+distinguish when the author of a macro is responsible for a symbol used in a
+macro, and when the caller of the macro is responsible.
+
 
 ## Includes with side effects ##
 
-While not a major problem, this indicates the myriad "gotchas" that exist around include-what-you-use: removing an `#include` and replacing it with a forward-declare may be dangerous even if no symbols are fully used from the `#include`.  Consider the following code:
+While not a major problem, this indicates the myriad "gotchas" that exist around
+include-what-you-use: removing an `#include` and replacing it with a
+forward-declare may be dangerous even if no symbols are fully used from the
+`#include`.  Consider the following code:
 
     foo.h:
       namespace ns { class Foo {}; }
@@ -119,7 +206,9 @@ While not a major problem, this indicates the myriad "gotchas" that exist around
       #include "foo.h"
       Foo* foo;`
 
-If IWYU just blindly replaces the `#include` with a forward declare such as `namespace ns { class Foo; }`, the code will break because of the lost using declaration. Include-what-you-use has to watch out for this case.
+If IWYU just blindly replaces the `#include` with a forward declare such as
+`namespace ns { class Foo; }`, the code will break because of the lost using
+declaration. Include-what-you-use has to watch out for this case.
 
 Another case is a header file like this:
 
@@ -127,15 +216,32 @@ Another case is a header file like this:
       #define MODULE_NAME MyModule
       #include "module_writer.h"
 
-We might think we can remove an `#include` of `foo.h` and replace it by `#include "module_writer.h"`, but that is likely to break the build if `module_writer.h` requires `MODULE_NAME` be defined.  Since my file doesn't participate in this dependency at all, it won't even notice it.  IWYU needs to keep track of dependencies between files it's not even trying to analyze!
+We might think we can remove an `#include` of `foo.h` and replace it by
+`#include "module_writer.h"`, but that is likely to break the build if
+`module_writer.h` requires `MODULE_NAME` be defined.  Since my file doesn't
+participate in this dependency at all, it won't even notice it.  IWYU needs to
+keep track of dependencies between files it's not even trying to analyze!
+
 
 ## Private includes ##
 
-Suppose you write `vector<int> v;`. You are using vector, and thus have to `#include <vector>`. Even this seemingly easy case is difficult, because vector isn't actually defined in `<vector>`; it's defined in `<bits/stl_vector.h>`. The C++ standard library has hundreds of private files that users are not supposed to `#include` directly. Third party libraries have hundreds more.  There's no general way to distinguish private from public headers; we have to manually construct the proper mapping.
+Suppose you write `vector<int> v;`. You are using vector, and thus have to
+`#include <vector>`. Even this seemingly easy case is difficult, because vector
+isn't actually defined in `<vector>`; it's defined in `<bits/stl_vector.h>`. The
+C++ standard library has hundreds of private files that users are not supposed
+to `#include` directly. Third party libraries have hundreds more.  There's no
+general way to distinguish private from public headers; we have to manually
+construct the proper mapping.
 
-In the future, we hope to provide a way for users to annotate if a file is public or private, either a comment or a `#pragma`. For now, we hard-code it in the IWYU tool.
+In the future, we hope to provide a way for users to annotate if a file is
+public or private, either a comment or a `#pragma`. For now, we hard-code it in
+the IWYU tool.
 
-The mappings themselves can be ambiguous. For instance, `NULL` is provided by many files, including `stddef.h`, `stdlib.h`, and more. If you use `NULL`, what header file should IWYU suggest? We have rules to try to minimize the number of `#includes` you have to add; it can get rather involved.
+The mappings themselves can be ambiguous. For instance, `NULL` is provided by
+many files, including `stddef.h`, `stdlib.h`, and more. If you use `NULL`, what
+header file should IWYU suggest? We have rules to try to minimize the number of
+`#includes` you have to add; it can get rather involved.
+
 
 ## Unparsed code ##
 
@@ -154,10 +260,21 @@ Conditional `#includes` are a problem for IWYU when the condition is false:
         ...
     }
 
-If you're running IWYU without that preprocessor definition set, it has no way of telling if `verbose_logger.h` is a necessary `#include` or not.
+If you're running IWYU without that preprocessor definition set, it has no way
+of telling if `verbose_logger.h` is a necessary `#include` or not.
+
 
 ## Placing new includes and forward-declares ##
 
-Figuring out where to insert new `#includes` and forward-declares is a complex problem of its own (one that is the responsibility of `fix_includes.py`). In general, we want to put new `#includes` with existing `#includes`. But the existing `#includes` may be broken up into sections, either because of conditional `#includes` (with `#ifdefs`), or macros (such as `#define __GNU_SOURCE`), or for other reasons. Some forward-declares may need to come early in the file, and some may prefer to come later (after we're in an appropriate namespace, for instance).
+Figuring out where to insert new `#includes` and forward-declares is a complex
+problem of its own (one that is the responsibility of `fix_includes.py`). In
+general, we want to put new `#includes` with existing `#includes`. But the
+existing `#includes` may be broken up into sections, either because of
+conditional `#includes` (with `#ifdefs`), or macros (such as `#define
+__GNU_SOURCE`), or for other reasons. Some forward-declares may need to come
+early in the file, and some may prefer to come later (after we're in an
+appropriate namespace, for instance).
 
-`fix_includes.py` tries its best to give pleasant-looking output, while being conservative about putting code in a place where it might not compile. It uses heuristics to do this, which are not yet perfect.
+`fix_includes.py` tries its best to give pleasant-looking output, while being
+conservative about putting code in a place where it might not compile. It uses
+heuristics to do this, which are not yet perfect.


### PR DESCRIPTION
Reflow to 80-column width to make text easier to read in editor.

Use two blank lines before headings.

Prefer backtick code blocks to indented blocks.

No significant content change intended (some code blocks wrapped to
avoid run-on lines).

The rendered Github Markdown is mostly unchanged.