### PR TITLE
Force exit code for dogfood diagnostics

### DIFF
--- a/iwyu-dogfood.bash
+++ b/iwyu-dogfood.bash
@@ -33,7 +33,7 @@ check_alsos=$(for h in $HEADER_ONLY; do echo "-Xiwyu --check_also=*/$h"; done)
 # Run IWYU over all source files using iwyu_tool.py with CMake-generated
 # compilation database.
 export IWYU_BINARY=$builddir/bin/include-what-you-use
-./iwyu_tool.py -v -p "$builddir" *.cc -- $check_alsos > iwyu-dogfood.out 2>&1
+./iwyu_tool.py -v -p "$builddir" *.cc -- -Xiwyu --error $check_alsos > iwyu-dogfood.out 2>&1
 iwyu_exit=$?
 
 # Apply changes in-tree using fix_includes.py.


### PR DESCRIPTION
The dogfood report does not clearly signal that IWYU found issues with itself -- you'd have to expand the details/summary blocks to discover diagnostics and diffs.

As a subtle hint, force a non-zero exit code if IWYU makes suggestions, so we can see it in the summary.