### PR TITLE
[ci] Add more systemic workaround for broken packaging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,20 +38,22 @@ jobs:
                libclang$LLVM_TAG-dev \
                clang$LLVM_TAG
 
-      - name: Capture LLVM major version
+      - name: Capture LLVM major version and install prefix
         run: |
-          echo "LLVM_MAJOR=$(ls -1d /usr/lib/llvm-* | sort -n | tail -n1 | sed 's/.*llvm-//')" >> $GITHUB_ENV
-
-      - name: Work around broken packaging
-        run: |
-          sudo touch /usr/lib/llvm-$LLVM_MAJOR/lib/libclang-$LLVM_MAJOR.so.1
-          # Link libLLVM.so.1 if it doesn't exist
-          [[ -f /usr/lib/llvm-$LLVM_MAJOR/lib/libLLVM.so.1 ]] || sudo ln -s libLLVM.so /usr/lib/llvm-$LLVM_MAJOR/lib/libLLVM.so.1
-          # Link libclang-cpp.so.*.0 if it doesn't exist
-          [[ -f /usr/lib/llvm-$LLVM_MAJOR/lib/libclang-cpp.so.$LLVM_MAJOR.0 ]] || sudo ln -s ../../x86_64-linux-gnu/libclang-cpp.so.$LLVM_MAJOR.0 /usr/lib/llvm-$LLVM_MAJOR/lib/libclang-cpp.so.$LLVM_MAJOR.0
+          LLVM_MAJOR=$(ls -1d /usr/lib/llvm-* | sort -n | tail -n1 | sed 's/.*llvm-//')
+          LLVM_PREFIX=$(llvm-config-$LLVM_MAJOR --prefix)
+          echo "LLVM_MAJOR=${LLVM_MAJOR}" >> $GITHUB_ENV
+          echo "LLVM_PREFIX=${LLVM_PREFIX}" >> $GITHUB_ENV
 
       - name: Check out branch
         uses: actions/checkout@v4
+
+      - name: Work around broken packaging
+        run: |
+          # Disable CMake target checks.
+          sudo ./iwyu-fixup-llvm-target-checks.bash "$LLVM_PREFIX"
+          # Link libclang-cpp.so.*.0 if it doesn't exist
+          [[ -e $LLVM_PREFIX/lib/libclang-cpp.so.$LLVM_MAJOR.0 ]] || sudo ln -s ../../x86_64-linux-gnu/libclang-cpp.so.$LLVM_MAJOR.0 $LLVM_PREFIX/lib/libclang-cpp.so.$LLVM_MAJOR.0
 
       - name: Build include-what-you-use
         run: |

--- a/iwyu-fixup-llvm-target-checks.bash
+++ b/iwyu-fixup-llvm-target-checks.bash
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+##===--- iwyu-fixup-llvm-target-checks.bash -------------------------------===##
+#
+#                     The LLVM Compiler Infrastructure
+#
+# This file is distributed under the University of Illinois Open Source
+# License. See LICENSE.TXT for details.
+#
+##===----------------------------------------------------------------------===##
+
+# CMake has sophisticated support for exporting targets pointing to installed
+# files. It also verifies at cmake configure time that all exported targets
+# actually exist on disk. There is no documented way to disable that check.
+#
+# The way apt.llvm.org packages LLVM and Clang, CMake can't quite keep up. It
+# knows about all targets and where they were installed by the 'install' step,
+# not how later packaging combines the files into more fine-grained .deb
+# packages.
+#
+# So the CMake modules installed will know about the sum total of all targets
+# built, and will attempt to verify that the files they produced exist. But the
+# packages containing the CMake modules (llvm-NN-dev and clang-NN) do not
+# contain all these files, so the verification would nominally always fail.
+#
+# There is some apriori fixup in the packaging scripts to work around this [1],
+# but it often falls behind changes to upstream such as new components being
+# added that are not part of the primary packages.
+#
+# This script comments out enough CMake-generated metadata to disable all the
+# builtin checks. For our purposes, it's better if the build fails later due to
+# actual missing dependencies than the cmake step failing due to _unused_
+# missing dependencies.
+#
+# [1]: https://salsa.debian.org/pkg-llvm-team/llvm-toolchain/-/blob/2537c98/debian/rules#L1368
+
+set -eu
+set -o pipefail
+
+if [[ $# != 1 ]]; then
+    echo "usage: $0 LLVM_INSTALL_PREFIX"
+    echo ""
+    echo "  LLVM_INSTALL_PREFIX    install root of llvm, e.g. /usr/lib/llvm-20"
+    exit 1
+fi
+
+LLVM_PREFIX="$1"
+TIMESTAMP=$(date +%Y%m%d%H%M%S)
+
+# The variable name changed from _IMPORT_CHECK_FILES_FOR_xxx to
+# _cmake_import_check_files_for_xxx in CMake 3.24:
+# https://gitlab.kitware.com/cmake/cmake/-/commit/59cc92085ea7c5a81de7d79946fa97f045adea78
+# so check for both.
+
+sed \
+    -i".$TIMESTAMP" \
+    -e '/^list(APPEND _\(IMPORT_CHECK_FILES_FOR\|cmake_import_check_files_for\)_/ {s|^|#|}' \
+    $LLVM_PREFIX/lib/cmake/llvm/LLVMExports-*.cmake \
+    $LLVM_PREFIX/lib/cmake/clang/ClangTargets-*.cmake


### PR DESCRIPTION
Add a script to disable target-vs-file wholesale in LLVM and Clang CMake
export modules.

We do this more heavy-handed disabling because our CI is blocked if
llvm-toolchain is in a bad state, even for modules we don't need, and we
can't verify compat with upstream or get patches tested.

This should fix the build so we can rely on our CI again.