### PR TITLE
Don't attempt to clear elaborated type duplicates

### DIFF
--- a/iwyu_output.cc
+++ b/iwyu_output.cc
@@ -1790,7 +1790,8 @@ void ClearDesiredForSurplusIncludesOrForwardDeclares(ContainerType& container) {
     typename ContainerType::iterator v = ++container.lower_bound(k->first);
     typename ContainerType::iterator vend = container.upper_bound(k->first);
     for (; v != vend; ++v) {
-      v->second->clear_desired();
+      if (!v->second->is_elaborated_type())
+        v->second->clear_desired();
     }
   }
 }

--- a/tests/cxx/elaborated_type.cc
+++ b/tests/cxx/elaborated_type.cc
@@ -75,6 +75,18 @@ class FirstForwardDeclared;
 void bare_first_forward_declared(FirstForwardDeclared*);
 void elaborated_first_forward_declared(class FirstForwardDeclared*);
 
+// Test that IWYU doesn't suggest to remove a line with an elaborated type as if
+// there was a duplicating forward-declaration.
+class ElaboratedInMultipleDecl *p1, *p2;
+union {
+  float a;
+  int b;
+} unnamed_union_obj1, unnamed_union_obj2;
+struct {
+} unnamed_struct_obj1, unnamed_struct_obj2;
+struct NamedStruct {
+} named_struct_obj1, named_struct_obj2;
+
 /**** IWYU_SUMMARY
 
 tests/cxx/elaborated_type.cc should add these lines:


### PR DESCRIPTION
It was assumed in #1232 that at most one elaborated type can "own" a tag declaration (i.e. none of possible following similar types redeclares that declaration), hence there should be no duplicates in `fwd_decl_map`. Even if that assumption is true, an `ElaboratedTypeLoc` may be handled more than once if it corresponds to different AST nodes. It happens when that type is used in a declaration of several variables.

Elaborated types should obviously not be removed in any case because they are part of user's main code and not of `#include` or fwd-decl lists.

This fixes #1674.