### PR TITLE
Remove unused include

### DIFF
--- a/iwyu_verrs.cc
+++ b/iwyu_verrs.cc
@@ -9,8 +9,6 @@
 
 #include "iwyu_verrs.h"
 
-#include <string>
-
 #include "iwyu_globals.h"
 #include "iwyu_location_util.h"
 


### PR DESCRIPTION
In 1bf8a9650e19e95613edbc22cf4b1e8f5318c5a9, I cleaned out all uses of std::string, but forgot to remove the include of the `<string>` header.

Drop it.