### PR TITLE
Add support for the cleanup attribute

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -197,6 +197,7 @@ using clang::CXXTypeidExpr;
 using clang::CallExpr;
 using clang::CastExpr;
 using clang::ClassTemplateSpecializationDecl;
+using clang::CleanupAttr;
 using clang::CompilerInstance;
 using clang::ConceptSpecializationExpr;
 using clang::Decl;
@@ -2552,6 +2553,17 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
       return true;
     if (!CanForwardDeclareType(current_ast_node()))
       ReportTypeUse(CurrentLoc(), type, DerefKind::None);
+    return true;
+  }
+
+  //------------------------------------------------------------
+  // Visitors of attributes.
+
+  bool VisitCleanupAttr(CleanupAttr *attr) {
+    if (CanIgnoreCurrentASTNode())
+      return true;
+
+    ReportDeclUse(CurrentLoc(), attr->getFunctionDecl());
     return true;
   }
 

--- a/tests/c/var_cleanup_attr-d1.h
+++ b/tests/c/var_cleanup_attr-d1.h
@@ -1,0 +1,10 @@
+//===--- var_cleanup_attr-d1.h - test input file for iwyu -----------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/c/var_cleanup_attr-i1.h"

--- a/tests/c/var_cleanup_attr-i1.h
+++ b/tests/c/var_cleanup_attr-i1.h
@@ -1,0 +1,10 @@
+//===--- var_cleanup_attr-i1.h - test input file for iwyu -----------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+void freep(void* p);

--- a/tests/c/var_cleanup_attr.c
+++ b/tests/c/var_cleanup_attr.c
@@ -1,0 +1,33 @@
+//===--- var_cleanup_attr.c - test input file for iwyu --------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_ARGS: -I .
+
+// The cleanup attribute runs a function when the variable goes out of scope.
+// This test makes sure that we track that function.
+
+#include "tests/c/var_cleanup_attr-d1.h"
+
+void cleanup(void) {
+  // IWYU: freep is...*var_cleanup_attr-i1.h
+  __attribute__((__cleanup__(freep))) char* x = 0;
+}
+
+/**** IWYU_SUMMARY
+
+tests/c/var_cleanup_attr.c should add these lines:
+#include "tests/c/var_cleanup_attr-i1.h"
+
+tests/c/var_cleanup_attr.c should remove these lines:
+- #include "tests/c/var_cleanup_attr-d1.h"  // lines XX-XX
+
+The full include-list for tests/c/var_cleanup_attr.c:
+#include "tests/c/var_cleanup_attr-i1.h"  // for freep
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
https://gcc.gnu.org/onlinedocs/gcc/Common-Variable-Attributes.html#index-cleanup-variable-attribute

This attribute takes a function which should be tracked by IWYU.

Fixes #1710