### PR TITLE
CMake: Only need a C++ compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ if (iwyu_standalone_build)
     cmake_policy(SET CMP0077 NEW)
   endif()
 
-  project(include-what-you-use)
+  project(include-what-you-use LANGUAGES CXX)
 
   find_package(LLVM CONFIG REQUIRED)
   find_package(Clang CONFIG REQUIRED)


### PR DESCRIPTION
Makes it easier to configure a different compiler because you only need to set CXX environment variable.
Before you would also set a CC compiler.

See [CMake's `project` documentation](https://cmake.org/cmake/help/latest/command/project.html) for details.