### PR TITLE
Make 'using std::find;' useful

### DIFF
--- a/iwyu_include_picker.cc
+++ b/iwyu_include_picker.cc
@@ -1374,9 +1374,8 @@ vector<string> ExtendMappingFileSearchPath(const vector<string>& search_path,
                                            const string& new_path) {
   CHECK_(IsAbsolutePath(new_path));
 
-  if (std::find(search_path.begin(),
-                search_path.end(),
-                new_path) == search_path.end()) {
+  if (find(search_path.begin(), search_path.end(), new_path) ==
+      search_path.end()) {
     vector<string> extended(search_path);
     extended.push_back(new_path);
     return extended;


### PR DESCRIPTION
For some reason, the unreferenced using-decl became recently to be attributed to a `std::find` declaration from `<pstl/glue_algorithm_defs.h>` accepting `ExecutionPolicy` as the first argument.

No functional change.