### PR TITLE
[clang compat] Handle new HLSL cast kinds

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -1869,6 +1869,8 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
                                               // the full type.
       case clang::CK_HLSLArrayRValue:
       case clang::CK_HLSLVectorTruncation:
+      case clang::CK_HLSLElementwiseCast:
+      case clang::CK_HLSLAggregateSplatCast:
         break;
 
       // Ignore non-ptr-to-ptr casts.


### PR DESCRIPTION
Two new cast kinds have been added in Clang:

CK_HLSLAggregateSplatCast:
https://github.com/llvm/llvm-project/commit/4d2d0afceeb732a5238c2167ab7a6b88cc66d976

CK_HLSLElementwiseCast:
https://github.com/llvm/llvm-project/commit/3f8e2802069aabe4384ecd4575d50fd4457dae51

I can't see that they would affect IWYU analysis, so just handle them silently to placate -Wswitch.