### PR TITLE
Always use "use location" as canonical use location for a decl

### DIFF
--- a/tests/cxx/badinc.cc
+++ b/tests/cxx/badinc.cc
@@ -1140,6 +1140,7 @@ int main() {
   // still detect that operator<< is being used here, and not in the
   // macro-definition file.
   // IWYU: I1_MACRO_LOGGING_CLASS is...*badinc-i1.h
+  // IWYU: I2_OperatorDefinedInI1Class is...*badinc-i2.h
   // IWYU: I2_OperatorDefinedInI1Class::operator<< is...*badinc-i1.h
   I1_MACRO_LOGGING_CLASS << 1;
 
@@ -1391,8 +1392,10 @@ int main() {
   (void)(i1_class_array);
   d1_i1_typedef.a();
   D1_I1_Typedef().a();
+  // IWYU: I4_Function is...*badinc-i4.h
   MACRO_CALLING_I4_FUNCTION;
   // IWYU: MACRO_CALLING_I6_FUNCTION is...*badinc-i1.h
+  // IWYU: I6_Function is...*badinc-i6.h
   MACRO_CALLING_I6_FUNCTION;
   // IWYU: kI1ConstInt is...*badinc-i1.h
   (void)(kI1ConstInt);
@@ -1704,8 +1707,9 @@ int main() {
   // IWYU: I1_Class needs a declaration
   if (I1_Class* i = NULL) i = NULL;
 
-  // Test some macros, including one we shouldn't mark as in-use.
+  // Test some macros, including one we should mark as in-use.
   // IWYU: MACRO_CALLING_I2_FUNCTION is...*badinc-i2.h
+  // IWYU: I2_Function is...*badinc-i2.h
   MACRO_CALLING_I2_FUNCTION;
   // Here are some uses of UNUSED_MACRO that we should not find:
   /*
@@ -1811,6 +1815,8 @@ tests/cxx/badinc.cc should add these lines:
 #include <stddef.h>
 #include <list>
 #include "tests/cxx/badinc-i1.h"
+#include "tests/cxx/badinc-i4.h"
+#include "tests/cxx/badinc-i6.h"
 class D2_Class;
 class D2_ForwardDeclareClass;
 class D2_Subclass;
@@ -1846,6 +1852,8 @@ The full include-list for tests/cxx/badinc.cc:
 #include "tests/cxx/badinc-d1.h"  // for D1CopyClassFn, D1Function, D1_Class, D1_CopyClass, D1_Enum, D1_I1_Typedef, D1_StructPtr, D1_Subclass, D1_TemplateClass, D1_TemplateStructWithDefaultParam, MACRO_CALLING_I4_FUNCTION
 #include "tests/cxx/badinc-d4.h"  // for D4_ClassForOperator, operator<<
 #include "tests/cxx/badinc-i1.h"  // for EmptyDestructorClass, H_Class::H_Class_DefinedInI1, I1_And_I2_OverloadedFunction, I1_Base, I1_Class, I1_ClassPtr, I1_Enum, I1_Function, I1_FunctionPtr, I1_I2_Class_Typedef, I1_MACRO_LOGGING_CLASS, I1_MACRO_SYMBOL_WITHOUT_VALUE, I1_MACRO_SYMBOL_WITH_VALUE, I1_MACRO_SYMBOL_WITH_VALUE0, I1_MACRO_SYMBOL_WITH_VALUE2, I1_ManyPtrStruct (ptr only), I1_MemberPtr, I1_NamespaceClass, I1_NamespaceStruct, I1_NamespaceTemplateFn, I1_OverloadedFunction, I1_PtrAndUseOnSameLine, I1_PtrDereferenceClass, I1_PtrDereferenceStatic, I1_PtrDereferenceStruct, I1_SiblingClass, I1_StaticMethod, I1_Struct, I1_Subclass, I1_SubclassesI2Class, I1_TemplateClass, I1_TemplateClassFwdDeclaredInD2 (ptr only), I1_TemplateFunction, I1_TemplateMethodOnlyClass, I1_TemplateSubclass, I1_Typedef, I1_TypedefOnly_Class, I1_Union, I1_UnnamedStruct, I1_UnusedNamespaceStruct (ptr only), I1_const_ptr, I2_OperatorDefinedInI1Class::operator<<, MACRO_CALLING_I6_FUNCTION, OperateOn, i1_GlobalFunction, i1_int, i1_int_global, i1_int_global2, i1_int_global2sub, i1_int_global3, i1_int_global3sub, i1_int_global4, i1_int_global4sub, i1_int_globalsub, i1_ns5, kI1ConstInt, operator==
+#include "tests/cxx/badinc-i4.h"  // for I4_Function
+#include "tests/cxx/badinc-i6.h"  // for I6_Function
 #include "tests/cxx/badinc2.c"
 class D2_Class;
 class D2_ForwardDeclareClass;

--- a/tests/cxx/badinc.h
+++ b/tests/cxx/badinc.h
@@ -392,7 +392,7 @@ tests/cxx/badinc.h should remove these lines:
 - template <typename T> class I2_TypedefOnly_Class;  // lines XX-XX
 
 The full include-list for tests/cxx/badinc.h:
-#include <errno.h>  // for errno
+#include <errno.h>  // for __errno_location, errno
 #include <stdio.h>  // for NULL, printf
 #include <queue>  // for queue
 #include <set>  // for set

--- a/tests/cxx/expl_inst_macro.cc
+++ b/tests/cxx/expl_inst_macro.cc
@@ -25,6 +25,13 @@ void test() {
 
 /**** IWYU_SUMMARY
 
-(tests/cxx/expl_inst_macro.cc has correct #includes/fwd-decls)
+tests/cxx/expl_inst_macro.cc should add these lines:
+#include <iostream>
+
+tests/cxx/expl_inst_macro.cc should remove these lines:
+
+The full include-list for tests/cxx/expl_inst_macro.cc:
+#include "tests/cxx/expl_inst_macro.h"
+#include <iostream>  // for basic_ostream, cout, operator<<
 
 ***** IWYU_SUMMARY */

--- a/tests/cxx/expl_inst_macro.h
+++ b/tests/cxx/expl_inst_macro.h
@@ -15,6 +15,11 @@
 
 /**** IWYU_SUMMARY
 
-(tests/cxx/expl_inst_macro.h has correct #includes/fwd-decls)
+tests/cxx/expl_inst_macro.h should add these lines:
+
+tests/cxx/expl_inst_macro.h should remove these lines:
+- #include <iostream>  // lines XX-XX
+
+The full include-list for tests/cxx/expl_inst_macro.h:
 
 ***** IWYU_SUMMARY */

--- a/tests/cxx/macro_location-d2.h
+++ b/tests/cxx/macro_location-d2.h
@@ -9,8 +9,8 @@
 
 #include "tests/cxx/macro_location-d1.h"
 
-// The forward-declare is a hint that the use should be attributed
-// to users of the DECLARE_INDIRECT macro, not this file.
+// The forward-declare should get removed as the use of the macro
+// is attributed to the users of DECLARE_INDIRECT macro, not this file.
 class IndirectClass;
 
 #define DECLARE_INDIRECT(name) IndirectClass name;
@@ -39,6 +39,12 @@ class IndirectClass;
 
 /**** IWYU_SUMMARY
 
-(tests/cxx/macro_location-d2.h has correct #includes/fwd-decls)
+tests/cxx/macro_location-d2.h should add these lines:
+
+tests/cxx/macro_location-d2.h should remove these lines:
+- #include "tests/cxx/macro_location-d1.h"  // lines XX-XX
+- class IndirectClass;  // lines XX-XX
+
+The full include-list for tests/cxx/macro_location-d2.h:
 
 ***** IWYU_SUMMARY */

--- a/tests/cxx/macro_location-d4.h
+++ b/tests/cxx/macro_location-d4.h
@@ -13,20 +13,20 @@
 #include "tests/cxx/macro_location-i5.h" // for UNNAMED_TYPE_IN_MACRO
 
 // A class declared in this file and used via a macro defined in this file
-// should not be seen by IWYU in files expanding the macro.
+// should be seen by IWYU in files expanding the macro.
 class Logger {
  public:
   void Log(int level, const char* msg);
 };
 
-// A forward-declaration inside a macro should not count as a use-attribution
-// hint and should not be seen by IWYU in files expanding other macros.
+// A forward-declaration inside a macro should count as a use-attribution
+// hint and should be seen by IWYU in files expanding other macros.
 #define UNRELATED_FORWARD_DECLARE class Logger;
 
 #define LOG_INFO(x) \
   Logger().Log(0, x);
 
-// A class declared and used in this macro should not be seen by IWYU in files
+// A class declared and used in this macro should be seen by IWYU in files
 // expanding the macro. This is similar to USE_CLASS in macro_location-d2.h, but
 // doesn't involve macro arg concatentation.
 // (And yes, this code is broken in so many ways, it's only to put the test case

--- a/tests/cxx/macro_location.h
+++ b/tests/cxx/macro_location.h
@@ -19,13 +19,14 @@ class HClass { };
 // IWYU: Foo is...*macro_location-i3.h
 const int s = ARRAYSIZE(foo);
 // Should not need a declaration of NewClass_Bar, or NewClass.
+// IWYU: NewClass is...*macro_location-d1.h
+// IWYU: OtherClass is...*macro_location-d1.h
 NEW_CLASS(Bar);
 // This shouldn't cause weird iwyu issues between us and macro_location-d2.h.
 USE_CLASS(HClass);
 // This shouldn't cause macro_location-d1.h to need to include us for HClass.
 CREATE_VAR(HClass);
-// This should force us to #include a definition of IndirectClass, because it's
-// forward-declared by DECLARE_INDIRECT's file.
+// This should force us to #include a definition of IndirectClass.
 DECLARE_INDIRECT(global_indirect);
 
 // Macro-concatenated locations end up in <scratch space>, check that they're
@@ -39,7 +40,7 @@ CONCAT(Concat, FwdDeclClass) *global_concat_ptr;
 CONCAT(Concat, Class) global_concat;
 
 // Make sure types defined and used only within a macro definition file
-// aren't attributed to the macro expansion loc.
+// are attributed to the macro expansion loc.
 
 // IWYU: UNNAMED_TYPE_IN_MACRO is...*macro_location-i5.h
 UNNAMED_TYPE_IN_MACRO(500);
@@ -52,6 +53,7 @@ void func() {
 /**** IWYU_SUMMARY
 
 tests/cxx/macro_location.h should add these lines:
+#include "tests/cxx/macro_location-d1.h"
 #include "tests/cxx/macro_location-i3.h"
 #include "tests/cxx/macro_location-i4.h"
 #include "tests/cxx/macro_location-i5.h"
@@ -62,8 +64,9 @@ tests/cxx/macro_location.h should remove these lines:
 
 The full include-list for tests/cxx/macro_location.h:
 #include "tests/cxx/indirect.h"  // for IndirectClass
+#include "tests/cxx/macro_location-d1.h"  // for NewClass, OtherClass
 #include "tests/cxx/macro_location-d2.h"  // for ARRAYSIZE, CREATE_VAR, DECLARE_INDIRECT, NEW_CLASS, USE_CLASS
-#include "tests/cxx/macro_location-d4.h"  // for DECLARE_AND_USE_CLASS, LOG_INFO
+#include "tests/cxx/macro_location-d4.h"  // for DECLARE_AND_USE_CLASS, LOG_INFO, Logger
 #include "tests/cxx/macro_location-i3.h"  // for Foo
 #include "tests/cxx/macro_location-i4.h"  // for ConcatClass, ConcatFwdDeclClass (ptr only)
 #include "tests/cxx/macro_location-i5.h"  // for UNNAMED_TYPE_IN_MACRO

--- a/tests/cxx/macro_location_tpl.cc
+++ b/tests/cxx/macro_location_tpl.cc
@@ -7,10 +7,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// Expands on macro_location test case to also cover template scenarios.  Macro
-// uses are attributed to spelling location, but forward-declarations of primary
-// templates also work as author intent hints for template specializations used
-// inside the macro.
+// Expands on macro_location test case to also cover template scenarios. All
+// macro uses are attributed to expansion location.
 
 // IWYU_ARGS: -I .
 
@@ -40,7 +38,7 @@ tests/cxx/macro_location_tpl.cc should remove these lines:
 - #include "tests/cxx/macro_location_tpl-d1.h"  // lines XX-XX
 
 The full include-list for tests/cxx/macro_location_tpl.cc:
-#include "tests/cxx/macro_location_tpl-d2.h"  // for ExpansionTemplate, expansion_template
+#include "tests/cxx/macro_location_tpl-d2.h"  // for ExpansionTemplate, SpellingTemplate, expansion_template, spelling_template
 #include "tests/cxx/macro_location_tpl-i1.h"  // for CLASS_TEMPLATE_SPEC_EXPANSION, CLASS_TEMPLATE_SPEC_SPELLING, FUNC_TEMPLATE_SPEC_EXPANSION, FUNC_TEMPLATE_SPEC_SPELLING
 
 ***** IWYU_SUMMARY */

--- a/tests/cxx/member_expr.cc
+++ b/tests/cxx/member_expr.cc
@@ -53,7 +53,8 @@ void ViaMacro(const IndirectClass& ic) {
       // IWYU: IndirectClass is...*indirect.h
       CALL_METHOD;
 
-  // But this member-expr is entirely in the macro, so we don't own it.
+  // This is entirely in a macro, but should still be attributed to us.
+  // IWYU: IndirectClass is...*indirect.h
   IC_CALL_METHOD;
 }
 
@@ -116,7 +117,8 @@ void ViaMacro(const IndirectTemplate<IndirectClass>& ic) {
       // IWYU: IndirectClass is...*indirect.h
       CALL_METHOD;
 
-  // But this member-expr is entirely in the macro, so we don't own it.
+  // This is entirely in a macro, but should still be attributed to us.
+  // IWYU: IndirectTemplate is...*indirect.h
   IC_CALL_METHOD;
 }
 

--- a/tests/cxx/placement_new.cc
+++ b/tests/cxx/placement_new.cc
@@ -43,14 +43,14 @@ void PlacementNewUserType() {
   delete icptr;
 }
 
-// Placement new in macro, use is attributed to the macro.
+// Placement new in macro, use is attributed to the macro expansion.
 static char global_buffer[256];
-// IWYU: operator new is...*<new>
 #define CONSTRUCT_GLOBAL(T) new (global_buffer) T;
 
 void PlacementNewInMacro() {
   // IWYU: IndirectClass needs a declaration
   // IWYU: IndirectClass is...*indirect.h
+  // IWYU: operator new is...*<new>
   IndirectClass* a = CONSTRUCT_GLOBAL(IndirectClass);
 }
 

--- a/tests/cxx/pointer_arith.cc
+++ b/tests/cxx/pointer_arith.cc
@@ -123,11 +123,11 @@ void MacroArgPointerArithmetic() {
 // IWYU: IndirectClass needs a declaration
 static IndirectClass* table;
 
-// IWYU: IndirectClass is...*indirect.h
+// Use is entirely contained in macro expansion.
 #define GET_NTH(n) (*(table + n))
 
 void MacroBodyPointerArithmetic() {
-  // Use is entirely contained in macro.
+  // IWYU: IndirectClass is...*indirect.h
   (void)GET_NTH(10);
 }
 


### PR DESCRIPTION
Currently, the headers that IWYU suggests to add to a header file defining a macro depend on whether that macro is used in the corresponding implementation file that causes the header file to be analyzed. So if a file a.h defines a macro that uses various declarations and the corresponding file a.c does not use that macro, then IWYU will suggest removing any headers that provide those decls from a.h. On the other hand, if a.c does use the macro, then IWYU will suggest keeping the headers.

This means that if a.c does not use the macro, then any other files that include a.h and use the macro will end up with missing header files as the required header files to use the macro will not be added to a.h and will not be added to the file using the macro either, causing compilation failures.

To fix this problem, let's always use the "use location" for decls within a macro as the canonical location, so that the required headers are always added to the file that's expanding the macro.

Fixes #1737