### PR TITLE
Make sure C arrays result in includes and not a forward declaration

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -2673,6 +2673,16 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
     return true;
   }
 
+  bool VisitArrayType(ArrayType* type) {
+    if (CanIgnoreCurrentASTNode())
+      return true;
+    if (!compiler()->getLangOpts().CPlusPlus) {
+      const Type* elem_type = type->getElementType().getTypePtr();
+      ReportTypeUse(CurrentLoc(), elem_type, DerefKind::None);
+    }
+    return true;
+  }
+
   //------------------------------------------------------------
   // Visitors of attributes.
 

--- a/tests/c/array.c
+++ b/tests/c/array.c
@@ -1,0 +1,35 @@
+//===--- array.c - test input file for iwyu -------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_ARGS: -I .
+
+#include "tests/c/direct.h"
+
+// IWYU: Indirect is defined in...*indirect.h
+// IWYU: Indirect needs a declaration
+void array(const struct Indirect array[]);
+
+// IWYU: Indirect is defined in...*indirect.h
+typedef struct Indirect (*ArrayPtr)[5];
+
+// IWYU: Indirect is defined in...*indirect.h
+extern const struct Indirect extern_array[];
+
+/**** IWYU_SUMMARY
+
+tests/c/array.c should add these lines:
+#include "tests/c/indirect.h"
+
+tests/c/array.c should remove these lines:
+- #include "tests/c/direct.h"  // lines XX-XX
+
+The full include-list for tests/c/array.c:
+#include "tests/c/indirect.h"  // for Indirect
+
+***** IWYU_SUMMARY */

--- a/tests/c/direct.h
+++ b/tests/c/direct.h
@@ -1,0 +1,14 @@
+//===--- direct.h - test input file for iwyu ------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// This file is meant to be directly #included by a .c file.  All it
+// does is #include another file (which the .c file is thus
+// #including indirectly).
+
+#include "tests/c/indirect.h"

--- a/tests/c/indirect.h
+++ b/tests/c/indirect.h
@@ -1,0 +1,17 @@
+//===--- indirect.h - test input file for iwyu ----------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// This file is meant to be #included by "direct.h", which is directly
+// #included by some .c file.  It provides an easy-to-access
+// definition of a symbol that will cause an iwyu violation in a .c
+// file.
+
+struct Indirect {
+    int a;
+};


### PR DESCRIPTION
If an array type is used in a function declaration, the full type has to be available, and not just a forward declaration.

Fixes #1747