### PR TITLE
Rename built-in mappings to internal mappings

### DIFF
--- a/docs/IWYUMappings.md
+++ b/docs/IWYUMappings.md
@@ -184,8 +184,8 @@ environments and generate external mappings out of whatever header source tree
 they have available.
 
 But one of them, `mapgen/iwyu-mapgen-libstdcxx.py`, is used to generate the
-built-in mappings for GNU libstdc++ shipped with IWYU. The procedure for
-refreshing built-in mappings is:
+internal mappings for GNU libstdc++ shipped with IWYU. The procedure for
+refreshing internal mappings is:
 
 ```
 $ mapgen/iwyu-mapgen-libstdcxx.py --lang=imp \
@@ -202,7 +202,7 @@ $ mapgen/iwyu-mapgen-libstdcxx.py --lang=c++ \
 The external mappings can be generated straight into the `gcc.stl.headers.imp`
 file.
 
-The built-in C++ mappings, however, are generated into a temporary file
+The internal C++ mappings, however, are generated into a temporary file
 `libstdcxx_11.cc`, and can then be pasted into `iwyu_include_picker.cc` to
 replace the `libstdcpp_include_map` table.
 
@@ -220,5 +220,5 @@ private per-target headers, but mapped to plain public headers).
 The generated mappings obviously work best on systems where both libstdc++
 version and target match, but they should port pretty well.
 
-There is no strong policy for updating the built-in mappings, we try to use a
+There is no strong policy for updating the internal mappings, we try to use a
 mainstream target and a middle-aged libstdc++ version.

--- a/include-what-you-use.1
+++ b/include-what-you-use.1
@@ -86,7 +86,7 @@ for current experimental features are:
 .TP
 .B clang_mappings
 Use Clang libTooling standard library symbol mappings instead of
-built-in mappings. This potentially replaces the built-in mappings in
+internal mappings. This potentially replaces the internal mappings in
 the future, but is currently experimental while the issues are being
 evaluated.
 .RE

--- a/iwyu_globals.cc
+++ b/iwyu_globals.cc
@@ -130,7 +130,7 @@ static void PrintHelp(const char* extra_msg) {
          "          ecmascript: slower, but more feature-complete\n"
          "   --experimental=flag[,flag...]: enable experimental features\n"
          "          clang_mappings: use Clang canonical standard library\n"
-         "                          mappings instead of built-in mappings\n"
+         "                          mappings instead of internal mappings\n"
          "\n"
          "In addition to IWYU-specific options you can specify the following\n"
          "options without -Xiwyu prefix:\n"

--- a/iwyu_globals.h
+++ b/iwyu_globals.h
@@ -80,7 +80,7 @@ void InitGlobalsAndFlagsForTesting();
 //   5: like 4, and add tons of debug info.
 //   6: like 5, and print every symbol that's needed by main-cu files.
 //   7: like 6, and print pointers of AST nodes (and uninstantiated templates)
-//   8: like 7, and print all mappings, built-in and dynamic.
+//   8: like 7, and print all mappings, internal and dynamic.
 //  10: like 8, and add tons more debug info (for all non-system header files).
 //  11: like 10, and add tons *more* debug info (for all header files).
 struct CommandlineFlags {


### PR DESCRIPTION
The word "built-in" is important in compiler design; it usually refers to an intrinsic function whose implementation is generated dynamically by the compiler (e.g. __builtin_addcb or pow from math.h).

IWYU has historically distinguished between two different kinds of mappings, built-in and external, where the built-in mappings are hard-coded in include_picker.cc and the external mappings are declared in YAML and parsed on demand.

The use of the word "built-in" here is confusing, particularly since we carry mappings for various intrinsics headers and symbols.

Rename all mentions of "built-in" or "builtin" mappings to use "internal" instead.