### PR TITLE
Accept <stdin> as a definition file for macros

### DIFF
--- a/iwyu_output.cc
+++ b/iwyu_output.cc
@@ -299,8 +299,8 @@ OneUse::OneUse(const string& symbol_name, OptionalFileEntryRef dfn_file,
       is_iwyu_violation_(false) {
   CHECK_(dfn_file && "OneUse: dfn_file must be set");
   CHECK_(!decl_filepath_.empty() && "OneUse: dfn_file must have a name");
-  CHECK_(!IsQuotedInclude(decl_filepath_))
-      << "OneUse: dfn_file must have a real name, was: " << decl_filepath_;
+  CHECK_(decl_filepath_ == "<stdin>" || !IsQuotedInclude(decl_filepath_))
+      << ": OneUse: dfn_file must have a real name, was: " << decl_filepath_;
 }
 
 OneUse::OneUse(OptionalFileEntryRef included_file, const string& quoted_include)


### PR DESCRIPTION
While experimenting with something, I triggered an assertion failure using something like:

    printf "#define M(x)\nM(0);" | include-what-you-use -xc -

i.e. a use of a macro defined in `<stdin>`.

It's questionable whether we should report uses defined in `<stdin>` at all, but accept it for now to avoid crashes.