### PR TITLE
Insert extra driver args before '--' if it exists

### DIFF
--- a/tests/driver/dashdash.c
+++ b/tests/driver/dashdash.c
@@ -1,0 +1,23 @@
+//===--- dashdash.c - test input file for ---------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// Clang uses '--' to separate flags from input args. Make sure IWYU doesn't put
+// implicit arguments after '--'.
+
+// IWYU_ARGS: -c --
+
+int main() {
+  return 0;
+}
+
+/**** IWYU_SUMMARY
+
+(tests/driver/dashdash.c has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
Clang uses '--' to optionally separate flags from inputs. If there are non-input
args after the dash-dash, Clang will reject the compilation.

IWYU would previously blindly append '-fsyntax-only' and other flags at the end
of the argument list, causing failures for dash-dash commands.

Instead, insert extra args immediately before '--' if it exists, otherwise
append them at the end.

Fixes #1668.