### PR TITLE
Handle array references in type traits

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -2116,10 +2116,10 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
                           DerefKind::None);
             return true;
           }
-          // Otherwise, report the rhs record type (ReportTypeUse doesn't report
-          // other kinds of types) because they may have a conversion operator
-          // to the lhs type.
-          ReportTypeUse(CurrentLoc(), rhs_type, DerefKind::RemoveRefs);
+          // Otherwise, report the rhs record type because they may have
+          // a conversion operator to the lhs type.
+          if (rhs_deref_type->isRecordType())
+            ReportTypeUse(CurrentLoc(), rhs_type, DerefKind::RemoveRefs);
         }
         return true;
       case TypeTrait::BTT_IsTriviallyAssignable: {
@@ -2247,7 +2247,7 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
           // reported even if it is under the pointer, because an rhs type ctor
           // might take a pointer to its base class (if not a union).
           ReportTypeUse(CurrentLoc(), lhs_type, DerefKind::RemoveRefsAndPtr);
-        } else {
+        } else if (lhs_deref_type->isRecordType()) {
           // In other cases, report the lhs type because it may contain a
           // conversion operator to the rhs type.
           ReportTypeUse(CurrentLoc(), lhs_type, DerefKind::RemoveRefs);

--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -56,6 +56,7 @@
 // IWYU pragma: no_include "clang/AST/StmtIterator.h"
 // IWYU pragma: no_include "clang/Basic/CustomizableOptional.h"
 
+using clang::ASTContext;
 using clang::ASTDumper;
 using clang::ArrayType;
 using clang::BlockPointerType;
@@ -1711,17 +1712,28 @@ bool RefCanBindToTemp(const Type* type) {
 
 bool IsDerivedToBasePtrConvertible(QualType derived_ptr_type,
                                    QualType base_ptr_type) {
-  if (!derived_ptr_type->isPointerType() || !base_ptr_type->isPointerType())
+  if (!base_ptr_type->isPointerType())
     return false;
-
-  const QualType derived = derived_ptr_type->getPointeeType();
   const QualType base = base_ptr_type->getPointeeType();
+  const CXXRecordDecl* base_decl = base->getAsCXXRecordDecl();
+  if (!base_decl)
+    return false;
+  const ASTContext& context = base_decl->getASTContext();
+
+  QualType derived;
+  if (derived_ptr_type->isPointerType()) {
+    derived = derived_ptr_type->getPointeeType();
+  } else if (const ArrayType* array =
+                 context.getAsArrayType(derived_ptr_type)) {
+    derived = array->getElementType();
+  } else {
+    return false;
+  }
+
   if (const CXXRecordDecl* derived_decl = derived->getAsCXXRecordDecl()) {
-    if (const CXXRecordDecl* base_decl = base->getAsCXXRecordDecl()) {
-      if (!derived_decl->isDerivedFrom(base_decl))
-        return false;
-      return base.isAtLeastAsQualifiedAs(derived, base_decl->getASTContext());
-    }
+    if (!derived_decl->isDerivedFrom(base_decl))
+      return false;
+    return base.isAtLeastAsQualifiedAs(derived, context);
   }
   return false;
 }

--- a/tests/cxx/type_trait-d2.h
+++ b/tests/cxx/type_trait-d2.h
@@ -16,6 +16,7 @@ using ClassNonProviding = Class;
 using DerivedPtrNonProviding = Derived*;
 using DerivedPtrRefNonProviding = Derived*&;
 using DerivedRefNonProviding = Derived&;
+using DerivedArrayNonProviding = Derived[];
 using ClassRefNonProviding = Class&;
 using ClassConstRefNonProviding = const Class&;
 using Union1RefNonProviding = Union1&;

--- a/tests/cxx/type_trait.cc
+++ b/tests/cxx/type_trait.cc
@@ -265,6 +265,52 @@ static_assert(__is_nothrow_convertible(Derived[], Base*));
 // IWYU: Derived needs a declaration
 // IWYU: Derived is...*-i2.h
 // IWYU: Base needs a declaration
+static_assert(__is_convertible(Derived (&)[], Base*));
+// IWYU: Derived needs a declaration
+// IWYU: Derived is...*-i2.h
+// IWYU: Base needs a declaration
+static_assert(__is_nothrow_convertible(Derived (&)[], Base*));
+// IWYU: Derived needs a declaration
+// IWYU: Derived is...*-i2.h
+// IWYU: Base needs a declaration
+static_assert(__is_convertible(Derived (&)[5], Base*));
+// IWYU: Derived needs a declaration
+// IWYU: Derived is...*-i2.h
+// IWYU: Base needs a declaration
+static_assert(__is_nothrow_convertible(Derived (&)[5], Base*));
+// IWYU: Derived needs a declaration
+// IWYU: Base needs a declaration
+static_assert(!__is_convertible(volatile Derived (&)[5], Base*));
+// IWYU: Derived needs a declaration
+// IWYU: Base needs a declaration
+static_assert(!__is_nothrow_convertible(volatile Derived (&)[5], Base*));
+// IWYU: Derived needs a declaration
+// IWYU: Derived is...*-i2.h
+// IWYU: Base needs a declaration
+static_assert(__is_convertible(volatile Derived (&)[5], volatile Base*));
+// IWYU: Derived needs a declaration
+// IWYU: Derived is...*-i2.h
+static_assert(__is_nothrow_convertible(volatile Derived (&)[5],
+                                       // IWYU: Base needs a declaration
+                                       volatile Base*));
+// IWYU: Base needs a declaration
+// IWYU: Derived is...*-i2.h
+static_assert(__is_convertible(DerivedArrayNonProviding&, Base*));
+// IWYU: Base needs a declaration
+// IWYU: Derived is...*-i2.h
+static_assert(__is_nothrow_convertible(DerivedArrayNonProviding&, Base*));
+// IWYU: Base needs a declaration
+static_assert(!__is_convertible(volatile DerivedArrayNonProviding&, Base*));
+static_assert(!__is_nothrow_convertible(volatile DerivedArrayNonProviding&,
+                                        // IWYU: Base needs a declaration
+                                        Base*));
+// IWYU: Derived needs a declaration
+static_assert(!__is_convertible(Derived (&)[5], int));
+// IWYU: Derived needs a declaration
+static_assert(!__is_nothrow_convertible(Derived (&)[5], int));
+// IWYU: Derived needs a declaration
+// IWYU: Derived is...*-i2.h
+// IWYU: Base needs a declaration
 static_assert(__is_convertible(Derived*, Base* const&));
 // IWYU: Derived needs a declaration
 // IWYU: Derived is...*-i2.h
@@ -513,6 +559,71 @@ static_assert(__is_assignable(Base*&, DerivedPtrRefProviding));
 static_assert(__is_trivially_assignable(Base*&, DerivedPtrRefProviding));
 // IWYU: Base needs a declaration
 static_assert(__is_nothrow_assignable(Base*&, DerivedPtrRefProviding));
+// IWYU: Base needs a declaration
+// IWYU: Derived needs a declaration
+// IWYU: Derived is...*tests/cxx/type_trait-i2.h
+static_assert(__is_assignable(Base*&, Derived (&)[5]));
+// IWYU: Base needs a declaration
+// IWYU: Derived needs a declaration
+// IWYU: Derived is...*tests/cxx/type_trait-i2.h
+static_assert(__is_trivially_assignable(Base*&, Derived (&)[5]));
+// IWYU: Base needs a declaration
+// IWYU: Derived needs a declaration
+// IWYU: Derived is...*tests/cxx/type_trait-i2.h
+static_assert(__is_nothrow_assignable(Base*&, Derived (&)[5]));
+// IWYU: Derived needs a declaration
+static_assert(!__is_assignable(int&, Derived (&)[5]));
+// IWYU: Derived needs a declaration
+static_assert(!__is_trivially_assignable(int&, Derived (&)[5]));
+// IWYU: Derived needs a declaration
+static_assert(!__is_nothrow_assignable(int&, Derived (&)[5]));
+// IWYU: Base needs a declaration
+// IWYU: Derived needs a declaration
+// IWYU: Derived is...*tests/cxx/type_trait-i2.h
+static_assert(__is_assignable(Base*&, Derived (&)[]));
+// IWYU: Base needs a declaration
+// IWYU: Derived needs a declaration
+// IWYU: Derived is...*tests/cxx/type_trait-i2.h
+static_assert(__is_trivially_assignable(Base*&, Derived (&)[]));
+// IWYU: Base needs a declaration
+// IWYU: Derived needs a declaration
+// IWYU: Derived is...*tests/cxx/type_trait-i2.h
+static_assert(__is_nothrow_assignable(Base*&, Derived (&)[]));
+// IWYU: Derived needs a declaration
+static_assert(!__is_assignable(int&, Derived (&)[]));
+// IWYU: Derived needs a declaration
+static_assert(!__is_trivially_assignable(int&, Derived (&)[]));
+// IWYU: Derived needs a declaration
+static_assert(!__is_nothrow_assignable(int&, Derived (&)[]));
+// IWYU: Base needs a declaration
+// IWYU: Derived needs a declaration
+static_assert(!__is_assignable(Base*&, const Derived (&)[]));
+// IWYU: Base needs a declaration
+// IWYU: Derived needs a declaration
+static_assert(!__is_trivially_assignable(Base*&, const Derived (&)[]));
+// IWYU: Base needs a declaration
+// IWYU: Derived needs a declaration
+static_assert(!__is_nothrow_assignable(Base*&, const Derived (&)[]));
+// IWYU: Base needs a declaration
+static_assert(!__is_assignable(Base*&, const DerivedArrayNonProviding&));
+// IWYU: Base needs a declaration
+static_assert(!__is_trivially_assignable(Base*&,
+                                         const DerivedArrayNonProviding&));
+// IWYU: Base needs a declaration
+static_assert(!__is_nothrow_assignable(Base*&,
+                                       const DerivedArrayNonProviding&));
+// IWYU: Base needs a declaration
+// IWYU: Derived is...*tests/cxx/type_trait-i2.h
+static_assert(__is_assignable(const volatile Base*&,
+                              const DerivedArrayNonProviding&));
+// IWYU: Base needs a declaration
+// IWYU: Derived is...*tests/cxx/type_trait-i2.h
+static_assert(__is_trivially_assignable(const volatile Base*&,
+                                        const DerivedArrayNonProviding&));
+// IWYU: Base needs a declaration
+// IWYU: Derived is...*tests/cxx/type_trait-i2.h
+static_assert(__is_nothrow_assignable(const volatile Base*&,
+                                      const DerivedArrayNonProviding&));
 // IWYU: Base needs a declaration
 // IWYU: Derived needs a declaration
 static_assert(!__is_assignable(Base**&, Derived**));
@@ -1179,7 +1290,7 @@ tests/cxx/type_trait.cc should remove these lines:
 
 The full include-list for tests/cxx/type_trait.cc:
 #include "tests/cxx/type_trait-d1.h"  // for ClassConstRefProviding, ClassRefProviding, DerivedPtrProviding, DerivedPtrRefProviding, DerivedRefProviding, Union1RefProviding
-#include "tests/cxx/type_trait-d2.h"  // for BaseMemPtr, ClassConstRefNonProviding, ClassNonProviding, ClassRefNonProviding, DerivedMemPtr, DerivedPtrNonProviding, DerivedPtrRefNonProviding, DerivedRefNonProviding, Union1PtrRefNonProviding, Union1RefNonProviding, UnionMemPtr
+#include "tests/cxx/type_trait-d2.h"  // for BaseMemPtr, ClassConstRefNonProviding, ClassNonProviding, ClassRefNonProviding, DerivedArrayNonProviding, DerivedMemPtr, DerivedPtrNonProviding, DerivedPtrRefNonProviding, DerivedRefNonProviding, Union1PtrRefNonProviding, Union1RefNonProviding, UnionMemPtr
 #include "tests/cxx/type_trait-i1.h"  // for Base, Class, Struct, StructDerivedClass, Union1, Union2
 #include "tests/cxx/type_trait-i2.h"  // for Derived
 


### PR DESCRIPTION
Due to array to pointer implicit conversion, arrays may be used where pointers to their elements are acceptable. Direct or typedefed array types in type traits should currently be reported unconditionally, because `CanForwardDeclareType` returns false for them. This change adds handling of arrays under reference types.

`ASTContext::getAsArrayType` desugars the given type to the array type and merges the cv-qualifier with the one of the array element type.

One comment has been corrected because `ReportTypeUse` performs reporting not only for record types but also for elements of arrays of them.