### PR TITLE
Add pragmas to keep right DiagnosticFrontend.h include

### DIFF
--- a/iwyu_driver.cc
+++ b/iwyu_driver.cc
@@ -22,7 +22,7 @@
 #include <vector>
 
 #include "clang/Basic/Diagnostic.h"
-#include "clang/Basic/DiagnosticFrontend.h"
+#include "clang/Basic/DiagnosticFrontend.h"  // IWYU pragma: keep
 #include "clang/Basic/DiagnosticOptions.h"
 #include "clang/Driver/Action.h"
 #include "clang/Driver/Compilation.h"
@@ -53,6 +53,7 @@
 #include "llvm/TargetParser/Host.h"
 
 // TODO: Clean out pragmas as IWYU improves.
+// IWYU pragma: no_include "clang/Basic/DiagnosticFrontendInterface.inc"
 // IWYU pragma: no_include "clang/Basic/LLVM.h"
 // IWYU pragma: no_include "llvm/ADT/iterator.h"
 


### PR DESCRIPTION
Clang reorganized the diagnostics headers in
https://github.com/llvm/llvm-project/commit/6c74fe9087fd85059158719ad1ab67e0f5098300

We don't seem to have a rule for .inc files, and I'm not entirely sure what it should be. Add pragmas to keep the public header.