### PR TITLE
[clang compat] Adjust GetQualifier for changed Clang API

### DIFF
--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -405,8 +405,10 @@ const NestedNameSpecifier* GetQualifier(const ASTNode* ast_node) {
   }
   if (!nns) nns = TryGetQualifier<ElaboratedType>(ast_node);
   if (!nns) nns = TryGetQualifier<DependentNameType>(ast_node);
-  if (!nns)
-    nns = TryGetQualifier<DependentTemplateSpecializationType>(ast_node);
+  if (!nns && ast_node->IsA<DependentTemplateSpecializationType>()) {
+    const auto* dtst = ast_node->GetAs<DependentTemplateSpecializationType>();
+    nns = dtst->getDependentTemplateName().getQualifier();
+  }
   if (!nns) nns = TryGetQualifier<UsingDirectiveDecl>(ast_node);
   if (!nns) nns = TryGetQualifier<EnumDecl>(ast_node);
   if (!nns) nns = TryGetQualifier<RecordDecl>(ast_node);


### PR DESCRIPTION
Clang removed DependentTemplateSpecializationType::getQualifier() and moved it into a DependentTemplateStorage accessible via getDependentTemplateName() in https://github.com/llvm/llvm-project/commit/dc17429ae6961a6783371dcf6749eea657b5446a

Fix our only use so it does the two-step extraction of qualifier.