### PR TITLE
Only show dogfood diff if changes were suggested

### DIFF
--- a/iwyu-dogfood.bash
+++ b/iwyu-dogfood.bash
@@ -65,9 +65,15 @@ $(cat iwyu-dogfood.fix)
 \`\`\`
 
 </details>
+EOF
+
+# Append diff if IWYU found something.
+if [[ $iwyu_exit -ne 0 ]]; then
+    cat<<EOF >> iwyu-dogfood.md
 
 \`\`\`diff
 $(cat iwyu-dogfood.diff)
 \`\`\`
-
 EOF
+
+fi


### PR DESCRIPTION
The empty preformatted block looked a little off, so only emit the diff block if IWYU suggested any changes.