### PR TITLE
Denote rvalue-referenced types as fwd-declarable

### DIFF
--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -110,6 +110,7 @@ using clang::RecordDecl;
 using clang::RecordType;
 using clang::RecursiveASTVisitor;
 using clang::Redeclarable;
+using clang::ReferenceType;
 using clang::SourceLocation;
 using clang::SourceManager;
 using clang::SourceRange;
@@ -1453,7 +1454,7 @@ bool InvolvesTypeForWhich(const Type* type, function<bool(const Type*)> pred) {
 
 bool IsPointerOrReferenceAsWritten(const Type* type) {
   type = Desugar(type);
-  return isa<PointerType>(type) || isa<LValueReferenceType>(type);
+  return isa<PointerType>(type) || isa<ReferenceType>(type);
 }
 
 const Type* RemovePointersAndReferencesAsWritten(const Type* type) {

--- a/tests/cxx/rvalue_reference.cc
+++ b/tests/cxx/rvalue_reference.cc
@@ -1,0 +1,37 @@
+//===--- rvalue_reference.cc - test input file for iwyu -------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_ARGS: -I .
+
+// Tests handling rvalue references. Their pointed-to types are
+// forward-declarable in general, as with lvalue references.
+
+#include "tests/cxx/direct.h"
+
+// IWYU: IndirectClass needs a declaration
+IndirectClass&& GetXValue();
+
+// IWYU: IndirectClass needs a declaration
+void Sink(IndirectClass&&) {
+  // IWYU: IndirectClass needs a declaration
+  IndirectClass&& rvalue_ref = GetXValue();
+}
+
+/**** IWYU_SUMMARY
+
+tests/cxx/rvalue_reference.cc should add these lines:
+class IndirectClass;
+
+tests/cxx/rvalue_reference.cc should remove these lines:
+- #include "tests/cxx/direct.h"  // lines XX-XX
+
+The full include-list for tests/cxx/rvalue_reference.cc:
+class IndirectClass;
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
IWYU should handle rvalue references as lvalue ones in most cases.