### PR TITLE
Don't require union type for ptr in "assignable"

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -2076,9 +2076,14 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
             return true;
           // If the first type is a class/struct/union type, it may have
           // a user-defined operator= which accepts the second type or its base
-          // class by reference or by pointer.
+          // class (for non-unions) by reference or by pointer. OTOH, the second
+          // type may have a conversion operator to the first type, which may be
+          // used if the rhs is not a pointer.
           ReportTypeUse(CurrentLoc(), lhs_type, DerefKind::RemoveRefs);
-          ReportTypeUse(CurrentLoc(), rhs_type, DerefKind::RemoveRefsAndPtr);
+          ReportTypeUse(CurrentLoc(), rhs_type,
+                        RemovePointersAndReferences(rhs_type)->isUnionType()
+                            ? DerefKind::RemoveRefs
+                            : DerefKind::RemoveRefsAndPtr);
           // TODO(bolshakov): report a 3rd type involved in the conversion, if
           // present. See an example in
           // github.com/include-what-you-use/include-what-you-use/pull/745.

--- a/tests/cxx/type_trait-d2.h
+++ b/tests/cxx/type_trait-d2.h
@@ -16,6 +16,7 @@ using DerivedPtrRefNonProviding = Derived*&;
 using DerivedRefNonProviding = Derived&;
 using ClassRefNonProviding = Class&;
 using Union1RefNonProviding = Union1&;
+using Union1PtrRefNonProviding = Union1*&;
 
 template <typename T>
 using BaseMemPtr = T Base::*;

--- a/tests/cxx/type_trait-i1.h
+++ b/tests/cxx/type_trait-i1.h
@@ -25,6 +25,7 @@ union Union1;
 struct Struct : Base {
   Struct& operator=(Class&) noexcept;
   Struct& operator=(Union1&) noexcept;
+  Struct& operator=(Union1*) noexcept;
 };
 
 class StructDerivedClass : public Struct {};

--- a/tests/cxx/type_trait.cc
+++ b/tests/cxx/type_trait.cc
@@ -344,6 +344,25 @@ static_assert(__is_assignable(Union1&, Union1&));
 static_assert(__is_trivially_assignable(Union1&, Union1&));
 // IWYU: Union1 is...*-i1.h
 static_assert(__is_nothrow_assignable(Union1&, Union1&));
+// IWYU: Struct is...*-i1.h
+static_assert(__is_assignable(Struct&, Union1*));
+static_assert(!__is_trivially_assignable(Struct&, Union1*));
+// IWYU: Struct is...*-i1.h
+static_assert(__is_nothrow_assignable(Struct&, Union1*));
+// IWYU: Struct is...*-i1.h
+static_assert(__is_assignable(Struct&, Union1PtrRefNonProviding));
+static_assert(!__is_trivially_assignable(Struct&, Union1PtrRefNonProviding));
+// IWYU: Struct is...*-i1.h
+static_assert(__is_nothrow_assignable(Struct&, Union1PtrRefNonProviding));
+// TODO: no need of the complete Union1 type for arrays of unknown bound.
+// IWYU: Struct is...*-i1.h
+// IWYU: Union1 is...*-i1.h
+static_assert(__is_assignable(Struct&, Union1[]));
+// IWYU: Union1 is...*-i1.h
+static_assert(!__is_trivially_assignable(Struct&, Union1[]));
+// IWYU: Struct is...*-i1.h
+// IWYU: Union1 is...*-i1.h
+static_assert(__is_nothrow_assignable(Struct&, Union1[]));
 // IWYU: Union1 is...*-i1.h
 static_assert(__is_assignable(Union1RefNonProviding, Union1RefNonProviding));
 // IWYU: Union1 is...*-i1.h
@@ -478,7 +497,7 @@ tests/cxx/type_trait.cc should remove these lines:
 
 The full include-list for tests/cxx/type_trait.cc:
 #include "tests/cxx/type_trait-d1.h"  // for ClassRefProviding, DerivedPtrRefProviding, DerivedRefProviding, Union1RefProviding
-#include "tests/cxx/type_trait-d2.h"  // for BaseMemPtr, ClassRefNonProviding, DerivedMemPtr, DerivedPtrRefNonProviding, DerivedRefNonProviding, Union1RefNonProviding, UnionMemPtr
+#include "tests/cxx/type_trait-d2.h"  // for BaseMemPtr, ClassRefNonProviding, DerivedMemPtr, DerivedPtrRefNonProviding, DerivedRefNonProviding, Union1PtrRefNonProviding, Union1RefNonProviding, UnionMemPtr
 #include "tests/cxx/type_trait-i1.h"  // for Base, Class, Struct, StructDerivedClass, Union1, Union2
 #include "tests/cxx/type_trait-i2.h"  // for Derived
 


### PR DESCRIPTION
The complete pointed-to type is required for cases when the lhs has an assignment operator from the pointer to base. But unions cannot take part in inheritance.