### PR TITLE
Make sure CodeAuthorWantsJustAForwardDeclare() also considers identical locations

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -1430,7 +1430,10 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
     // Check if the author forward-declared the class in the same file.
     bool found_earlier_forward_declare_in_same_file = false;
     for (const NamedDecl* redecl : redecls) {
-      if (IsBeforeInSameFile(redecl, use_loc)) {
+      // In case of something like "typedef struct Manager Manager", the
+      // redeclaration and the type will have the same location.
+      if (GetLocation(redecl) == use_loc ||
+          IsBeforeInSameFile(redecl, use_loc)) {
         found_earlier_forward_declare_in_same_file = true;
         break;
       }

--- a/tests/c/elaborated_struct-d2.h
+++ b/tests/c/elaborated_struct-d2.h
@@ -1,0 +1,16 @@
+//===--- elaborated_struct-d2.h - test input file for iwyu ----------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+typedef struct Struct Typedef;
+
+/**** IWYU_SUMMARY
+
+(tests/c/elaborated_struct-d2.h has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/c/elaborated_struct.c
+++ b/tests/c/elaborated_struct.c
@@ -7,8 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-// IWYU_ARGS: -I .
+// IWYU_ARGS: -I . -Xiwyu --check_also=tests/c/elaborated_struct-d2.h
 
+#include "tests/c/elaborated_struct-d2.h"
 #include "tests/c/elaborated_struct-d1.h"
 
 // C basically never requires an explicit forward declaration, all uses of
@@ -43,6 +44,7 @@ struct Struct;
 
 tests/c/elaborated_struct.c should remove these lines:
 - #include "tests/c/elaborated_struct-d1.h"  // lines XX-XX
+- #include "tests/c/elaborated_struct-d2.h"  // lines XX-XX
 
 The full include-list for tests/c/elaborated_struct.c:
 struct ForwardDeclared;  // lines XX-XX


### PR DESCRIPTION
If the locations are the same, we can also consider one location to
be before the other. This matters in case where an elaborated type
appears on the same line as the record declaration
(typedef struct Manager Manager).

Fixes https://github.com/include-what-you-use/include-what-you-use/issues/1730