### PR TITLE
[clang compat] Pass DiagnosticOptions by reference

### DIFF
--- a/iwyu_driver.cc
+++ b/iwyu_driver.cc
@@ -331,8 +331,9 @@ bool ExecuteAction(int argc,
   args.insert(extra_pos, extra_args.begin(), extra_args.end());
 
   IntrusiveRefCntPtr<FileSystem> fs = llvm::vfs::getRealFileSystem();
+  DiagnosticOptions diag_opts;
   IntrusiveRefCntPtr<DiagnosticsEngine> diagnostics =
-      CompilerInstance::createDiagnostics(*fs, new DiagnosticOptions);
+      CompilerInstance::createDiagnostics(*fs, diag_opts);
 
   // The Driver constructor sets the resource dir implicitly based on path,
   // which may then be overwritten by BuildCompilation based on any


### PR DESCRIPTION
CompilerInstance::createDiagnostics was modified to take DiagnosticOptions by reference instead of by pointer in:
https://github.com/llvm/llvm-project/commit/13e1a2cb2246dc5e9a4afcdacabed4d43154ec3f

Adjust our only use in IWYU driver code.