### PR TITLE
Improve "convertible" trait handling

### DIFF
--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -1698,6 +1698,17 @@ bool IsReferenceToModifiableLValue(const Type* type) {
          !type->getPointeeType().getQualifiers().hasConst();
 }
 
+bool RefCanBindToTemp(const Type* type) {
+  if (type->isRValueReferenceType())
+    return true;
+  const auto* ref_type = type->getAs<LValueReferenceType>();
+  if (!ref_type)
+    return false;
+  const QualType referred_type = ref_type->getPointeeType();
+  return referred_type.isConstQualified() &&
+         !referred_type.isVolatileQualified();
+}
+
 bool IsDerivedToBasePtrConvertible(const Type* derived_ptr_type,
                                    const Type* base_ptr_type) {
   if (!derived_ptr_type->isPointerType() || !base_ptr_type->isPointerType())

--- a/iwyu_ast_util.h
+++ b/iwyu_ast_util.h
@@ -879,6 +879,11 @@ std::vector<const clang::Type*> GetCanonicalArgComponents(
 
 bool IsReferenceToModifiableLValue(const clang::Type*);
 
+// Returns true if the given type is a reference that can bind to a temporary
+// object, i.e. when it is either an rvalue reference or an lvalue reference to
+// a non-volatile const type (C++17 [dcl.init.ref]p.5.2).
+bool RefCanBindToTemp(const clang::Type*);
+
 // Returns true when the arguments are pointer types referring to classes or
 // structs related by direct inheritance. Also checks that their qualifiers
 // allow the conversion.

--- a/tests/cxx/ptr_ref_aliases.cc
+++ b/tests/cxx/ptr_ref_aliases.cc
@@ -160,14 +160,16 @@ void TestSomeComplexIndirectionCases() {
 
 tests/cxx/ptr_ref_aliases.cc should add these lines:
 #include "tests/cxx/ptr_ref_aliases-i2.h"
+struct IndirectBase;
 
 tests/cxx/ptr_ref_aliases.cc should remove these lines:
+- #include "tests/cxx/ptr_ref_aliases-d3.h"  // lines XX-XX
 
 The full include-list for tests/cxx/ptr_ref_aliases.cc:
 #include <typeinfo>  // for type_info
 #include "tests/cxx/ptr_ref_aliases-d1.h"  // for NonProvidingDoublePtrAlias, NonProvidingDoubleRefAlias, NonProvidingDoubleRefPtrAlias, NonProvidingPtrAlias, NonProvidingRefAlias, NonProvidingRefPtrAlias
 #include "tests/cxx/ptr_ref_aliases-d2.h"  // for ProvidingPtrAlias, ProvidingRefAlias
-#include "tests/cxx/ptr_ref_aliases-d3.h"  // for IndirectBase
 #include "tests/cxx/ptr_ref_aliases-i2.h"  // for Indirect
+struct IndirectBase;
 
 ***** IWYU_SUMMARY */

--- a/tests/cxx/type_trait-d1.h
+++ b/tests/cxx/type_trait-d1.h
@@ -15,6 +15,7 @@
 using DerivedPtrRefProviding = Derived*&;
 using DerivedRefProviding = Derived&;
 using ClassRefProviding = Class&;
+using ClassConstRefProviding = const Class&;
 using Union1RefProviding = Union1&;
 
 #endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_TYPE_TRAIT_D1_H_

--- a/tests/cxx/type_trait-d2.h
+++ b/tests/cxx/type_trait-d2.h
@@ -12,9 +12,11 @@ class Derived;
 class Class;
 union Union1;
 
+using ClassNonProviding = Class;
 using DerivedPtrRefNonProviding = Derived*&;
 using DerivedRefNonProviding = Derived&;
 using ClassRefNonProviding = Class&;
+using ClassConstRefNonProviding = const Class&;
 using Union1RefNonProviding = Union1&;
 using Union1PtrRefNonProviding = Union1*&;
 

--- a/tests/cxx/type_trait-i1.h
+++ b/tests/cxx/type_trait-i1.h
@@ -14,6 +14,10 @@ class Base {};
 
 class Class {
  public:
+  Class(Base*) noexcept;
+  Class(Base&) noexcept;
+  Class(void()) noexcept;
+
   Class& operator=(int) noexcept;
   Class& operator=(Base*) noexcept;
   Class& operator=(const Base&) noexcept;
@@ -23,14 +27,19 @@ class Class {
 union Union1;
 
 struct Struct : Base {
+  Struct(Union1*) noexcept;
+
   Struct& operator=(Class&) noexcept;
   Struct& operator=(Union1&) noexcept;
   Struct& operator=(Union1*) noexcept;
+  operator Class&() const noexcept;
 };
 
 class StructDerivedClass : public Struct {};
 
 union Union1 {
+  Union1(const Base*) noexcept;
+
   Union1& operator=(Struct&) noexcept;
 };
 union Union2 {


### PR DESCRIPTION
Because `__is_convertible_to` is a synonym for `__is_convertible`, and already has some test coverage, test cases for it have not been added. OTOH, `__is_nothrow_convertible` has also been handled similarly in IWYU, so the test cases for it may be redundant as well...


The change in the `ptr_ref_aliases` test is because the only `IndirectBase` use that was considered as a full use by IWYU was inside `__is_convertible_to` traits.