### PR TITLE
Avoid full type for assignable from void trait

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -2071,6 +2071,9 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
         // TODO(bolshakov): require complete argument types here when
         // CanForwardDeclareType stops doing it.
         if (RemoveReference(lhs_type)->isRecordType()) {
+          // No assignment from void.
+          if (rhs_type->isVoidType())
+            return true;
           // If the first type is a class/struct/union type, it may have
           // a user-defined operator= which accepts the second type or its base
           // class by reference or by pointer.

--- a/tests/cxx/type_trait.cc
+++ b/tests/cxx/type_trait.cc
@@ -356,6 +356,9 @@ static_assert(__is_assignable(Union1RefProviding, Union1RefProviding));
 static_assert(__is_trivially_assignable(Union1RefProviding,
                                         Union1RefProviding));
 static_assert(__is_nothrow_assignable(Union1RefProviding, Union1RefProviding));
+static_assert(!__is_assignable(Class&, void));
+static_assert(!__is_trivially_assignable(Class&, void));
+static_assert(!__is_nothrow_assignable(Class&, void));
 // IWYU: Base needs a declaration
 // IWYU: Derived needs a declaration
 // IWYU: Derived is...*tests/cxx/type_trait-i2.h


### PR DESCRIPTION
'void' cannot be assigned to an object, so the complete object type is not needed for proper evaluation of such a trait.

The case when 'void' appears at the LHS should already be discarded by the logic.