### PR TITLE
[ci] Work around broken llvm-21 CMake modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,11 @@ jobs:
         run: |
           # Disable CMake target checks.
           # sudo ./iwyu-fixup-llvm-target-checks.bash "$LLVM_PREFIX"
+          # Patch broken relative paths in the CMake Config modules.
+          sudo sed -zi 's/get_filename_component/#get_filename_component/2' \
+              $LLVM_PREFIX/lib/cmake/llvm/LLVMConfig.cmake
+          sudo sed -zi 's/get_filename_component/#get_filename_component/2' \
+              $LLVM_PREFIX/lib/cmake/clang/ClangConfig.cmake
 
       - name: Build include-what-you-use
         run: |


### PR DESCRIPTION
Somehow the LLVMConfig.cmake and ClangConfig.cmake modules compute the install prefix by stepping up from the current file, and they end up one step too far up.

So when using this faulty install prefix to compute the CMake dir used for includes, they wind up in /usr/lib/lib/cmake instead of /usr/lib/llvm-21/lib/cmake.

Use a terrifying sed hack to remove the second get_filename_component and set the world straight again.