### PR TITLE
Rename default mappings to internal mappings

### DIFF
--- a/docs/IWYUMappings.md
+++ b/docs/IWYUMappings.md
@@ -16,7 +16,7 @@ header pulls in `NULL` one way or another, and we probably shouldn't force
 people to `#include <cstddef>`.
 
 To simplify IWYU deployment and command-line interface, many of these mappings
-are compiled into the executable. These constitute the *default mappings*.
+are compiled into the executable. These constitute the *internal mappings*.
 
 However, many mappings are toolchain- and version-dependent. Symbol homes and
 `#include` dependencies change between releases of GCC and are dramatically
@@ -24,15 +24,15 @@ different for the standard libraries shipped with Microsoft Visual C++. Also,
 mappings such as these are usually necessary for third-party libraries
 (e.g. Boost, Qt) or even project-local symbols and headers as well.
 
-Any mappings outside of the default set can therefore be specified as external
-*mapping files*.
+Any mappings outside of the default internal set can therefore be specified as
+external *mapping files*.
 
 
-## Default mappings ##
+## Internal mappings ##
 
-IWYU's default mappings are hard-coded in `iwyu_include_picker.cc`, and are very
-GCC-centric. There are both symbol- and include mappings for GNU libstdc++ and
-libc.
+IWYU's internal mappings are hard-coded in `iwyu_include_picker.cc`, and are
+very GCC-centric. There are both symbol- and include mappings for GNU libstdc++
+and libc.
 
 
 ## Mapping files ##
@@ -168,10 +168,10 @@ current directory.
 `ref` directives are first looked up relative to the current directory and if
 not found, relative to the referring mapping file.
 
-The default mappings can be turned off (e.g. for baremetal projects like an OS
-kernel) using the `--no_default_mappings` switch:
+The internal mappings can be turned off (e.g. for baremetal projects like an OS
+kernel) using the `--no_internal_mappings` switch:
 
-    $ include-what-you-use -Xiwyu --no_default_mappings \
+    $ include-what-you-use -Xiwyu --no_internal_mappings \
         --mapping_file=kernel_libc.imp kernel/main.c
 
 

--- a/docs/IWYUStyle.md
+++ b/docs/IWYUStyle.md
@@ -275,7 +275,7 @@ comment:
 ```
 // IWYU_ARGS: -I . \
               -std=c++20 \
-              -Xiwyu --no_default_mappings
+              -Xiwyu --no_internal_mappings
 ```
 
 The args are added to the `include-what-you-use` command as-written after line

--- a/include-what-you-use.1
+++ b/include-what-you-use.1
@@ -108,8 +108,8 @@ length can still be exceeded with long filenames (default: 80).
 Do not add comments after includes about which symbols the header was required
 for.
 .TP
-.B \-\-no_default_mappings
-Do not use the default mappings.
+.B \-\-no_internal_mappings
+Do not use the internal mappings.
 .TP
 .B \-\-no_fwd_decls
 Do not use forward declarations, and instead always include the required header.

--- a/iwyu_globals.h
+++ b/iwyu_globals.h
@@ -95,7 +95,7 @@ struct CommandlineFlags {
   bool transitive_includes_only;   // -t: don't add 'new' #includes to files
   int verbose;             // -v: how much information to emit as we parse
   vector<string> mapping_files; // -m: mapping files
-  bool no_default_mappings;     // -n: no default mappings
+  bool no_internal_mappings;    // -n: no internal mappings
   // Truncate output lines to this length. No short option.
   int max_line_length;
   // Policy regarding files included via -include option.  No short option.

--- a/iwyu_include_picker.cc
+++ b/iwyu_include_picker.cc
@@ -1476,11 +1476,10 @@ IncludePicker::IncludePicker(RegexDialect regex_dialect,
                              CXXStdLib cxxstdlib)
     : has_called_finalize_added_include_lines_(false),
       regex_dialect(regex_dialect) {
-  AddDefaultMappings(cstdlib, cxxstdlib);
+  AddInternalMappings(cstdlib, cxxstdlib);
 }
 
-void IncludePicker::AddDefaultMappings(CStdLib cstdlib,
-                                       CXXStdLib cxxstdlib) {
+void IncludePicker::AddInternalMappings(CStdLib cstdlib, CXXStdLib cxxstdlib) {
   using clang::tooling::stdlib::Header;
   using clang::tooling::stdlib::Lang;
   using clang::tooling::stdlib::Symbol;

--- a/iwyu_include_picker.h
+++ b/iwyu_include_picker.h
@@ -200,8 +200,8 @@ class IncludePicker {
   void AddMappingsFromFile(const string& filename,
                            const vector<string>& search_path);
 
-  // Adds all hard-coded default mappings.
-  void AddDefaultMappings(CStdLib cstdlib, CXXStdLib cxxstdlib);
+  // Adds all hard-coded internal mappings.
+  void AddInternalMappings(CStdLib cstdlib, CXXStdLib cxxstdlib);
 
   // Adds a mapping from a one header to another, typically
   // from a private to a public quoted include.


### PR DESCRIPTION
I switched "builtin mappings" to "internal mappings" in 9ef4feb6ff07039711b3b878b57fd35add65ba9d, but I somehow overlooked the fact that we're also using "default mappings" to denote the same set.

Rephrase all uses of default mappings to talk about internal mappings.

Rename switch --no_default_mappings to --no_internal_mappings, but leave the old name as a deprecated alias.