### PR TITLE
[clang compat] Use new CompilerInstance constructor

### DIFF
--- a/iwyu_driver.cc
+++ b/iwyu_driver.cc
@@ -389,8 +389,8 @@ bool ExecuteAction(int argc,
   // FIXME: This is copied from cc1_main.cpp; simplify and eliminate.
 
   // Create a compiler instance to handle the actual work.
-  unique_ptr<CompilerInstance> compiler(new CompilerInstance);
-  compiler->setInvocation(invocation);
+  unique_ptr<CompilerInstance> compiler(
+      new CompilerInstance(std::move(invocation)));
   // It's tempting to reuse the DiagnosticsEngine we created above, but we need
   // to create a new one to get the options produced by the compiler invocation.
   compiler->createDiagnostics(*fs);


### PR DESCRIPTION
Clang removed setInvocation in favor of a constructor parameter in:
https://github.com/llvm/llvm-project/commit/b69dcb873476cd8e7d3f6f9ffd5b6d0bbe1a3a17

Adjust our only use in IWYU driver code.