### PR TITLE
Remove questionable IsSystemIncludeFile

### DIFF
--- a/iwyu_path_util.cc
+++ b/iwyu_path_util.cc
@@ -210,12 +210,6 @@ bool IsQuotedInclude(const string& s) {
           (StartsWith(s, "\"") && EndsWith(s, "\"")));
 }
 
-// Returns whether this is a system (as opposed to user) include file,
-// based on where it lives.
-bool IsSystemIncludeFile(const string& filepath) {
-  return ConvertToQuotedInclude(filepath)[0] == '<';
-}
-
 string AddQuotes(string include_name, bool angled) {
   if (angled) {
       return "<" + include_name + ">";

--- a/iwyu_path_util.h
+++ b/iwyu_path_util.h
@@ -84,10 +84,6 @@ string ConvertToQuotedInclude(const string& filepath,
 // Returns true if the string is a quoted include.
 bool IsQuotedInclude(const string& s);
 
-// Returns whether this is a system (as opposed to user) include
-// file, based on where it lives.
-bool IsSystemIncludeFile(const string& filepath);
-
 // Returns true if argument is one of the special filenames used by Clang for
 // implicit buffers ("<built-in>", "<command-line>", etc).
 inline bool IsSpecialFilename(llvm::StringRef name) {

--- a/iwyu_verrs.cc
+++ b/iwyu_verrs.cc
@@ -13,7 +13,6 @@
 
 #include "iwyu_globals.h"
 #include "iwyu_location_util.h"
-#include "iwyu_path_util.h"
 
 namespace include_what_you_use {
 
@@ -37,7 +36,7 @@ bool ShouldPrintSymbolFromFile(OptionalFileEntryRef file) {
   } else if (GetVerboseLevel() < 10) {
     return ShouldReportIWYUViolationsFor(file);
   } else if (GetVerboseLevel() < 11) {
-    return !IsSystemIncludeFile(GetFilePath(file));
+    return !IsSpecialFile(file) && !IsSystemHeader(file);
   } else {
     return true;
   }


### PR DESCRIPTION
This would return true for special filenames, such as "\<built-in\>", "\<command-line\>", etc.

We have library functions to check for system headers and special files now, so use them directly.

Check for both special files and system headers to preserve semantics, but we might consider only checking IsSystemHeader now.