### PR TITLE
Add all reproducible bugs to bugs suite

### DIFF
--- a/tests/bugs/1000/1000.cc
+++ b/tests/bugs/1000/1000.cc
@@ -1,0 +1,21 @@
+//===--- 1000.cc - iwyu test ----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_XFAIL
+#include <cmath>
+
+static void f() {
+  (void)std::abs(-12);
+}
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/1000/1000.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/1061/1061.cc
+++ b/tests/bugs/1061/1061.cc
@@ -1,0 +1,22 @@
+//===--- 1061.cc - iwyu test ----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_XFAIL
+#include <chrono>
+
+auto calc(std::chrono::seconds d)
+{
+    return d + std::chrono::seconds(1);
+}
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/1061/1061.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/1087/1087.cc
+++ b/tests/bugs/1087/1087.cc
@@ -1,0 +1,21 @@
+//===--- 1087.cc - iwyu test ----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_ARGS: -I tests/bugs/1087 -include b.h
+// IWYU_XFAIL
+
+#include "1087.h"
+void foo() {
+}
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/1087/1087.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/1087/1087.h
+++ b/tests/bugs/1087/1087.h
@@ -1,0 +1,11 @@
+//===--- 1087.h - iwyu test -----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+void foo();

--- a/tests/bugs/1087/b.h
+++ b/tests/bugs/1087/b.h
@@ -1,0 +1,10 @@
+//===--- b.h - iwyu test --------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include <1087.h>

--- a/tests/bugs/1122/1122.cc
+++ b/tests/bugs/1122/1122.cc
@@ -1,0 +1,25 @@
+//===--- 1122.cc - test input file for iwyu -------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// Adapted from:
+// https://github.com/graveljp/iwyu-bugs/tree/main/operator_overload_macro
+
+// IWYU_XFAIL
+
+#include "utils.h"
+
+int main() {
+  return TimesTen(3);
+}
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/1122/1122.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/1122/1122b.cc
+++ b/tests/bugs/1122/1122b.cc
@@ -1,0 +1,25 @@
+//===--- 1122b.cc - test input file for iwyu ------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// Adapted from:
+// https://github.com/graveljp/iwyu-bugs/tree/main/operator_overload
+
+// IWYU_XFAIL
+
+#include "foo.h"
+
+int main() {
+  return Foo<int>();
+}
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/1122b/1122b.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/1122/foo.h
+++ b/tests/bugs/1122/foo.h
@@ -1,0 +1,19 @@
+//===--- foo.h - iwyu test ------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "map.h"
+
+template <typename T>
+bool Foo() {
+  Map<T> map;
+  Iterator<T> it = map.find();
+  return it == it;
+}

--- a/tests/bugs/1122/map.h
+++ b/tests/bugs/1122/map.h
@@ -1,0 +1,20 @@
+//===--- map.h - iwyu test ------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "table.h"  // IWYU pragma: export
+
+template <typename T>
+struct Map {
+  Iterator<T> find() {
+    Table<T> impl;
+    return impl.find();
+  }
+};

--- a/tests/bugs/1122/my_int.h
+++ b/tests/bugs/1122/my_int.h
@@ -1,0 +1,25 @@
+//===--- my_int.h - iwyu test ---------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MY_INT_H
+#define MY_INT_H
+
+#include "operations.h"
+
+struct MyInt {
+  int value;
+};
+
+MyInt MakeMyInt(int value) {
+  return {value};
+}
+
+MULTIPLY_OP()
+
+#endif  // MY_INT_H

--- a/tests/bugs/1122/operations.h
+++ b/tests/bugs/1122/operations.h
@@ -1,0 +1,18 @@
+//===--- operations.h - iwyu test -----------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef OPERATIONS_H
+#define OPERATIONS_H
+
+#define MULTIPLY_OP() \
+int operator *(MyInt lhs, int rhs) { \
+  return lhs.value * rhs; \
+}
+
+#endif  // OPERATIONS_H

--- a/tests/bugs/1122/table.h
+++ b/tests/bugs/1122/table.h
@@ -1,0 +1,23 @@
+//===--- table.h - iwyu test ----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+template <typename T>
+struct Iterator {};
+
+template <typename T>
+bool operator==(const Iterator<T>& lhs, const Iterator<T>& rhs) {
+  return true;
+}
+
+template <typename T>
+struct Table {
+  Iterator<T> find() { return Iterator<T>(); }
+};

--- a/tests/bugs/1122/utils.h
+++ b/tests/bugs/1122/utils.h
@@ -1,0 +1,20 @@
+//===--- utils.h - iwyu test ----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef UTILS_H
+#define UTILS_H
+
+#include "my_int.h"
+
+template <typename T>
+constexpr int TimesTen(T n) {
+  return MakeMyInt(n) * 10;
+}
+
+#endif  // UTILS_H

--- a/tests/bugs/1127/1127.cc
+++ b/tests/bugs/1127/1127.cc
@@ -1,0 +1,25 @@
+//===--- 1127.cc - iwyu test ----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_XFAIL
+
+#include "c.h"
+
+int main() {
+  auto i = getIntArray();
+  auto i2 = i;
+  auto s = i.size();
+  return 0;
+}
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/1127/1127.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/1127/1127b.cc
+++ b/tests/bugs/1127/1127b.cc
@@ -1,0 +1,27 @@
+//===--- 1127b.cc - iwyu test ---------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_XFAIL
+
+#include <iostream>
+#include "lib.h"
+
+int main() {
+  const auto my_set = make_set();
+  for (auto& e : my_set) {
+    std::cout << e << '\n';
+  }
+  return 0;
+}
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/1127b/1127b.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/1127/c.h
+++ b/tests/bugs/1127/c.h
@@ -1,0 +1,14 @@
+//===--- c.h - iwyu test --------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <array>
+
+std::array<int, 3> getIntArray();

--- a/tests/bugs/1127/lib.h
+++ b/tests/bugs/1127/lib.h
@@ -1,0 +1,15 @@
+//===--- lib.h - iwyu test ------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include <set>
+#include <string>
+
+std::set<std::string> make_set() {
+  return std::set<std::string>{"one", "two", "three"};
+}

--- a/tests/bugs/1145/1145.cc
+++ b/tests/bugs/1145/1145.cc
@@ -1,0 +1,34 @@
+//===--- 1145.cc - iwyu test ----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_XFAIL
+
+#include "subclass.h"
+
+template <typename T>
+struct TObjectPtr2 {
+ public:
+  template <typename U>
+  TObjectPtr2(U&& Object) : ObjectPtr(Object) {
+  }
+  T* ObjectPtr;
+};
+
+struct TestClass {
+ public:
+  TObjectPtr2<BaseClass> Foo;
+  TestClass(SubClass* InFoo) : Foo(InFoo) {
+  }
+};
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/1145/1145.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/1145/baseclass.h
+++ b/tests/bugs/1145/baseclass.h
@@ -1,0 +1,10 @@
+//===--- baseclass.h - iwyu test ------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+class BaseClass {};

--- a/tests/bugs/1145/subclass.h
+++ b/tests/bugs/1145/subclass.h
@@ -1,0 +1,11 @@
+//===--- subclass.h - iwyu test -------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "baseclass.h"
+class SubClass : public BaseClass {};

--- a/tests/bugs/1147/1147.cc
+++ b/tests/bugs/1147/1147.cc
@@ -1,0 +1,30 @@
+//===--- 1147.cc - iwyu test ----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_XFAIL
+
+#include "BaseClass.h"
+
+template <typename TheType, bool Size = sizeof(TheType)>
+struct TGetCastType2
+{
+	static inline constexpr bool SizeValue = Size;
+};
+
+void myfunc()
+{
+	auto v = TGetCastType2<BaseClass>::SizeValue;
+	(void)v;
+}
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/1147/1147.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/1147/baseclass.h
+++ b/tests/bugs/1147/baseclass.h
@@ -1,0 +1,10 @@
+//===--- baseclass.h - iwyu test ------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+class BaseClass {};

--- a/tests/bugs/1181/1181.cc
+++ b/tests/bugs/1181/1181.cc
@@ -1,0 +1,20 @@
+//===--- 1181.cc - iwyu test ----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_XFAIL
+
+#include "1181.h"
+enum class color { RED = 2 };
+enum_data<color> d;
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/1181/1181.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/1181/1181.h
+++ b/tests/bugs/1181/1181.h
@@ -1,0 +1,21 @@
+//===--- 1181.h - iwyu test -----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+template <typename> struct enum_data {
+  static const int staticVar;
+  virtual void var() const;
+};
+template <typename E> const int enum_data<E>::staticVar = 0;
+template <typename E> void enum_data<E>::var() const { (void)staticVar; }
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/1181/1181.h has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/1220/1220.cc
+++ b/tests/bugs/1220/1220.cc
@@ -1,0 +1,22 @@
+//===--- 1220.cc - iwyu test ----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_ARGS: -Xiwyu -v3
+// IWYU_XFAIL
+
+#include <array> // IWYU pragma: keep
+// IWYU pragma: no_include <cstddef>
+
+std::size_t x = 123;
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/1220/1220.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/1250/1250.cc
+++ b/tests/bugs/1250/1250.cc
@@ -1,0 +1,25 @@
+//===--- 1250.cc - iwyu test ----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_ARGS: -stdlib=libc++
+// IWYU_XFAIL
+
+#include "1250.h"
+
+int main() {
+  int x[10]{};
+  // No diagnostic expected here.
+  return get_begin(x);
+}
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/1250/1250.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/1250/1250.h
+++ b/tests/bugs/1250/1250.h
@@ -1,0 +1,31 @@
+//===--- 1250.h - iwyu test -----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "bar.h"
+
+template <typename T>
+T get_begin(T const (&x)[10]) {
+  // IWYU: begin is...*<iterator>
+  return *std::begin(x);
+}
+
+/**** IWYU_SUMMARY
+
+tests/bugs/1250/1250.h should add these lines:
+#include <iterator>
+
+tests/bugs/1250/1250.h should remove these lines:
+- #include "bar.h"  // lines XX-XX
+
+The full include-list for tests/bugs/1250/1250.h:
+#include <iterator>  // for begin
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/1250/bar.h
+++ b/tests/bugs/1250/bar.h
@@ -1,0 +1,11 @@
+//===--- bar.h - iwyu test ------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+#include <iterator>

--- a/tests/bugs/1256/1256.cc
+++ b/tests/bugs/1256/1256.cc
@@ -1,0 +1,27 @@
+//===--- 1256.cc - iwyu test ----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_XFAIL
+
+#include "1256.h"
+#include "results.h"
+
+static auto f() {
+  return results{};
+}
+
+static auto g() {
+  funcs fs = {.get_results = &f};
+}
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/1256/1256.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/1256/1256.h
+++ b/tests/bugs/1256/1256.h
@@ -1,0 +1,21 @@
+//===--- 1256.h - iwyu test -----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+struct results;
+
+struct funcs {
+  // No diagnostic expected
+  results (*get_results)();
+};
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/1256/1256.h has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/1256/results.h
+++ b/tests/bugs/1256/results.h
@@ -1,0 +1,10 @@
+//===--- results.h - iwyu test --------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+struct results {};

--- a/tests/bugs/1311/1311.cc
+++ b/tests/bugs/1311/1311.cc
@@ -1,0 +1,26 @@
+//===--- 1311.cc - iwyu test ----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_XFAIL
+
+#include "s.h"
+
+// #include <unordered_set>
+
+void f(const S& s) {
+  // No diagnostic expected.
+  for (int i : s.i) {
+  }
+}
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/1311/1311.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/1311/s.h
+++ b/tests/bugs/1311/s.h
@@ -1,0 +1,14 @@
+//===--- s.h - iwyu test --------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include <unordered_set>
+
+struct S {
+  std::unordered_set<int> i;
+};

--- a/tests/bugs/1349/1349.cc
+++ b/tests/bugs/1349/1349.cc
@@ -1,0 +1,27 @@
+//===--- 1349.cc - iwyu test ----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_XFAIL
+#include <iostream>
+
+#include "vector.h"
+
+int main() {
+  Vector<int> v{1, 2, 3};
+
+  for (int x : v) {
+    std::cout << x << std::endl;
+  }
+}
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/1349/1349.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/1349/vector.h
+++ b/tests/bugs/1349/vector.h
@@ -1,0 +1,20 @@
+//===--- vector.h - iwyu test ---------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include <vector>
+
+template <typename T>
+class Vector : private std::vector<T> {
+ public:
+  using Base = std::vector<T>;
+
+  using Base::Base;
+  using Base::begin;
+  using Base::end;
+};

--- a/tests/bugs/1370/1370.c
+++ b/tests/bugs/1370/1370.c
@@ -1,0 +1,39 @@
+//===--- 1370.c - iwyu test -----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_XFAIL
+#include "b.h"
+
+struct SymbolC {
+  struct SymbolA* a;
+  struct SymbolB* b;
+};
+
+int main(void) {
+  // IWYU: SymbolA is...*a.h
+  struct SymbolA a = {.eh = 0};
+  struct SymbolB b = {.a = a};
+  const struct SymbolC c = {.a = &a, .b = &b};
+  (void)c;
+
+  return 0;
+}
+
+/**** IWYU_SUMMARY
+
+tests/bugs/1370/1370.c should add these lines:
+#include "a.h"
+
+tests/bugs/1370/1370.c should remove these lines:
+
+The full include-list for tests/bugs/1370/1370.c:
+#include "a.h"  // for SymbolA
+#include "b.h"  // for SymbolB
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/1370/a.h
+++ b/tests/bugs/1370/a.h
@@ -1,0 +1,21 @@
+//===--- a.h - iwyu test --------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef A_H
+#define A_H
+
+#ifndef oopsie
+#define oopsie
+#endif
+
+struct SymbolA {
+  void* eh;
+};
+
+#endif  // A_H

--- a/tests/bugs/1370/b.h
+++ b/tests/bugs/1370/b.h
@@ -1,0 +1,23 @@
+//===--- b.h - iwyu test --------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef B_H
+#define B_H
+
+#ifndef oopsie
+#define oopsie
+#endif
+
+#include "a.h"
+
+struct SymbolB {
+  struct SymbolA a;
+};
+
+#endif  // B_H

--- a/tests/bugs/1414/1414.cc
+++ b/tests/bugs/1414/1414.cc
@@ -1,0 +1,31 @@
+//===--- 1414.cc - iwyu test ----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_ARGS: -std=c++20
+// IWYU_XFAIL
+
+#include <concepts>
+#include "derived.h"
+
+class Base;
+
+template <typename T, typename U>
+  requires std::derived_from<T, U>
+class C {};
+
+int main() {
+  C<Derived, Base>();
+  return 0;
+}
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/1414/1414.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/1414/base.h
+++ b/tests/bugs/1414/base.h
@@ -1,0 +1,15 @@
+//===--- base.h - iwyu test -----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef BASE_H
+#define BASE_H
+
+class Base {};
+
+#endif

--- a/tests/bugs/1414/derived.h
+++ b/tests/bugs/1414/derived.h
@@ -1,0 +1,17 @@
+//===--- derived.h - iwyu test --------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef DERIVED_H
+#define DERIVED_H
+
+#include "base.h"
+
+class Derived : public Base {};
+
+#endif

--- a/tests/bugs/1428/1428.cc
+++ b/tests/bugs/1428/1428.cc
@@ -1,0 +1,30 @@
+//===--- 1428.cc - iwyu test ----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_ARGS: -Xiwyu --mapping_file=tests/bugs/1428/m.imp
+// IWYU_XFAIL
+
+#include <time.h>
+
+void f() {
+  (void)time(nullptr);
+}
+
+/**** IWYU_SUMMARY
+
+tests/bugs/1370/1370.c should add these lines:
+#include <ctime>
+
+tests/bugs/1370/1370.c should remove these lines:
+#include <time.h>  // lines XX-XX
+
+The full include-list for tests/bugs/1370/1370.c:
+#include <ctime>  // for time
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/1428/m.imp
+++ b/tests/bugs/1428/m.imp
@@ -1,0 +1,3 @@
+[
+  { "include": ["<time.h>", "private", "<ctime>", "public"] }
+]

--- a/tests/bugs/1481/1481.cc
+++ b/tests/bugs/1481/1481.cc
@@ -1,0 +1,27 @@
+//===--- 1481.cc - iwyu test ----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_XFAIL
+#include <cstdlib>
+
+// Jury's still out on whether sys/wait.h should be required here.
+// <cstdlib> is documented to provide WIFEXITED.
+#include <sys/wait.h>
+
+void f(int res) {
+  if (WIFEXITED(res)) {
+    abort();
+  }
+}
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/1481/1481.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/1539/1539.cc
+++ b/tests/bugs/1539/1539.cc
@@ -1,0 +1,24 @@
+//===--- 1539.cc - iwyu test ----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_ARGS: -stdlib=libstdc++
+// IWYU_XFAIL
+#include "my_vector.h"
+
+int main() {
+  MyVector<int> v;
+  bool at_end = v.begin() == v.end();
+  return 0;
+}
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/1539/1539.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/1539/my_vector.h
+++ b/tests/bugs/1539/my_vector.h
@@ -1,0 +1,24 @@
+//===--- my_vector.h - iwyu test ------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <vector>
+
+template<typename T>
+class MyVector {
+ public:
+  using iterator = typename std::vector<T>::iterator;
+
+  iterator begin() { return data_.begin(); }
+  iterator end() { return data_.end(); }
+
+ private:
+  std::vector<T> data_;
+};

--- a/tests/bugs/1541/1541.cc
+++ b/tests/bugs/1541/1541.cc
@@ -1,0 +1,25 @@
+//===--- 1541.cc - iwyu test ----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_XFAIL
+
+#include <list>
+
+struct S;
+
+class C {
+  // IWYU requires the complete type for S, while compilers do not.
+  std::list<S> l_s;
+};
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/1541/1541.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/1546/1546.cc
+++ b/tests/bugs/1546/1546.cc
@@ -1,0 +1,22 @@
+//===--- 1546.cc - iwyu test ----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_XFAIL
+#include "macro.h"
+
+int main() {
+  MY_MACRO();
+  return 0;
+}
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/1546/1546.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/1546/macro.h
+++ b/tests/bugs/1546/macro.h
@@ -1,0 +1,19 @@
+//===--- macro.h - iwyu test ----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+#include <string>
+
+void UseString(const char* message);
+std::string GetString();
+
+// clang-format off
+#define MY_MACRO() UseString(GetString() \
+    .c_str())
+// clang-format on

--- a/tests/bugs/1569/1569.cc
+++ b/tests/bugs/1569/1569.cc
@@ -1,0 +1,19 @@
+//===--- 1569.cc - iwyu test ----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_XFAIL
+
+// The export pragma should protect this #include.
+#include "f1.h"    // IWYU pragma: export
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/1569/1569.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/1569/f1.h
+++ b/tests/bugs/1569/f1.h
@@ -1,0 +1,15 @@
+//===--- f1.h - iwyu test -------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef F1_H
+#define F1_H
+
+// empty
+
+#endif // F1_H

--- a/tests/bugs/1570/1570.cc
+++ b/tests/bugs/1570/1570.cc
@@ -1,0 +1,23 @@
+//===--- 1570.cc - iwyu test ----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_XFAIL
+
+// IWYU does not understand forwarding headers.
+
+#include "foo-fwd.h"         // Foo (forward)
+
+// Forward suffices.
+Foo *p;
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/1570/1570.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/1570/1570b.cc
+++ b/tests/bugs/1570/1570b.cc
@@ -1,0 +1,27 @@
+//===--- 1570b.cc - iwyu test ---------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_XFAIL
+#include "bar-fwd.h"  // Bar (forward)
+
+// Note IWYU suggests to forward-declare Bar as
+//
+//    template <typename T = int> class Bar;
+//
+// which leads to errors down the line as default arguments must only be present
+// on one decl.
+
+// Forward should suffice.
+Bar<>* p;
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/1570/1570b.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/1570/bar-fwd.h
+++ b/tests/bugs/1570/bar-fwd.h
@@ -1,0 +1,16 @@
+//===--- bar-fwd.h - iwyu test --------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef BAR_FWD_H
+#define BAR_FWD_H
+
+template <typename T = int>
+class Bar;
+
+#endif  // BAR_FWD_H

--- a/tests/bugs/1570/foo-fwd.h
+++ b/tests/bugs/1570/foo-fwd.h
@@ -1,0 +1,15 @@
+//===--- foo-fwd.h - iwyu test --------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef FWD_FOO_H
+#define FWD_FOO_H
+
+class Foo;
+
+#endif // FWD_FOO_H

--- a/tests/bugs/1573/1573.cc
+++ b/tests/bugs/1573/1573.cc
@@ -1,0 +1,24 @@
+//===--- 1573.cc - iwyu test ----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_XFAIL
+
+namespace foo {
+struct Bar;
+}
+
+struct foo::Bar {
+  void frombulate();
+};
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/1573/1573.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/1616/1616.cc
+++ b/tests/bugs/1616/1616.cc
@@ -1,0 +1,23 @@
+//===--- 1616.cc - iwyu test ----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_ARGS: -std=c++20
+// IWYU_XFAIL
+
+#include <utility>
+#include <span>
+
+template <typename T>
+std::pair<T, T> foo(std::span<int>);
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/1616/1616.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/1617/1617.cc
+++ b/tests/bugs/1617/1617.cc
@@ -1,0 +1,24 @@
+//===--- 1617.cc - iwyu test ----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_ARGS: -stdlib=libc++
+// IWYU_XFAIL
+#include "item.h"
+#include <tuple>
+
+void process(std::tuple<Item*> foo) {
+    auto [item] = foo;
+    item->process();
+}
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/1617/1617.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/1617/item.h
+++ b/tests/bugs/1617/item.h
@@ -1,0 +1,13 @@
+//===--- item.h - iwyu test -----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+class Item {
+public:
+    void process();
+};

--- a/tests/bugs/1626/1626.cc
+++ b/tests/bugs/1626/1626.cc
@@ -1,0 +1,43 @@
+//===--- 1626.cc - iwyu test ----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_ARGS: -std=c++17
+// IWYU_XFAIL
+
+#include "unary_expression.h"
+#include "expression.h"
+
+// IWYU will suggest forward-declaring UnaryExpression, which causes this file
+// to no longer compile.
+
+template <typename T>
+struct ExpressionVisitor {
+  virtual ~ExpressionVisitor() = default;
+  virtual bool visitExpression(typename T::Expression& e);
+};
+
+template <typename T>
+bool ExpressionVisitor<T>::visitExpression(typename T::Expression& e) {
+  if (e.template is<UnaryExpression>()) {
+    auto& b = e.template as<UnaryExpression>();
+    return bool(b.expr());
+  }
+  return false;
+}
+
+struct ExpressionVisitorTypes {
+  using Expression = const Expression;
+};
+template struct ExpressionVisitor<ExpressionVisitorTypes>;
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/1626/1626.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/1626/expression.h
+++ b/tests/bugs/1626/expression.h
@@ -1,0 +1,34 @@
+//===--- expression.h - iwyu test -----------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef EXPRESSION
+#define EXPRESSION
+
+enum class ExpressionKind : int {
+    kUnary = 0,
+    kLiteral,
+};
+
+class Expression {
+public:
+    Expression(ExpressionKind kind) : fKind(kind) {}
+
+    template <typename T> bool is() const {
+        return fKind == T::kIRNodeKind;
+    }
+
+    template <typename T> const T& as() const {
+        return static_cast<const T&>(*this);
+    }
+
+private:
+    ExpressionKind fKind;
+};
+
+#endif

--- a/tests/bugs/1626/unary_expression.h
+++ b/tests/bugs/1626/unary_expression.h
@@ -1,0 +1,24 @@
+//===--- unary_expression.h - iwyu test -----------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef UNARY_EXPRESSION
+#define UNARY_EXPRESSION
+
+#include "expression.h"
+
+class UnaryExpression final : public Expression {
+public:
+    inline static constexpr ExpressionKind kIRNodeKind = ExpressionKind::kUnary;
+    UnaryExpression(Expression* expr) : Expression(kIRNodeKind), fExpr(expr) { }
+    Expression* expr() const { return fExpr; }
+private:
+    Expression* fExpr;
+};
+
+#endif

--- a/tests/bugs/1629/1629.cc
+++ b/tests/bugs/1629/1629.cc
@@ -1,0 +1,23 @@
+//===--- 1629.cc - iwyu test ----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_ARGS: -std=c++14
+// IWYU_XFAIL
+
+#include "foo.h"
+
+int main() {
+  Vector<int> v;
+}
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/1629/1629.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/1629/foo.h
+++ b/tests/bugs/1629/foo.h
@@ -1,0 +1,16 @@
+//===--- foo.h - iwyu test ------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include <vector>
+
+template <typename T, typename Alloc = typename std::vector<T>::allocator_type>
+class Vector final : private std::vector<T, Alloc> {
+ public:
+  Vector() = default;
+};

--- a/tests/bugs/1645/1645.cc
+++ b/tests/bugs/1645/1645.cc
@@ -1,0 +1,22 @@
+//===--- 1645.cc - iwyu test ----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_XFAIL
+#include "bar.h"
+
+int main() {
+  bar();
+  foo_t foo{};
+}
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/1645/1645.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/1645/bar.h
+++ b/tests/bugs/1645/bar.h
@@ -1,0 +1,15 @@
+//===--- bar.h - iwyu test ------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+#include "foo.h"
+
+int bar() {
+  return foo();
+}

--- a/tests/bugs/1645/foo.h
+++ b/tests/bugs/1645/foo.h
@@ -1,0 +1,15 @@
+//===--- foo.h - iwyu test ------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "foo_private.h"  // IWYU pragma: export
+
+int foo();
+int foo(foo_t);

--- a/tests/bugs/1645/foo_private.h
+++ b/tests/bugs/1645/foo_private.h
@@ -1,0 +1,12 @@
+//===--- foo_private.h - iwyu test ----------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+struct foo_t{};

--- a/tests/bugs/1649/1649.cc
+++ b/tests/bugs/1649/1649.cc
@@ -1,0 +1,25 @@
+//===--- 1649.cc - test input file for iwyu -------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_XFAIL
+
+#include <map>
+
+void f() {
+  std::map<const char*, int> m;
+
+  const std::map<const char*, int>::const_iterator entry = m.find(nullptr);
+  (void)entry->second;
+}
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/1649/1649.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/1651/1651.cc
+++ b/tests/bugs/1651/1651.cc
@@ -1,0 +1,32 @@
+//===--- 1651.cc - iwyu test ----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_ARGS: -stdlib=libstdc++
+// IWYU_XFAIL
+#include "1651.h"
+
+#include <iostream>
+#include <string>
+
+void f(const S& s) {
+  std::cout << s.str;
+}
+
+/**** IWYU_SUMMARY
+
+tests/bugs/1651/1651.cc should add these lines:
+
+tests/bugs/1651/1651.cc should remove these lines:
+- #include <string>  // lines XX-XX
+
+The full include-list for tests/bugs/1651/1651.cc:
+#include "1651.h"
+#include <iostream>  // for basic_ostream, operator<<, cout
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/1651/1651.h
+++ b/tests/bugs/1651/1651.h
@@ -1,0 +1,20 @@
+//===--- 1651.h - iwyu test -----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include <string>
+
+struct S {
+  std::string str;
+};
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/1651/1651.h has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/1665/1665.cc
+++ b/tests/bugs/1665/1665.cc
@@ -1,0 +1,22 @@
+//===--- 1665.cc - iwyu test ----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_XFAIL
+#include "inner.h"
+#include "outer.h"
+
+bool foo(Outer *outer) {
+    return outer->inner->w == 123;
+}
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/1665/1665.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/1665/inner.h
+++ b/tests/bugs/1665/inner.h
@@ -1,0 +1,13 @@
+//===--- inner.h - iwyu test ----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+typedef struct Inner
+{
+    int w = 0;
+} Inner;

--- a/tests/bugs/1665/outer.h
+++ b/tests/bugs/1665/outer.h
@@ -1,0 +1,14 @@
+//===--- outer.h - iwyu test ----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+struct Inner;
+
+struct Outer {
+    Inner *inner = nullptr;
+};

--- a/tests/bugs/1685/1685.cc
+++ b/tests/bugs/1685/1685.cc
@@ -1,0 +1,21 @@
+//===--- 1685.cc - iwyu test ----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_XFAIL
+#include "buffer.h"
+
+struct Foo {
+  Buffer<float> x;
+};
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/1685/1685.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/1685/buffer.h
+++ b/tests/bugs/1685/buffer.h
@@ -1,0 +1,22 @@
+//===--- buffer.h - iwyu test ---------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "memory.h"
+
+template <typename T>
+class Buffer {
+  T* data_;
+
+ public:
+  ~Buffer() noexcept {
+    destroy_memory(data_);
+  }
+};

--- a/tests/bugs/1685/memory.h
+++ b/tests/bugs/1685/memory.h
@@ -1,0 +1,12 @@
+//===--- memory.h - iwyu test ---------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "memory_impl.h"

--- a/tests/bugs/1685/memory_impl.h
+++ b/tests/bugs/1685/memory_impl.h
@@ -1,0 +1,14 @@
+//===--- memory_impl.h - iwyu test ----------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+template <typename T>
+inline void destroy_memory(T*) {
+}

--- a/tests/bugs/169/169.cc
+++ b/tests/bugs/169/169.cc
@@ -1,0 +1,22 @@
+//===--- 169.cc - test input file for iwyu --------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_ARGS: -stdlib=libc++
+// IWYU_XFAIL
+
+#include <type_traits>
+#include "type.h"
+
+std::remove_pointer<Type*>::type x;
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/169/169.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/169/type.h
+++ b/tests/bugs/169/type.h
@@ -1,0 +1,10 @@
+//===--- type.h - test input file for iwyu --------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+struct Type {};

--- a/tests/bugs/1707/1707.cc
+++ b/tests/bugs/1707/1707.cc
@@ -1,0 +1,17 @@
+//===--- 1707.cc - iwyu test ----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_XFAIL
+#include "1707.h"
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/1707/1707.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/1707/1707.h
+++ b/tests/bugs/1707/1707.h
@@ -1,0 +1,54 @@
+//===--- 1707.h - iwyu test -----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <type_traits>
+#include <variant>
+#include <vector>
+
+struct Foo;
+
+// template magic from https://stackoverflow.com/a/45896101
+template <class T, class U>
+struct is_one_of;
+template <class T, class... Ts>
+struct is_one_of<T, std::variant<Ts...>>
+    : std::bool_constant<(std::is_same_v<T, Ts> || ...)> {};
+template <class T, class V>
+using is_variant_type = is_one_of<T, V>;
+
+struct Foo {
+  struct Foo_Inner;
+  using impl_t = std::variant<Foo_Inner>;
+
+  Foo() = default;
+
+  template <class U, std::enable_if_t<is_variant_type<U, impl_t>{}, int> = 0>
+  explicit Foo(U u) {
+  }
+
+  struct Foo_Inner {};
+
+  impl_t data;
+};
+
+class Bar {
+  void stuff(Foo value) {
+    my_vec.push_back(value);
+  }
+
+  std::vector<Foo> my_vec;
+};
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/1707/1707.h has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/1720/1720.cc
+++ b/tests/bugs/1720/1720.cc
@@ -1,0 +1,25 @@
+//===--- 1720.cc - iwyu test ----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_ARGS: -I tests/bugs/1720 \
+//            -include public.h \
+//            -Xiwyu --mapping_file=tests/bugs/1720/m.imp \
+//            -Xiwyu --prefix_header_includes=remove
+// IWYU_XFAIL
+
+#include "another.h"
+
+s32 val;
+ComplexType other;
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/1720/1720.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/1720/another.h
+++ b/tests/bugs/1720/another.h
@@ -1,0 +1,14 @@
+//===--- another.h - iwyu test --------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "private.h"
+
+class ComplexType {
+    s32 a;
+};

--- a/tests/bugs/1720/m.imp
+++ b/tests/bugs/1720/m.imp
@@ -1,0 +1,3 @@
+[
+    { "include": ["\"private.h\"", "private", "\"public.h\"", "public"] },
+]

--- a/tests/bugs/1720/private.h
+++ b/tests/bugs/1720/private.h
@@ -1,0 +1,10 @@
+//===--- private.h - iwyu test --------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+typedef int s32;

--- a/tests/bugs/1720/public.h
+++ b/tests/bugs/1720/public.h
@@ -1,0 +1,10 @@
+//===--- public.h - iwyu test ---------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+typedef int s32;

--- a/tests/bugs/1743/1743.cc
+++ b/tests/bugs/1743/1743.cc
@@ -1,0 +1,20 @@
+//===--- 1743.cc - iwyu test ----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_XFAIL
+
+enum Foo {
+#include "enumerators.def"
+};
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/1743/1743.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/1743/enumerators.def
+++ b/tests/bugs/1743/enumerators.def
@@ -1,0 +1,3 @@
+FOO,
+BAR,
+BAZ,

--- a/tests/bugs/228/228.cc
+++ b/tests/bugs/228/228.cc
@@ -1,0 +1,23 @@
+//===--- 228.cc - test input file for iwyu --------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_ARGS: -I tests/bugs/228
+// IWYU_XFAIL
+
+#include <228.hpp>
+
+void B::doSomethingMore() {
+  A::doSomething();
+}
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/228/228.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/228/228.hpp
+++ b/tests/bugs/228/228.hpp
@@ -1,0 +1,21 @@
+//===--- 228.hpp - test input file for iwyu -------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include <a.hpp>
+
+class B : public A {
+  public:
+    void doSomethingMore();
+};
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/228/228.hpp has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/228/a.hpp
+++ b/tests/bugs/228/a.hpp
@@ -1,0 +1,13 @@
+//===--- a.hpp - test input file for iwyu ---------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+class A {
+  public:
+    void doSomething();
+};

--- a/tests/bugs/283/283.cc
+++ b/tests/bugs/283/283.cc
@@ -1,0 +1,21 @@
+//===--- 283.cc - test input file for iwyu --------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_XFAIL
+
+#include "macro.h"
+#include "function.h"
+
+MACRO_A(mydomain)
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/283/283.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/283/function.h
+++ b/tests/bugs/283/function.h
@@ -1,0 +1,14 @@
+//===--- function.h - iwyu test -------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// function.h
+namespace ns {
+    class Class {};
+    Class& getmyclassmydomain();
+}

--- a/tests/bugs/283/macro.h
+++ b/tests/bugs/283/macro.h
@@ -1,0 +1,14 @@
+//===--- macro.h - iwyu test ----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// macro.h
+#define MACRO_A(domain) \
+  void myfunc() { \
+    static ns::Class s_var(ns::getmyclass##domain()); \
+  }

--- a/tests/bugs/297/297.cc
+++ b/tests/bugs/297/297.cc
@@ -1,0 +1,29 @@
+//===--- 297.cc - test input file for iwyu --------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_XFAIL
+
+#include "t.h"
+#include "o.h"
+
+class Class : public Template<Object> {
+  // If the function is called - it is tracked correctly
+  // void bar() {
+  //     Template<Object>::foo();
+  // }
+
+  // But when the function is made visible with using - it is not
+  using Template<Object>::foo;
+};
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/297/297.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/297/o.h
+++ b/tests/bugs/297/o.h
@@ -1,0 +1,10 @@
+//===--- o.h - iwyu test --------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+class Object {};

--- a/tests/bugs/297/t.h
+++ b/tests/bugs/297/t.h
@@ -1,0 +1,21 @@
+//===--- t.h - iwyu test --------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include <memory>
+
+template <typename T>
+class Template {
+ public:
+  typedef T Type;
+  typedef std::shared_ptr<Type> TypeSPtr;
+
+  void foo() {
+    TypeSPtr obj = std::make_shared<Type>();
+  }
+};

--- a/tests/bugs/300/300.cc
+++ b/tests/bugs/300/300.cc
@@ -1,0 +1,26 @@
+//===--- 300.cc - iwyu test -----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_ARGS: -stdlib=libc++
+// IWYU_XFAIL
+
+#include <string>
+#include <unordered_set>
+
+static const std::unordered_set<std::string> us;
+
+bool f() {
+  return (us.find("") != us.end());
+}
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/300/300.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/411/411.cc
+++ b/tests/bugs/411/411.cc
@@ -1,0 +1,30 @@
+//===--- 411.cc - iwyu test -----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_XFAIL
+
+// Swapping the order of these two includes makes the testcase pass, so IWYU
+// behavior is a factor of include order here (because of dependencies between
+// the headers.)
+#include "include2.h"
+#include "include1.h"
+
+int main(int argc, char* argv[]) {
+  importantthing s1;
+  something2 s3;
+  s1.x = OPTION1;
+  s1.y = OPTION2;
+  return 0;
+}
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/411/411.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/411/include1.h
+++ b/tests/bugs/411/include1.h
@@ -1,0 +1,26 @@
+//===--- include1.h - iwyu test -------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __INCLUDE1_H__
+
+#ifndef __disabled_things
+#define __INCLUDE1_H__ 1
+
+struct importantthing {
+  int x, y, z;
+};
+#define OPTION1 2
+#define OPTION2 4
+
+#endif
+
+extern int superimportantvariable;  // always visible
+
+#undef __disabled_things
+#endif  //__INCLUDE1_H__

--- a/tests/bugs/411/include2.h
+++ b/tests/bugs/411/include2.h
@@ -1,0 +1,20 @@
+//===--- include2.h - iwyu test -------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __INCLUDE2_H__
+#define __INCLUDE2_H__
+
+#define __disabled_things
+#include "include1.h"
+#undef __disabled_things
+
+struct something2 {
+  char text[32];
+};
+#endif  //__INCLUDE2_H__

--- a/tests/bugs/422/422.cc
+++ b/tests/bugs/422/422.cc
@@ -1,0 +1,26 @@
+//===--- 422.cc - iwyu test -----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_XFAIL
+
+#include "bar.h"
+template <typename T>
+void do_something() {
+  Foo<T> f;
+}
+
+void baz() {
+  do_something<int>();
+}
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/422/422.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/422/bar.h
+++ b/tests/bugs/422/bar.h
@@ -1,0 +1,14 @@
+//===--- bar.h - iwyu test ------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "foo.h"
+template <>
+class Foo<int> {
+  // Special implementation for ints.
+};

--- a/tests/bugs/422/foo.h
+++ b/tests/bugs/422/foo.h
@@ -1,0 +1,11 @@
+//===--- foo.h - iwyu test ------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+template <typename T>
+class Foo {};

--- a/tests/bugs/432/432.cc
+++ b/tests/bugs/432/432.cc
@@ -1,0 +1,24 @@
+//===--- 432.cc - iwyu test -----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_XFAIL
+
+#include <stri\
+ng>
+
+/**** IWYU_SUMMARY
+
+tests/bugs/432/432.cc should add these lines:
+
+tests/bugs/432/432.cc should remove these lines:
+- #include <string>  // lines XX-XX
+
+The full include-list for tests/bugs/432/432.cc:
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/460/460.cc
+++ b/tests/bugs/460/460.cc
@@ -1,0 +1,33 @@
+//===--- 460.cc - iwyu test -----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_XFAIL
+
+#include "foo.h"
+
+int main() {
+  bar::MyVec c;
+  bar::MyVec::iterator cit = c.begin();
+  while (cit != c.end()) {
+    cit++;
+  }
+
+  bar2::MyList d;
+  bar2::MyList::iterator dit = d.begin();
+  while (dit != d.end()) {
+    dit++;
+  }
+  return 0;
+}
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/460/460.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/460/foo.h
+++ b/tests/bugs/460/foo.h
@@ -1,0 +1,20 @@
+//===--- foo.h - iwyu test ------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include <vector>
+#include <list>
+
+class bar {
+ public:
+  using MyVec = std::vector<int>;
+};
+
+namespace bar2 {
+using MyList = std::list<int>;
+}

--- a/tests/bugs/536/536.cc
+++ b/tests/bugs/536/536.cc
@@ -1,0 +1,23 @@
+//===--- 536.cc - iwyu test -----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_XFAIL
+
+#include "intent-decl.h"
+#include "intent-type.h"
+
+void func() {
+  decl();  // Full-use of Type in return
+}
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/536/536.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/536/intent-decl.h
+++ b/tests/bugs/536/intent-decl.h
@@ -1,0 +1,12 @@
+//===--- intent-decl.h - iwyu test ----------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "intent-fwd.h"
+
+Type decl();

--- a/tests/bugs/536/intent-fwd.h
+++ b/tests/bugs/536/intent-fwd.h
@@ -1,0 +1,10 @@
+//===--- intent-fwd.h - iwyu test -----------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+struct Type;

--- a/tests/bugs/536/intent-type.h
+++ b/tests/bugs/536/intent-type.h
@@ -1,0 +1,10 @@
+//===--- intent-type.h - iwyu test ----------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+struct Type {};

--- a/tests/bugs/598/598.cc
+++ b/tests/bugs/598/598.cc
@@ -1,0 +1,24 @@
+//===--- 598.cc - iwyu test -----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_XFAIL
+
+#include "container.h"
+
+int foo(Container& c) {
+    c.push_back(5);
+    auto it = c.begin();
+    return *it;
+}
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/598/598.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/598/container.h
+++ b/tests/bugs/598/container.h
@@ -1,0 +1,11 @@
+//===--- container.h - iwyu test ------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include <vector>
+using Container = std::vector<int>;

--- a/tests/bugs/633/633.cc
+++ b/tests/bugs/633/633.cc
@@ -1,0 +1,22 @@
+//===--- 633.cc - iwyu test -----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// Shows that IWYU crashes with --check_also="*"; there's something about
+// matching all possible files that's tripping up our include-name handling.
+
+// IWYU_ARGS: -Xiwyu --check_also="*"
+// IWYU_XFAIL
+
+void nothing();
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/633/633.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/659/659.cc
+++ b/tests/bugs/659/659.cc
@@ -1,0 +1,23 @@
+//===--- 659.cc - iwyu test -----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_XFAIL
+
+#include "macro_template.h"
+#include "type.h"
+
+void hello() {
+  MACRO().func<Test>();    // If you write MacroClass().func<Test>();, it is OK
+}
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/659/659.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/659/macro_template.h
+++ b/tests/bugs/659/macro_template.h
@@ -1,0 +1,15 @@
+//===--- macro_template.h - iwyu test -------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#define MACRO() MacroClass()
+
+class MacroClass {
+public:
+  template <typename T> T func() { return T(); }
+};

--- a/tests/bugs/659/type.h
+++ b/tests/bugs/659/type.h
@@ -1,0 +1,10 @@
+//===--- type.h - iwyu test -----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+class Test {};

--- a/tests/bugs/700/700.cc
+++ b/tests/bugs/700/700.cc
@@ -1,0 +1,35 @@
+//===--- 700.cc - iwyu test -----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_XFAIL
+
+#include "header.h"
+
+namespace BarNs {
+  // IWYU: BarNs::FooClass needs a declaration
+  void f(FooClass *);
+}
+
+// There are a few possible resolutions for this example:
+//
+// Two forward declarations:
+//   namespace FooNs { class FooClass; }
+//   namespace BarNs { using namespace FooNs; }
+//
+// or maybe a "fake" forward-declaration in BarNs:
+//   namespace BarNs { class FooClass; }
+//
+// or keep header.h unchanged, because the dependency introduced by 'using
+// namespace FooNs' is not worth replicating as a forward-decl.
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/700/700.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/700/header.h
+++ b/tests/bugs/700/header.h
@@ -1,0 +1,19 @@
+//===--- header.h - iwyu test ---------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+namespace FooNs {
+  class FooClass {};
+};
+
+namespace BarNs {
+  using namespace FooNs;
+
+  class BarClass {
+  };
+}

--- a/tests/bugs/752/752.cc
+++ b/tests/bugs/752/752.cc
@@ -1,0 +1,23 @@
+//===--- 752.cc - iwyu test -----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_XFAIL
+// IWYU_ARGS: -std=c++2a
+
+#include "compat.h"
+
+int main() {
+  compat::optional<int> o;
+}
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/752/752.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/752/compat.h
+++ b/tests/bugs/752/compat.h
@@ -1,0 +1,15 @@
+//===--- compat.h - iwyu test ---------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <optional>
+namespace compat {
+using std::optional;
+}

--- a/tests/bugs/801/801.cc
+++ b/tests/bugs/801/801.cc
@@ -1,0 +1,29 @@
+//===--- 801.cc - iwyu test -----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_XFAIL
+
+struct Foo {
+  static constexpr int num = 10;
+};
+
+#include "num_getter.h"
+
+#include "int_wrapper_foo.h"
+
+int dummy() {
+  NumGetter<Foo> x;
+  return x.GetNum();
+}
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/801/801.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/801/int_wrapper_foo.h
+++ b/tests/bugs/801/int_wrapper_foo.h
@@ -1,0 +1,13 @@
+//===--- int_wrapper_foo.h - iwyu test ------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+template <>
+struct IntegerWrapper<Foo> {
+  static constexpr int num = Foo::num;
+};

--- a/tests/bugs/801/num_getter.h
+++ b/tests/bugs/801/num_getter.h
@@ -1,0 +1,18 @@
+//===--- num_getter.h - iwyu test -----------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+template <typename T>
+struct IntegerWrapper {};
+
+template <typename T>
+struct NumGetter {
+  int GetNum() {
+    return IntegerWrapper<T>::num;
+  }
+};

--- a/tests/bugs/837/837.cc
+++ b/tests/bugs/837/837.cc
@@ -1,0 +1,26 @@
+//===--- 837.cc - iwyu test -----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_XFAIL
+
+#include "fooa.h"
+#include "foob.h"
+
+int main() {
+  auto pFooB{getPointerFooB()};
+
+  // std::unique_ptr<fooB> pFooB{ getPointerFooB()};
+  return 0;
+}
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/837/837.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/837/fooa.h
+++ b/tests/bugs/837/fooa.h
@@ -1,0 +1,15 @@
+//===--- fooa.h - iwyu test -----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include <memory>
+class fooB;
+
+std::unique_ptr<fooB> getPointerFooB() {
+  return std::make_unique<fooB>();
+}

--- a/tests/bugs/837/foob.h
+++ b/tests/bugs/837/foob.h
@@ -1,0 +1,17 @@
+//===--- foob.h - iwyu test -----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef FOOB_H
+#define FOOB_H
+
+class fooB {
+ public:
+  int fooBVar;
+};
+#endif

--- a/tests/bugs/901/901.cc
+++ b/tests/bugs/901/901.cc
@@ -1,0 +1,22 @@
+//===--- 901.cc - iwyu test -----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_XFAIL
+#include "b.h"
+
+int f() {
+  MyData data{};
+  return data.meters.value;
+}
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/901/901.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/901/a.h
+++ b/tests/bugs/901/a.h
@@ -1,0 +1,12 @@
+//===--- a.h - iwyu test --------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+struct Meters {
+  int value;
+};

--- a/tests/bugs/901/b.h
+++ b/tests/bugs/901/b.h
@@ -1,0 +1,14 @@
+//===--- b.h - iwyu test --------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "a.h"
+
+struct MyData {
+  Meters meters;
+};

--- a/tests/bugs/917/917.cc
+++ b/tests/bugs/917/917.cc
@@ -1,0 +1,25 @@
+//===--- 917.cc - iwyu test -----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_ARGS: -std=c++20
+// IWYU_XFAIL
+
+#include <concepts>
+
+#include "mytype.h"
+
+static_assert(!std::constructible_from<MyType, int>);
+
+int main() {}
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/917/917.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/917/mytype.h
+++ b/tests/bugs/917/mytype.h
@@ -1,0 +1,10 @@
+//===--- mytype.h - iwyu test ---------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+struct MyType {};

--- a/tests/bugs/958/958.cc
+++ b/tests/bugs/958/958.cc
@@ -1,0 +1,28 @@
+//===--- 958.cc - iwyu test -----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_XFAIL
+
+#include "958.h"
+#include "file1.h"
+
+template <typename T>
+int templFunc(T val) {
+  return val.x;
+}
+
+// Explicit function template instantiation:
+// https://en.cppreference.com/w/cpp/language/function_template#Explicit_instantiation
+template int templFunc<X>(X val);
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/958/958.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/958/958.h
+++ b/tests/bugs/958/958.h
@@ -1,0 +1,17 @@
+//===--- 958.h - iwyu test ------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+template <typename T>
+int templFunc(T);
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/958/958.h has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/958/file1.h
+++ b/tests/bugs/958/file1.h
@@ -1,0 +1,12 @@
+//===--- file1.h - iwyu test ----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+struct X {
+  int x = 42;
+};

--- a/tests/bugs/965/965.cc
+++ b/tests/bugs/965/965.cc
@@ -1,0 +1,18 @@
+//===--- 965.cc - iwyu test -----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_XFAIL
+
+#include "965.h"
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/965/965.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/965/965.h
+++ b/tests/bugs/965/965.h
@@ -1,0 +1,25 @@
+//===--- 965.h - iwyu test ------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "a.h"
+
+template <typename T>
+int size() {
+  return sizeof(T);
+}
+template <int X>
+int foo() {
+  return X + size<Foo>();
+}
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/965/965.h has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/965/a.h
+++ b/tests/bugs/965/a.h
@@ -1,0 +1,10 @@
+//===--- a.h - iwyu test --------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+struct Foo {};

--- a/tests/bugs/969/969.cc
+++ b/tests/bugs/969/969.cc
@@ -1,0 +1,24 @@
+//===--- 969.cc - iwyu test -----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_XFAIL
+
+#define define_my_var           \
+struct my_struct {              \
+        int my_member;          \
+};                              \
+struct my_struct my_var;
+
+define_my_var
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/969/969.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/973/973.cc
+++ b/tests/bugs/973/973.cc
@@ -1,0 +1,32 @@
+//===--- 973.cc - iwyu test -----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_XFAIL
+
+#include "a.h"
+
+struct Bar {
+  Foo* f;
+};
+
+template <typename T>
+int baz(const T& t) {
+  return t.f->foo;
+}
+
+int bazz() {
+  Bar b;
+  return baz(b);
+}
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/973/973.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/973/a.h
+++ b/tests/bugs/973/a.h
@@ -1,0 +1,12 @@
+//===--- a.h - iwyu test --------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+struct Foo {
+  int foo;
+};

--- a/tests/bugs/987/987.cc
+++ b/tests/bugs/987/987.cc
@@ -1,0 +1,28 @@
+//===--- 987.cc - iwyu test -----------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_XFAIL
+#include "987.h"
+
+// This is already included in 987.h, and so could be removed here.
+#include <cstdint>
+
+void foo(std::uint8_t arg) {
+}
+
+/**** IWYU_SUMMARY
+
+tests/bugs/987/987.cc should add these lines:
+
+tests/bugs/987/987.cc should remove these lines:
+- #include <cstdint>  // lines XX-XX
+
+The full include-list for tests/bugs/987/987.cc:
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/987/987.h
+++ b/tests/bugs/987/987.h
@@ -1,0 +1,18 @@
+//===--- 987.h - iwyu test ------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cstdint>
+
+void foo(std::uint8_t arg);
+
+/**** IWYU_SUMMARY
+
+(tests/bugs/987/987.h has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
Now that the bugs suite exists to do negative regression testing
(i.e. notice when bugs are fixed), add repro cases for all bugs where
I've been able to produce a fully contained repro, or one that only
depends on libc, libstdc++ or libc++.

So far these are probably only reproducible in a Linux environment with
GCC and Clang available.

Once this is merged, our CI environment will fail the build if a PR
fixes a bug -- not that there's anything wrong with that, but we need to
make sure it comes with fully reduced regression tests. Once that's
taken care of, we can remove the bugs test and close the bug.

Roughly 60 bugs are getting test coverage with this patch.