### PR TITLE
Fix sys/ttycom.h mapping

### DIFF
--- a/gcc.libc.imp
+++ b/gcc.libc.imp
@@ -218,11 +218,12 @@
   { "include": [ "<asm/unistd.h>", "private", "<sys/syscall.h>", "public"] },
   { "include": [ "<linux/limits.h>", "private", "<limits.h>", "public"] },   # PATH_MAX
   { "include": [ "<linux/prctl.h>", "private", "<sys/prctl.h>", "public"] },
+  { "include": [ "<sys/ucontext.h>", "private", "<ucontext.h>", "public"] },
+  # System headers available on AIX, BSD, Solaris and other Unix systems
   { "include": [ "<sys/dtrace.h>", "private", "<dtrace.h>", "public"] },
   { "include": [ "<sys/paths.h>", "private", "<paths.h>", "public"] },
   { "include": [ "<sys/syslimits.h>", "private", "<limits.h>", "public"] },
-  { "include": [ "<sys/ttycom.h>", "private", "<termios.h>", "public"] },
-  { "include": [ "<sys/ucontext.h>", "private", "<ucontext.h>", "public"] },
+  { "include": [ "<sys/ttycom.h>", "private", "<sys/ioctl.h>", "public"] },
   { "include": [ "<sys/ustat.h>", "private", "<ustat.h>", "public"] },
   # Exports guaranteed by the C standard
   { "include": [ "<stdint.h>", "public", "<inttypes.h>", "public"] },

--- a/iwyu_include_picker.cc
+++ b/iwyu_include_picker.cc
@@ -561,11 +561,12 @@ const IncludeMapEntry libc_include_map[] = {
   { "<asm/unistd.h>", kPrivate, "<sys/syscall.h>", kPublic },
   { "<linux/limits.h>", kPrivate, "<limits.h>", kPublic },   // PATH_MAX
   { "<linux/prctl.h>", kPrivate, "<sys/prctl.h>", kPublic },
+  { "<sys/ucontext.h>", kPrivate, "<ucontext.h>", kPublic },
+  // System headers available on AIX, BSD, Solaris and other Unix systems
   { "<sys/dtrace.h>", kPrivate, "<dtrace.h>", kPublic },
   { "<sys/paths.h>", kPrivate, "<paths.h>", kPublic },
   { "<sys/syslimits.h>", kPrivate, "<limits.h>", kPublic },
-  { "<sys/ttycom.h>", kPrivate, "<termios.h>", kPublic },
-  { "<sys/ucontext.h>", kPrivate, "<ucontext.h>", kPublic },
+  { "<sys/ttycom.h>", kPrivate, "<sys/ioctl.h>", kPublic },
   { "<sys/ustat.h>", kPrivate, "<ustat.h>", kPublic },
   // Exports guaranteed by the C standard
   { "<stdint.h>", kPublic, "<inttypes.h>", kPublic },


### PR DESCRIPTION
Some BSDs define winsize in sys/ttycom.h, so it was originally mapped to
termios.h. A mapping for the winsize symbol has since been added and the
remaining symbols should be imported via sys/ioctl.h. While here, group
it with other system headers that are not present on Linux.