### PR TITLE
[ci] Disable packaging workarounds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,9 +51,7 @@ jobs:
       - name: Work around broken packaging
         run: |
           # Disable CMake target checks.
-          sudo ./iwyu-fixup-llvm-target-checks.bash "$LLVM_PREFIX"
-          # Link libclang-cpp.so.*.0 if it doesn't exist
-          [[ -e $LLVM_PREFIX/lib/libclang-cpp.so.$LLVM_MAJOR.0 ]] || sudo ln -s ../../x86_64-linux-gnu/libclang-cpp.so.$LLVM_MAJOR.0 $LLVM_PREFIX/lib/libclang-cpp.so.$LLVM_MAJOR.0
+          # sudo ./iwyu-fixup-llvm-target-checks.bash "$LLVM_PREFIX"
 
       - name: Build include-what-you-use
         run: |


### PR DESCRIPTION
Both upstream llvm-19 and llvm-20 should have been fixed so the workarounds are no longer necessary. Remove them to reflect what users will see when using IWYU with the packages.