### PR TITLE
Canonicalize test assertion format

### DIFF
--- a/tests/c/array.c
+++ b/tests/c/array.c
@@ -11,14 +11,14 @@
 
 #include "tests/c/direct.h"
 
-// IWYU: Indirect is defined in...*indirect.h
+// IWYU: Indirect is...*indirect.h
 // IWYU: Indirect needs a declaration
 void array(const struct Indirect array[]);
 
-// IWYU: Indirect is defined in...*indirect.h
+// IWYU: Indirect is...*indirect.h
 typedef struct Indirect (*ArrayPtr)[5];
 
-// IWYU: Indirect is defined in...*indirect.h
+// IWYU: Indirect is...*indirect.h
 extern const struct Indirect extern_array[];
 
 /**** IWYU_SUMMARY

--- a/tests/cxx/badinc.cc
+++ b/tests/cxx/badinc.cc
@@ -142,7 +142,7 @@ using i1_ns::I1_NamespaceTemplateFn;
 // IWYU: i1_ns::I1_UnusedNamespaceStruct needs a declaration
 using i1_ns::I1_UnusedNamespaceStruct;
 // TODO(csilvers): mark this using statement as redundant and remove it.
-// IWYU: i1_ns5 is defined in...*which isn't directly #included.
+// IWYU: i1_ns5 is...*badinc-i1.h
 using namespace i1_ns5;
 
 // We do some proper forward-declaring here, and also some unnecessary
@@ -815,11 +815,11 @@ int (*i1_globalfunctionptr2)(void) = &i1_GlobalFunction;
 I2_InlFileClass i2_inlfileclass;
 // IWYU: I2_InlFileTemplateClass is...*badinc-i2-inl.h
 I2_InlFileTemplateClass<int> i2_inlfiletemplateclass;
-// IWYU: I2_Class...*badinc-i2.h
-// IWYU: I2_Class::I2_Class...*badinc-i2-inl.h
+// IWYU: I2_Class is...*badinc-i2.h
+// IWYU: I2_Class::I2_Class is...*badinc-i2-inl.h
 // IWYU: I2_Class::~I2_Class is...*badinc-i2-inl.h
 I2_Class i2_class_with_inl_constructor("calling ctor in badinc-i2-inl.h");
-// IWYU: I2_TemplateClass...*badinc-i2.h
+// IWYU: I2_TemplateClass is...*badinc-i2.h
 // IWYU: I2_TemplateClass::I2_TemplateClass<.*> is...*badinc-i2-inl.h
 // IWYU: I2_TemplateClass::~I2_TemplateClass<.*> is...*badinc-i2-inl.h
 I2_TemplateClass<int> i2_template_class_with_inl_constructor(4, "inl ctor");
@@ -1051,7 +1051,7 @@ int main() {
   D1_Subclass local_d1_subclass;
   // IWYU: I2_Class needs a declaration
   I2_Class* local_i2_class_ptr = 0;  // ptr-only in this .cc, non-ptr in .h
-  // IWYU: I2_TemplateClass...*badinc-i2.h
+  // IWYU: I2_TemplateClass is...*badinc-i2.h
   // IWYU: I2_TemplateClass::~I2_TemplateClass<.*> is...*badinc-i2-inl.h
   I2_TemplateClass<int> local_i2_template_class(1);
   // IWYU: I1_PtrDereferenceStruct needs a declaration

--- a/tests/cxx/builtins_with_mapping.cc
+++ b/tests/cxx/builtins_with_mapping.cc
@@ -19,10 +19,10 @@
 // have two test cases:
 
 // First test case for a builtin which was already used in a header we included
-// IWYU: __builtin_expect is defined in...*which isn't directly #included.
+// IWYU: __builtin_expect is...*builtins_with_mapping-d2.h
 int j = __builtin_expect(i, 0);
 // Second test case for a first use of a builtin
-// IWYU: __builtin_strlen is defined in...*which isn't directly #included.
+// IWYU: __builtin_strlen is...*builtins_with_mapping-d3.h
 int k = __builtin_strlen("");
 
 /**** IWYU_SUMMARY

--- a/tests/cxx/catch.cc
+++ b/tests/cxx/catch.cc
@@ -14,50 +14,50 @@
 
 int main() {
   try {
-  // IWYU: CatchByValue...*catch-byvalue.h
+  // IWYU: CatchByValue is...*catch-byvalue.h
   } catch (const CatchByValue cbv) {
-    // IWYU: LogException...*catch-logex.h
+    // IWYU: LogException is...*catch-logex.h
     LogException(cbv);
   }
 
   try {
-  // IWYU: CatchByRef needs a declaration...*
-  // IWYU: CatchByRef...*catch-byref.h
+  // IWYU: CatchByRef needs a declaration
+  // IWYU: CatchByRef is...*catch-byref.h
   } catch (const CatchByRef& cbr) {
-    // IWYU: LogException...*catch-logex.h
+    // IWYU: LogException is...*catch-logex.h
     LogException(cbr);
   }
 
   try {
-  // IWYU: CatchByPtr needs a declaration...*
-  // IWYU: CatchByPtr...*catch-byptr.h
+  // IWYU: CatchByPtr needs a declaration
+  // IWYU: CatchByPtr is...*catch-byptr.h
   } catch (const CatchByPtr* cpr) {
-    // IWYU: LogException...*catch-logex.h
+    // IWYU: LogException is...*catch-logex.h
     LogException(*cpr);
   }
 
   // Make sure we see through elaborated types
   try {
-  // IWYU: CatchElab needs a declaration...*
-  // IWYU: CatchElab...*catch-elab.h
+  // IWYU: CatchElab needs a declaration
+  // IWYU: CatchElab is...*catch-elab.h
   } catch (const Namespace::CatchElab&) {
   }
 
   // Make sure we don't crash when there's no type.
   try {
-    // IWYU: Thrown...*catch-thrown.h
+    // IWYU: Thrown is...*catch-thrown.h
     throw Thrown();
   } catch (...) {
-    // IWYU: puts...*stdio.h
+    // IWYU: puts is...*stdio.h
     puts("Unknown exception");
   }
 
-  // IWYU: CatchMacro1 needs a declaration...*
-  // IWYU: CatchMacro1...*catch-macro-1.h
+  // IWYU: CatchMacro1 needs a declaration
+  // IWYU: CatchMacro1 is...*catch-macro-1.h
   CHECK_THROW_1(CatchMacro1);
 
-  // IWYU: CatchMacro2 needs a declaration...*
-  // IWYU: CatchMacro2...*catch-macro-2.h
+  // IWYU: CatchMacro2 needs a declaration
+  // IWYU: CatchMacro2 is...*catch-macro-2.h
   CHECK_THROW_2(CatchMacro2);
 
   return 0;

--- a/tests/cxx/comment_pragmas.cc
+++ b/tests/cxx/comment_pragmas.cc
@@ -142,7 +142,7 @@ CommentPragmasD4 cpd4;
 CommentPragmasI8 cpi8;
 
 // indirect.h is not private and not exported by i2.h.
-// IWYU: IndirectClass is ...*indirect.h
+// IWYU: IndirectClass is...*indirect.h
 IndirectClass ic;
 
 // IWYU: CommentPragmasD8 is...*"some_public_header_file"

--- a/tests/cxx/decl_inside_func.cc
+++ b/tests/cxx/decl_inside_func.cc
@@ -23,7 +23,7 @@
 #include "tests/cxx/decl_inside_func-d1.h"
 
 const char* f() {
-  // IWYU: MACRO is ...*decl_inside_func-i1.h
+  // IWYU: MACRO is...*decl_inside_func-i1.h
   return MACRO("bleh").value();
 }
 

--- a/tests/cxx/explicit_instantiation2.cc
+++ b/tests/cxx/explicit_instantiation2.cc
@@ -50,13 +50,13 @@ Template<bool> t1b; // 1b
 // IWYU: Template is...*explicit_instantiation-template.h
 // IWYU: Template is...*template_short.h.*for explicit instantiation
 FullUseArg<
-    // IWYU: Template needs a declaration...*
+    // IWYU: Template needs a declaration
     Template<short>>
     // IWYU: Template is...*explicit_instantiation-template.h
     t3; // 3
 
 FwdDeclUseArg<
-    // IWYU: Template needs a declaration...*
+    // IWYU: Template needs a declaration
     Template<short>>
     t4; // 4
 
@@ -79,7 +79,7 @@ TemplateTemplateArgShortFwd<
 // IWYU: Template is...*explicit_instantiation-template.h
 Template<int> t9; // 9
 
-// IWYU: Template needs a declaration...*
+// IWYU: Template needs a declaration
 template <> class Template<char> {};
 
 TemplateAsDefaultFull<char> t10; // 10

--- a/tests/cxx/inheriting_ctor.cc
+++ b/tests/cxx/inheriting_ctor.cc
@@ -11,7 +11,7 @@
 
 #include "inheriting_ctor-d1.h"
 
-// IWYU: Derived is defined in .*-i1.h
+// IWYU: Derived is...*inheriting_ctor-i1.h
 void func() { Derived d(1); }
 
 /**** IWYU_SUMMARY

--- a/tests/cxx/iwyu_stricter_than_cpp-autocast.h
+++ b/tests/cxx/iwyu_stricter_than_cpp-autocast.h
@@ -149,7 +149,7 @@ struct AutocastStruct {
 // IWYU should not print the comment "for autocast" when the type info is
 // mandatory.
 inline void Fn(
-    // IWYU: IndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h", which isn't directly #included\.
+    // IWYU: IndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h.*#included\.
     TplDirectStruct7<decltype(IndirectStruct1::c), IndirectStruct2>) {
 }
 

--- a/tests/cxx/iwyu_stricter_than_cpp-fnreturn.h
+++ b/tests/cxx/iwyu_stricter_than_cpp-fnreturn.h
@@ -94,7 +94,7 @@ struct FnreturnStruct {
 };
 
 // IWYU should not print the comment "for fn return type" when the type info is mandatory.
-// IWYU: IndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h", which isn't directly #included\.
+// IWYU: IndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h.*#included\.
 decltype(IndirectStruct1::c) FnReturningTypeOfMember();
 
 

--- a/tests/cxx/macro_location_tpl.cc
+++ b/tests/cxx/macro_location_tpl.cc
@@ -18,16 +18,16 @@
 #include "tests/cxx/macro_location_tpl-d1.h"
 
 void use_macro_with_template_spec() {
-  // IWYU: FUNC_TEMPLATE_SPEC_EXPANSION is defined...*macro_location_tpl-i1.h
+  // IWYU: FUNC_TEMPLATE_SPEC_EXPANSION is...*macro_location_tpl-i1.h
   FUNC_TEMPLATE_SPEC_EXPANSION;
 
-  // IWYU: FUNC_TEMPLATE_SPEC_SPELLING is defined...*macro_location_tpl-i1.h
+  // IWYU: FUNC_TEMPLATE_SPEC_SPELLING is...*macro_location_tpl-i1.h
   FUNC_TEMPLATE_SPEC_SPELLING;
 
-  // IWYU: CLASS_TEMPLATE_SPEC_EXPANSION is defined...*macro_location_tpl-i1.h
+  // IWYU: CLASS_TEMPLATE_SPEC_EXPANSION is...*macro_location_tpl-i1.h
   CLASS_TEMPLATE_SPEC_EXPANSION;
 
-  // IWYU: CLASS_TEMPLATE_SPEC_SPELLING is defined...*macro_location_tpl-i1.h
+  // IWYU: CLASS_TEMPLATE_SPEC_SPELLING is...*macro_location_tpl-i1.h
   CLASS_TEMPLATE_SPEC_SPELLING;
 }
 

--- a/tests/cxx/mapping_regex.cc
+++ b/tests/cxx/mapping_regex.cc
@@ -24,7 +24,7 @@
 #include "tests/cxx/direct.h"
 
 void f() {
-  // IWYU: IndirectClass is defined in...*foobar.h
+  // IWYU: IndirectClass is...*foobar.h
   IndirectClass i;
 }
 

--- a/tests/cxx/mapping_replace_regex_ecmascript.cc
+++ b/tests/cxx/mapping_replace_regex_ecmascript.cc
@@ -20,7 +20,7 @@
 #include "tests/cxx/direct.h"
 
 void f() {
-  // IWYU: IndirectClass is defined in "foobar/tests/cxx/indirect.h"
+  // IWYU: IndirectClass is...*"foobar/tests/cxx/indirect.h"
   IndirectClass i;
 }
 

--- a/tests/cxx/mapping_replace_regex_llvm.cc
+++ b/tests/cxx/mapping_replace_regex_llvm.cc
@@ -20,7 +20,7 @@
 #include "tests/cxx/direct.h"
 
 void f() {
-  // IWYU: IndirectClass is defined in "foobar/tests/cxx/indirect.h"
+  // IWYU: IndirectClass is...*"foobar/tests/cxx/indirect.h"
   IndirectClass i;
 }
 

--- a/tests/cxx/namespace_alias.cc
+++ b/tests/cxx/namespace_alias.cc
@@ -15,12 +15,12 @@
 
 // The referenced namespace must be declared. This file doesn't use symbols from
 // the namespace, so a header is explicitly suggested for it.
-// IWYU: ns3::ns4 is defined in...*namespace_alias-i3.h
+// IWYU: ns3::ns4 is...*namespace_alias-i3.h
 namespace ns_alias2 = ns3::ns4;
 
 void Func() {
   // IWYU: ns1::ns2::Function1 is...*namespace_alias-i1.h
-  // IWYU: ns_alias1 is defined in...*namespace_alias-i2.h
+  // IWYU: ns_alias1 is...*namespace_alias-i2.h
   ns_alias1::Function1();
 }
 

--- a/tests/cxx/namespace_use.cc
+++ b/tests/cxx/namespace_use.cc
@@ -17,7 +17,7 @@
 // Purely using the namespace, not any symbols.
 // This could be unused, or being used transitively in namespace lookup.
 // The include suggestion will be the first header that declares the namespace.
-// IWYU: i1_ns is defined in ...*
+// IWYU: i1_ns is...*namespace_use-i1.h
 using namespace i1_ns;
 
 // This namespace gets used for symbols within it.
@@ -25,7 +25,7 @@ using namespace i1_ns;
 using namespace i2_ns;
 
 int main(int, const char**) {
-  // IWYU: i2_ns::GetValue is defined in ...*namespace_use-i2.h
+  // IWYU: i2_ns::GetValue is...*namespace_use-i2.h
   return GetValue();
 }
 

--- a/tests/cxx/out_of_line.cc
+++ b/tests/cxx/out_of_line.cc
@@ -32,7 +32,7 @@ void Class<T, U>::MethodStaticOut() {
 
 template <>
 void Class<int, int>::MethodOut() {
-  // IWYU: Dependent is.*dep-int.h
+  // IWYU: Dependent is...*out_of_line-dep-int.h
   Dependent(Type());
 }
 
@@ -41,12 +41,12 @@ int main()
 {
     //Inline template method
     Class<int> c;
-    // IWYU: Dependent is.*dep-int.h
+    // IWYU: Dependent is...*out_of_line-dep-int.h
     c.MethodIn();
 
     //Out-of-line template method
     Class<int> c2;
-    // IWYU: Dependent is.*dep-int.h
+    // IWYU: Dependent is...*out_of_line-dep-int.h
     c2.MethodOut();
 
     //A explicit specialization of MethodOut(). It does not
@@ -56,11 +56,11 @@ int main()
     c3.MethodOut();
 
     //Inline static method
-    // IWYU: Dependent is.*dep-int.h
+    // IWYU: Dependent is...*out_of_line-dep-int.h
     Class<int>::MethodStaticIn();
 
     //Out-of-line static method
-    // IWYU: Dependent is.*dep-int.h
+    // IWYU: Dependent is...*out_of_line-dep-int.h
     Class<int>::MethodStaticOut();
 }
 

--- a/tests/cxx/using_aliased_symbol.cc
+++ b/tests/cxx/using_aliased_symbol.cc
@@ -17,15 +17,15 @@
 #include "tests/cxx/using_aliased_symbol-alias.h"
 
 void use_symbol() {
-  // IWYU: ns::symbol is defined in ...*using_aliased_symbol-declare.h", which isn't directly #included.
+  // IWYU: ns::symbol is...*using_aliased_symbol-declare.h
   ns2::symbol();
   // Use of non-providing typedef requires full underlying type info to be
   // provided by the user. Hence, full IndirectClass info is required here.
-  // IWYU: ns::Typedef is defined in ...*using_aliased_symbol-declare.h", which isn't directly #included.
-  // IWYU: IndirectClass is defined in ...*indirect.h", which isn't directly #included.
+  // IWYU: ns::Typedef is...*using_aliased_symbol-declare.h
+  // IWYU: IndirectClass is...*indirect.h
   ns2::Typedef a;
   // Typedef use in a fwd-decl context doesn't require underlying type info.
-  // IWYU: ns::Typedef is defined in ...*using_aliased_symbol-declare.h", which isn't directly #included.
+  // IWYU: ns::Typedef is...*using_aliased_symbol-declare.h
   ns2::Typedef* pa;
 }
 


### PR DESCRIPTION
The canonical forms for test assertions are:

    // IWYU: Symbol is...*header.h
    // IWYU: Symbol needs a declaration

Clean up a bunch of unconventional but otherwise correct spellings:

* Remove `defined in`
* Remove trailing `which isn't directly #included` where incidental
* Remove trailing wildcard after `needs a declaration`
* Make sure all include expectations spell out a headername
* Change `.*` to `...*`
* Remove whitespace in `is ...*`

No functional change expected.
