### PR TITLE
Handle member pointer types in "assignable" traits

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -2084,9 +2084,19 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
           const Type* rhs_deref_type = RemoveReference(rhs_type);
           // For derived-to-base pointer conversion to be allowed, the derived
           // type should be complete.
-          // TODO(bolshakov): what about member pointers?
           if (IsDerivedToBasePtrConvertible(rhs_deref_type, lhs_deref_type)) {
             ReportTypeUse(CurrentLoc(), rhs_type, DerefKind::RemoveRefsAndPtr);
+            return true;
+          }
+          if (IsBaseToDerivedMemPtrConvertible(rhs_deref_type, lhs_deref_type,
+                                               compiler()->getSema())) {
+            const auto* lhs_mem_ptr_type =
+                lhs_deref_type->castAs<MemberPointerType>();
+            // TODO(bolshakov): check whether the type is provided by member
+            // pointer type alias, probably?
+            ReportTypeUse(CurrentLoc(),
+                          lhs_mem_ptr_type->getQualifier()->getAsType(),
+                          DerefKind::None);
             return true;
           }
           // Otherwise, report the rhs record type (ReportTypeUse doesn't report
@@ -2112,8 +2122,17 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
             ReportTypeUse(CurrentLoc(), rhs_type, DerefKind::RemoveRefs);
         } else if (IsReferenceToModifiableLValue(lhs_type)) {
           const Type* rhs_deref_type = RemoveReference(rhs_type);
-          if (IsDerivedToBasePtrConvertible(rhs_deref_type, lhs_deref_type))
+          if (IsDerivedToBasePtrConvertible(rhs_deref_type, lhs_deref_type)) {
             ReportTypeUse(CurrentLoc(), rhs_type, DerefKind::RemoveRefsAndPtr);
+          } else if (IsBaseToDerivedMemPtrConvertible(rhs_deref_type,
+                                                      lhs_deref_type,
+                                                      compiler()->getSema())) {
+            const auto* lhs_mem_ptr_type =
+                lhs_deref_type->castAs<MemberPointerType>();
+            ReportTypeUse(CurrentLoc(),
+                          lhs_mem_ptr_type->getQualifier()->getAsType(),
+                          DerefKind::None);
+          }
           // Don't care about user-defined conversions.
         }
         return true;

--- a/iwyu_ast_util.h
+++ b/iwyu_ast_util.h
@@ -43,6 +43,7 @@ class Expr;
 class FunctionDecl;
 class NamedDecl;
 class NamespaceDecl;
+class Sema;
 class Stmt;
 class TagDecl;
 class TemplateDecl;
@@ -883,6 +884,18 @@ bool IsReferenceToModifiableLValue(const clang::Type*);
 // allow the conversion.
 bool IsDerivedToBasePtrConvertible(const clang::Type* derived_ptr_type,
                                    const clang::Type* base_ptr_type);
+
+// Pointers to members of a class can be implicitly converted to pointers
+// to members of its derived class (looks like the opposite to the conventional
+// derived-to-base pointer conversion) when the member types are identical or
+// related by certain standard conversions, like in this case:
+// int Base::* p1;
+// const int Derived::* p2 = p1;
+// This function checks if it actually can be done. If either of the given types
+// is not a MemberPointerType, returns false.
+bool IsBaseToDerivedMemPtrConvertible(const clang::Type* base_mem_ptr_type,
+                                      const clang::Type* derived_mem_ptr_type,
+                                      clang::Sema&);
 
 // --- Utilities for Stmt.
 

--- a/tests/cxx/type_trait-d2.h
+++ b/tests/cxx/type_trait-d2.h
@@ -7,6 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+class Base;
 class Derived;
 class Class;
 union Union1;
@@ -15,3 +16,10 @@ using DerivedPtrRefNonProviding = Derived*&;
 using DerivedRefNonProviding = Derived&;
 using ClassRefNonProviding = Class&;
 using Union1RefNonProviding = Union1&;
+
+template <typename T>
+using BaseMemPtr = T Base::*;
+template <typename T>
+using DerivedMemPtr = T Derived::*;
+template <typename T>
+using UnionMemPtr = T Union1::*;

--- a/tests/cxx/type_trait.cc
+++ b/tests/cxx/type_trait.cc
@@ -366,6 +366,95 @@ static_assert(__is_trivially_assignable(int Derived::*&, int Base::*));
 // IWYU: Base is...*tests/cxx/type_trait-i1.h
 // IWYU: Derived is...*tests/cxx/type_trait-i2.h
 static_assert(__is_nothrow_assignable(int Derived::*&, int Base::*));
+// IWYU: Derived is...*tests/cxx/type_trait-i2.h
+static_assert(__is_assignable(DerivedMemPtr<int>&, BaseMemPtr<int>));
+// IWYU: Derived is...*tests/cxx/type_trait-i2.h
+static_assert(__is_trivially_assignable(DerivedMemPtr<int>&, BaseMemPtr<int>));
+// IWYU: Derived is...*tests/cxx/type_trait-i2.h
+static_assert(__is_nothrow_assignable(DerivedMemPtr<int>&, BaseMemPtr<int>));
+static_assert(!__is_assignable(BaseMemPtr<int>&, UnionMemPtr<int>));
+static_assert(!__is_trivially_assignable(BaseMemPtr<int>&, UnionMemPtr<int>));
+static_assert(!__is_nothrow_assignable(BaseMemPtr<int>&, UnionMemPtr<int>));
+static_assert(__is_assignable(BaseMemPtr<int>&, BaseMemPtr<int>));
+static_assert(__is_trivially_assignable(BaseMemPtr<int>&, BaseMemPtr<int>));
+static_assert(__is_nothrow_assignable(BaseMemPtr<int>&, BaseMemPtr<int>));
+static_assert(!__is_assignable(DerivedMemPtr<unsigned int>&, BaseMemPtr<int>));
+static_assert(!__is_trivially_assignable(DerivedMemPtr<unsigned int>&,
+                                         BaseMemPtr<int>));
+static_assert(!__is_nothrow_assignable(DerivedMemPtr<unsigned int>&,
+                                       BaseMemPtr<int>));
+// IWYU: Derived is...*tests/cxx/type_trait-i2.h
+static_assert(__is_assignable(DerivedMemPtr<const int>&, BaseMemPtr<int>));
+// IWYU: Derived is...*tests/cxx/type_trait-i2.h
+static_assert(__is_trivially_assignable(DerivedMemPtr<const int>&,
+                                        BaseMemPtr<int>));
+// IWYU: Derived is...*tests/cxx/type_trait-i2.h
+static_assert(__is_nothrow_assignable(DerivedMemPtr<const int>&,
+                                      BaseMemPtr<int>));
+static_assert(!__is_assignable(DerivedMemPtr<const int>&,
+                               BaseMemPtr<volatile int>));
+static_assert(!__is_trivially_assignable(DerivedMemPtr<const int>&,
+                                         BaseMemPtr<volatile int>));
+static_assert(!__is_nothrow_assignable(DerivedMemPtr<const int>&,
+                                       BaseMemPtr<volatile int>));
+// IWYU: Derived is...*tests/cxx/type_trait-i2.h
+static_assert(__is_assignable(DerivedMemPtr<int()>&, BaseMemPtr<int()>));
+// IWYU: Derived is...*tests/cxx/type_trait-i2.h
+static_assert(__is_trivially_assignable(DerivedMemPtr<int()>&,
+                                        BaseMemPtr<int()>));
+// IWYU: Derived is...*tests/cxx/type_trait-i2.h
+static_assert(__is_nothrow_assignable(DerivedMemPtr<int()>&,
+                                      BaseMemPtr<int()>));
+// IWYU: Derived is...*tests/cxx/type_trait-i2.h
+static_assert(__is_assignable(DerivedMemPtr<int()>&,
+                              BaseMemPtr<int() noexcept>));
+// IWYU: Derived is...*tests/cxx/type_trait-i2.h
+static_assert(__is_trivially_assignable(DerivedMemPtr<int()>&,
+                                        BaseMemPtr<int() noexcept>));
+// IWYU: Derived is...*tests/cxx/type_trait-i2.h
+static_assert(__is_nothrow_assignable(DerivedMemPtr<int()>&,
+                                      BaseMemPtr<int() noexcept>));
+static_assert(!__is_assignable(DerivedMemPtr<int() noexcept>&,
+                               BaseMemPtr<int()>));
+static_assert(!__is_trivially_assignable(DerivedMemPtr<int() noexcept>&,
+                                         BaseMemPtr<int()>));
+static_assert(!__is_nothrow_assignable(DerivedMemPtr<int() noexcept>&,
+                                       BaseMemPtr<int()>));
+// IWYU: Derived is...*tests/cxx/type_trait-i2.h
+static_assert(__is_assignable(DerivedMemPtr<int() noexcept>&,
+                              BaseMemPtr<int() noexcept>));
+// IWYU: Derived is...*tests/cxx/type_trait-i2.h
+static_assert(__is_trivially_assignable(DerivedMemPtr<int() noexcept>&,
+                                        BaseMemPtr<int() noexcept>));
+// IWYU: Derived is...*tests/cxx/type_trait-i2.h
+static_assert(__is_nothrow_assignable(DerivedMemPtr<int() noexcept>&,
+                                      BaseMemPtr<int() noexcept>));
+static_assert(!__is_assignable(DerivedMemPtr<void()>&, BaseMemPtr<int()>));
+static_assert(!__is_trivially_assignable(DerivedMemPtr<void()>&,
+                                         BaseMemPtr<int()>));
+static_assert(!__is_nothrow_assignable(DerivedMemPtr<void()>&,
+                                       BaseMemPtr<int()>));
+static_assert(!__is_assignable(DerivedMemPtr<void()>&,
+                               BaseMemPtr<int() noexcept>));
+static_assert(!__is_trivially_assignable(DerivedMemPtr<void()>&,
+                                         BaseMemPtr<int() noexcept>));
+static_assert(!__is_nothrow_assignable(DerivedMemPtr<void()>&,
+                                       BaseMemPtr<int() noexcept>));
+// IWYU: Derived is...*tests/cxx/type_trait-i2.h
+static_assert(__is_assignable(DerivedMemPtr<int (*)()>&,
+                              BaseMemPtr<int (*)()>));
+// IWYU: Derived is...*tests/cxx/type_trait-i2.h
+static_assert(__is_trivially_assignable(DerivedMemPtr<int (*)()>&,
+                                        BaseMemPtr<int (*)()>));
+// IWYU: Derived is...*tests/cxx/type_trait-i2.h
+static_assert(__is_nothrow_assignable(DerivedMemPtr<int (*)()>&,
+                                      BaseMemPtr<int (*)()>));
+static_assert(!__is_assignable(DerivedMemPtr<int (*)()>&,
+                               BaseMemPtr<int (*)() noexcept>));
+static_assert(!__is_trivially_assignable(DerivedMemPtr<int (*)()>&,
+                                         BaseMemPtr<int (*)() noexcept>));
+static_assert(!__is_nothrow_assignable(DerivedMemPtr<int (*)()>&,
+                                       BaseMemPtr<int (*)() noexcept>));
 // TODO: handle other types in an implicit conversion chain like Derived in
 // __is_assignable(Base*&, Class&) when Class has operator Derived*().
 
@@ -384,7 +473,7 @@ tests/cxx/type_trait.cc should remove these lines:
 
 The full include-list for tests/cxx/type_trait.cc:
 #include "tests/cxx/type_trait-d1.h"  // for ClassRefProviding, DerivedPtrRefProviding, DerivedRefProviding, Union1RefProviding
-#include "tests/cxx/type_trait-d2.h"  // for ClassRefNonProviding, DerivedPtrRefNonProviding, DerivedRefNonProviding, Union1RefNonProviding
+#include "tests/cxx/type_trait-d2.h"  // for BaseMemPtr, ClassRefNonProviding, DerivedMemPtr, DerivedPtrRefNonProviding, DerivedRefNonProviding, Union1RefNonProviding, UnionMemPtr
 #include "tests/cxx/type_trait-i1.h"  // for Base, Class, Struct, StructDerivedClass, Union1, Union2
 #include "tests/cxx/type_trait-i2.h"  // for Derived
 


### PR DESCRIPTION
This has been done before fixing forward-declarability in member pointer types to avoid regression. Due to this, the test cases have been written using aliased types. (If the direct class types were used, they would be reported in all cases.)