### PR TITLE
Make dogfood diff always expanded

### DIFF
--- a/iwyu-dogfood.bash
+++ b/iwyu-dogfood.bash
@@ -66,12 +66,8 @@ $(cat iwyu-dogfood.fix)
 
 </details>
 
-<details>
-<summary>diff</summary>
-
 \`\`\`diff
 $(cat iwyu-dogfood.diff)
 \`\`\`
 
-</details>
 EOF


### PR DESCRIPTION
Changes detected by the dogfood build step doesn't fail the build, so it's easy to overlook when it finds changes.

Remove the details/summary wrapping of the diff, so it lights up a bit more. Diffs are usually small, so it should not be too disruptive.