### PR TITLE
[clang compat] Adjust Sema::IsFunctionConversion call

### DIFF
--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -1760,8 +1760,7 @@ bool IsBaseToDerivedMemPtrConvertible(const Type* maybe_base_mem_ptr_type,
   // The unqualified canonical member types should be the same except the known
   // acceptable differences in 'noexcept' specifier of member functions.
   if (base_mem_type->isFunctionProtoType()) {
-    QualType converted{};
-    if (sema.IsFunctionConversion(base_mem_type, derived_mem_type, converted))
+    if (sema.IsFunctionConversion(base_mem_type, derived_mem_type))
       return true;
   }
   if (base_mem_type.getTypePtr() != derived_mem_type.getTypePtr())


### PR DESCRIPTION
The function was refactored in
https://github.com/llvm/llvm-project/commit/a6385a87a2e5537f0790494ebe8bb4c3cc9506b9 to no longer take an output argument for the result type.

We didn't use the returned value, so no functional change.