### PR TITLE
Use expansion loc when the use macro defined in command line

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -135,6 +135,7 @@
 #include "iwyu_port.h"  // for CHECK_
 #include "iwyu_preprocessor.h"
 #include "iwyu_stl_util.h"
+#include "iwyu_string_util.h"
 #include "iwyu_use_flags.h"
 #include "iwyu_verrs.h"
 #include "llvm/ADT/ArrayRef.h"
@@ -1352,6 +1353,11 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
     if (IsInScratchSpace(spelling_loc)) {
       VERRS(5) << "Spelling location is in <scratch space>, presumably as a "
                << "result of macro arg concatenation\n";
+      use_loc = expansion_loc;
+      side = "expansion";
+    } else if (StartsWith(PrintableLoc(spelling_loc), "<command line>")) {
+      VERRS(5) << "Spelling location is in <command line> (macro defined in "
+                  "command line), use expansion location instead\n";
       use_loc = expansion_loc;
       side = "expansion";
     } else if (fwd_decl != nullptr) {

--- a/tests/cxx/namespace_macro-direct.h
+++ b/tests/cxx/namespace_macro-direct.h
@@ -1,0 +1,16 @@
+
+//===--- namespace_macro-direct.h - test input file for IWYU --------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_NAMESPACE_MACRO_DIRECT_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_NAMESPACE_MACRO_DIRECT_H_
+
+#include "tests/cxx/namespace_macro-indirect.h"
+
+#endif

--- a/tests/cxx/namespace_macro-indirect.h
+++ b/tests/cxx/namespace_macro-indirect.h
@@ -1,0 +1,25 @@
+//===--- namespace_macro-indirect.h - test input file for IWYU ------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_NAMESPACE_MACRO_INDIRECT_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_NAMESPACE_MACRO_INDIRECT_H_
+
+#ifndef MYNS
+#define MYNS myns
+#endif
+
+namespace MYNS {
+
+void foo() {
+  // do something
+}
+
+}  // namespace MYNS
+
+#endif

--- a/tests/cxx/namespace_macro.cc
+++ b/tests/cxx/namespace_macro.cc
@@ -1,0 +1,32 @@
+//===--- namespace_macro.cc - test input file for IWYU --------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/namespace_macro-direct.h"
+
+// IWYU_ARGS: -I . -DMYNS=myns
+
+int main() {
+  // IWYU: myns::foo is...*namespace_macro-indirect.h
+  MYNS::foo();
+
+  return 0;
+}
+
+/**** IWYU_SUMMARY
+
+tests/cxx/namespace_macro.cc should add these lines:
+#include "tests/cxx/namespace_macro-indirect.h"
+
+tests/cxx/namespace_macro.cc should remove these lines:
+- #include "tests/cxx/namespace_macro-direct.h"  // lines XX-XX
+
+The full include-list for tests/cxx/namespace_macro.cc:
+#include "tests/cxx/namespace_macro-indirect.h"  // for foo
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
This PR uses expansion loc as the use_loc to report for the declare when the spelling loc is in `<comman line>` (macro defined through command line -DXXX, which is not a reasonable location) to avoid some wrong removal.