### PR TITLE
Fix member pointer class alias handling

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -2235,16 +2235,16 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
               }
             } else if (const auto* elem_mem_ptr_type =
                            elem_type->getAs<MemberPointerType>()) {
-              const Type* elem_class = GetCanonicalType(
-                  elem_mem_ptr_type->getQualifier()->getAsType());
+              const Type* elem_qualifier =
+                  elem_mem_ptr_type->getQualifier()->getAsType();
               if (const auto* arg_mem_ptr_type =
                       arg_deref_type->getAs<MemberPointerType>()) {
                 const Type* arg_class = GetCanonicalType(
                     arg_mem_ptr_type->getQualifier()->getAsType());
-                if (arg_class == elem_class)
+                if (arg_class == GetCanonicalType(elem_qualifier))
                   continue;
               }
-              ReportTypeUse(CurrentLoc(), elem_class, DerefKind::None);
+              ReportTypeUse(CurrentLoc(), elem_qualifier, DerefKind::None);
             }
             const Type* arg_type = arg_qual_type.getTypePtr();
             // Unions cannot be derived but can have conversion functions.

--- a/tests/cxx/type_trait-d1.h
+++ b/tests/cxx/type_trait-d1.h
@@ -12,6 +12,7 @@
 
 #include "tests/cxx/type_trait-i2.h"
 
+using DerivedProviding = Derived;
 using DerivedPtrProviding = Derived*;
 using DerivedPtrRefProviding = Derived*&;
 using DerivedRefProviding = Derived&;

--- a/tests/cxx/type_trait-d2.h
+++ b/tests/cxx/type_trait-d2.h
@@ -16,6 +16,7 @@ using ClassNonProviding = Class;
 using ClassArray2NonProviding = Class[2];
 using ClassArray3NonProviding = Class[3];
 using BaseNonProviding = Base;
+using DerivedNonProviding = Derived;
 using DerivedPtrNonProviding = Derived*;
 using DerivedPtrRefNonProviding = Derived*&;
 using DerivedRefNonProviding = Derived&;

--- a/tests/cxx/type_trait.cc
+++ b/tests/cxx/type_trait.cc
@@ -1511,6 +1511,18 @@ static_assert(!__is_constructible(int Derived::* [3], int Base::*&));
 // IWYU: Derived needs a declaration
 // IWYU: Derived is...*-i2.h
 static_assert(!__is_nothrow_constructible(int Derived::* [3], int Base::*&));
+// IWYU: Base needs a declaration
+static_assert(!__is_constructible(int DerivedProviding::* [3], int Base::*));
+static_assert(!__is_nothrow_constructible(int DerivedProviding::* [3],
+                                          // IWYU: Base needs a declaration
+                                          int Base::*));
+// IWYU: Base needs a declaration
+// IWYU: Derived is...*-i2.h
+static_assert(!__is_constructible(int DerivedNonProviding::* [3], int Base::*));
+// IWYU: Derived is...*-i2.h
+static_assert(!__is_nothrow_constructible(int DerivedNonProviding::* [3],
+                                          // IWYU: Base needs a declaration
+                                          int Base::*));
 static_assert(!__is_constructible(int Class::* [3], int Class::*));
 static_assert(!__is_nothrow_constructible(int Class::* [3], int Class::*));
 static_assert(!__is_constructible(int Class::* [3], int Class::*&));
@@ -1563,8 +1575,8 @@ tests/cxx/type_trait.cc should remove these lines:
 - union Union2;  // lines XX-XX
 
 The full include-list for tests/cxx/type_trait.cc:
-#include "tests/cxx/type_trait-d1.h"  // for ClassConstRefProviding, ClassRefProviding, DerivedPtrProviding, DerivedPtrRefProviding, DerivedRefProviding, Union1RefProviding
-#include "tests/cxx/type_trait-d2.h"  // for BaseMemPtr, BaseNonProviding, ClassArray2NonProviding, ClassArray3NonProviding, ClassConstRefNonProviding, ClassNonProviding, ClassRefNonProviding, DerivedArrayNonProviding, DerivedMemPtr, DerivedPtrNonProviding, DerivedPtrRefNonProviding, DerivedRefNonProviding, Union1PtrRefNonProviding, Union1RefNonProviding, UnionMemPtr
+#include "tests/cxx/type_trait-d1.h"  // for ClassConstRefProviding, ClassRefProviding, DerivedProviding, DerivedPtrProviding, DerivedPtrRefProviding, DerivedRefProviding, Union1RefProviding
+#include "tests/cxx/type_trait-d2.h"  // for BaseMemPtr, BaseNonProviding, ClassArray2NonProviding, ClassArray3NonProviding, ClassConstRefNonProviding, ClassNonProviding, ClassRefNonProviding, DerivedArrayNonProviding, DerivedMemPtr, DerivedNonProviding, DerivedPtrNonProviding, DerivedPtrRefNonProviding, DerivedRefNonProviding, Union1PtrRefNonProviding, Union1RefNonProviding, UnionMemPtr
 #include "tests/cxx/type_trait-i1.h"  // for Base, Class, Struct, StructDerivedClass, Union1, Union2
 #include "tests/cxx/type_trait-i2.h"  // for Derived
 


### PR DESCRIPTION
`GetCanonicalType` removes the sugar, hence information that the class type was provided by a typedef was lost.