### PR TITLE
Clean out IWYU pragmas in iwyu_globals.cc

### DIFF
--- a/iwyu_getopt.h
+++ b/iwyu_getopt.h
@@ -41,7 +41,8 @@ int getopt_long(int argc, char* const argv[],
 
 #else  // #if defined(_MSC_VER)
 
-#include <getopt.h>   // IWYU pragma: export
+#include <unistd.h> // IWYU pragma: export
+#include <getopt.h> // IWYU pragma: export
 
 #endif  // #if defined(_MSC_VER)
 

--- a/iwyu_globals.cc
+++ b/iwyu_globals.cc
@@ -42,10 +42,6 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Option/ArgList.h"
 
-// TODO: Clean out pragmas as IWYU improves.
-// IWYU pragma: no_include <unistd.h>
-// IWYU pragma: no_include "llvm/ADT/iterator.h"
-
 using clang::CompilerInstance;
 using clang::HeaderSearch;
 using clang::LangOptions;


### PR DESCRIPTION
Export unistd.h from iwyu_getopt.h to suppress the need for unistd.h in iwyu_globals.cc for 'optarg'. This better captures iwyu_getopt.h portability wrapper semantics.

Mainline IWYU no longer requires "llvm/ADT/iterator.h".