### PR TITLE
[clang compat] Ignore type trait deprecation

### DIFF
--- a/tests/cxx/type_trait.cc
+++ b/tests/cxx/type_trait.cc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// IWYU_ARGS: -I .
+// IWYU_ARGS: -I . -Wno-deprecated-builtins
 
 #include "tests/cxx/type_trait-d1.h"
 #include "tests/cxx/type_trait-d2.h"


### PR DESCRIPTION
https://github.com/llvm/llvm-project/commit/208e3b09564ea7ab2b10004742e553938a2dc60f deprecated `__reference_binds_to_temporary` builtin type trait, so the warnings appeared on running the test.