### PR TITLE
Denote member pointer type parts as fwd-declarable

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -2575,6 +2575,13 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
     return true;
   }
 
+  bool VisitMemberPointerType(MemberPointerType* type) {
+    if (CanIgnoreCurrentASTNode())
+      return true;
+    current_ast_node()->set_in_forward_declare_context(true);
+    return true;
+  }
+
   //------------------------------------------------------------
   // Visitors of attributes.
 

--- a/tests/cxx/badinc.cc
+++ b/tests/cxx/badinc.cc
@@ -241,7 +241,7 @@ class Cc_Subclass : public I2_ThisClassIsOnlySubclassed {
     (m.*ptr_)();
     a();   // defined in the superclass
   }
-  // IWYU: I1_MemberPtr is...*badinc-i1.h
+  // IWYU: I1_MemberPtr needs a declaration
   int (I1_MemberPtr::*ptr_)();
   // IWYU: I2_Class needs a declaration
   H_ScopedPtr<I2_Class> scoped_ptr_;

--- a/tests/cxx/funcptrs.cc
+++ b/tests/cxx/funcptrs.cc
@@ -107,9 +107,11 @@ void ClassMembers() {
   // IWYU: Retval is...*funcptrs-i1.h
   int (*static_template_method_ptr)() = &Class::StaticMemberTemplate<Retval>;
 
+  // IWYU: Class needs a declaration
   // IWYU: Class is...*funcptrs-i1.h
   int (Class::*method_ptr)() const = &Class::MemberFunction;
 
+  // IWYU: Class needs a declaration
   // IWYU: Class is...*funcptrs-i1.h
   // IWYU: Retval needs a declaration
   // IWYU: Retval is...*funcptrs-i1.h
@@ -163,14 +165,14 @@ void ClassTemplateMembers() {
       // IWYU: Retval is...*funcptrs-i1.h
       &ClassTemplate<Class>::StaticMemberTemplate<Retval>;
 
-  // IWYU: ClassTemplate is...*funcptrs-i1.h
+  // IWYU: ClassTemplate needs a declaration
   // IWYU: Class needs a declaration
   int (ClassTemplate<Class>::*method_ptr)() const =
       // IWYU: ClassTemplate is...*funcptrs-i1.h
       // IWYU: Class needs a declaration
       &ClassTemplate<Class>::MemberFunction;
 
-  // IWYU: ClassTemplate is...*funcptrs-i1.h
+  // IWYU: ClassTemplate needs a declaration
   // IWYU: Class needs a declaration
   int (ClassTemplate<Class>::*template_method_ptr)() const =
       // IWYU: ClassTemplate is...*funcptrs-i1.h

--- a/tests/cxx/memptrs.cc
+++ b/tests/cxx/memptrs.cc
@@ -1,0 +1,53 @@
+//===--- memptrs.cc - test input file for iwyu ----------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_ARGS: -I .
+
+// Tests handling pointers to members.
+
+#include "tests/cxx/direct.h"
+
+class Class {};
+
+template <typename T>
+class TplUsingInQualifier {
+  int T::* p;
+};
+
+template <typename T>
+class TplUsingInMemberType {
+  T Class::* p;
+};
+
+// The types involved in member pointer type are forward-declarable in general.
+
+// IWYU: IndirectClass needs a declaration
+int IndirectClass::* p1;
+
+// IWYU: IndirectClass needs a declaration
+IndirectClass Class::* p2;
+
+// IWYU: IndirectClass needs a declaration
+TplUsingInQualifier<IndirectClass> tpl1;
+
+// IWYU: IndirectClass needs a declaration
+TplUsingInMemberType<IndirectClass> tpl2;
+
+/**** IWYU_SUMMARY
+
+tests/cxx/memptrs.cc should add these lines:
+class IndirectClass;
+
+tests/cxx/memptrs.cc should remove these lines:
+- #include "tests/cxx/direct.h"  // lines XX-XX
+
+The full include-list for tests/cxx/memptrs.cc:
+class IndirectClass;
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/type_trait.cc
+++ b/tests/cxx/type_trait.cc
@@ -356,14 +356,16 @@ static_assert(__is_assignable(Union1RefProviding, Union1RefProviding));
 static_assert(__is_trivially_assignable(Union1RefProviding,
                                         Union1RefProviding));
 static_assert(__is_nothrow_assignable(Union1RefProviding, Union1RefProviding));
-// TODO: the full Base type is redundant here.
-// IWYU: Base is...*tests/cxx/type_trait-i1.h
+// IWYU: Base needs a declaration
+// IWYU: Derived needs a declaration
 // IWYU: Derived is...*tests/cxx/type_trait-i2.h
 static_assert(__is_assignable(int Derived::*&, int Base::*));
-// IWYU: Base is...*tests/cxx/type_trait-i1.h
+// IWYU: Base needs a declaration
+// IWYU: Derived needs a declaration
 // IWYU: Derived is...*tests/cxx/type_trait-i2.h
 static_assert(__is_trivially_assignable(int Derived::*&, int Base::*));
-// IWYU: Base is...*tests/cxx/type_trait-i1.h
+// IWYU: Base needs a declaration
+// IWYU: Derived needs a declaration
 // IWYU: Derived is...*tests/cxx/type_trait-i2.h
 static_assert(__is_nothrow_assignable(int Derived::*&, int Base::*));
 // IWYU: Derived is...*tests/cxx/type_trait-i2.h


### PR DESCRIPTION
Templates have been used in the test to make sure that the handler is placed in the correct (common) visitor.