### PR TITLE
Refactor some functions to work with QualType

### DIFF
--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -1544,9 +1544,9 @@ const NamedDecl* TypeToDeclForContent(const Type* type) {
   return TypeToDeclImpl(type, /*as_written=*/false);
 }
 
-const Type* RemoveReference(const Type* type) {
+QualType RemoveReference(QualType type) {
   if (const auto* ref_type = type->getAs<ReferenceType>())
-    return ref_type->getPointeeType().getTypePtr();
+    return ref_type->getPointeeType();
   return type;
 }
 
@@ -1709,8 +1709,8 @@ bool RefCanBindToTemp(const Type* type) {
          !referred_type.isVolatileQualified();
 }
 
-bool IsDerivedToBasePtrConvertible(const Type* derived_ptr_type,
-                                   const Type* base_ptr_type) {
+bool IsDerivedToBasePtrConvertible(QualType derived_ptr_type,
+                                   QualType base_ptr_type) {
   if (!derived_ptr_type->isPointerType() || !base_ptr_type->isPointerType())
     return false;
 

--- a/iwyu_ast_util.h
+++ b/iwyu_ast_util.h
@@ -782,7 +782,7 @@ bool InvolvesTypeForWhich(const clang::Type* type,
 bool IsPointerOrReferenceAsWritten(const clang::Type* type);
 
 // This function removes a reference even it is hidden by some type sugar.
-const clang::Type* RemoveReference(const clang::Type*);
+clang::QualType RemoveReference(clang::QualType);
 
 // This function doesn't "see through" type sugar.
 const clang::Type* RemoveReferenceAsWritten(const clang::Type* type);
@@ -887,8 +887,8 @@ bool RefCanBindToTemp(const clang::Type*);
 // Returns true when the arguments are pointer types referring to classes or
 // structs related by direct inheritance. Also checks that their qualifiers
 // allow the conversion.
-bool IsDerivedToBasePtrConvertible(const clang::Type* derived_ptr_type,
-                                   const clang::Type* base_ptr_type);
+bool IsDerivedToBasePtrConvertible(clang::QualType derived_ptr_type,
+                                   clang::QualType base_ptr_type);
 
 // Pointers to members of a class can be implicitly converted to pointers
 // to members of its derived class (looks like the opposite to the conventional


### PR DESCRIPTION
`IsDerivedToBasePtrConvertible` should be made working with arrays because they may be considered like pointers to their element types due to array-to-pointer implicit conversion. In order to determine the cv-qualifier of the resulting pointer correctly, the function should take `QualType`, because a cv-qualifier applied to an array type propagates to its element type.

`base_ptr_type` parameter could in principle be kept as `const Type*`, but I've decided to change its type too for symmetry.

`RemoveReference` function has been transformed to work with `QualType` so that `IsDerivedToBasePtrConvertible` can be supplied with its result.

No functional change.