### PR TITLE
Add `--no_fwd_decls_source_only` option to disable forward declarations in source files

### DIFF
--- a/iwyu_globals.cc
+++ b/iwyu_globals.cc
@@ -117,6 +117,9 @@ static void PrintHelp(const char* extra_msg) {
          "   --update_comments: update and insert 'why' comments, even if no\n"
          "        #include lines need to be added or removed.\n"
          "   --no_fwd_decls: do not use forward declarations.\n"
+         "   --no_fwd_decls_source_only: do not use forward declarations\n"
+         "        in source files only (header files still allow forward\n"
+         "        declarations).\n"
          "   --verbose=<level>: the higher the level, the more output.\n"
          "   --quoted_includes_first: when sorting includes, place quoted\n"
          "        ones first.\n"
@@ -217,6 +220,7 @@ CommandlineFlags::CommandlineFlags()
       update_comments(false),
       comments_with_namespace(false),
       no_fwd_decls(false),
+      no_fwd_decls_source_only(false),
       quoted_includes_first(false),
       cxx17ns(false),
       exit_code_error(EXIT_SUCCESS),
@@ -242,6 +246,7 @@ int CommandlineFlags::ParseArgv(int argc, char** argv) {
     {"no_comments", no_argument, nullptr, 'o'},
     {"update_comments", no_argument, nullptr, 'u'},
     {"no_fwd_decls", no_argument, nullptr, 'f'},
+    {"no_fwd_decls_source_only", no_argument, nullptr, 'g'},
     {"quoted_includes_first", no_argument, nullptr, 'q' },
     {"cxx17ns", no_argument, nullptr, 'C'},
     {"error", optional_argument, nullptr, 'e'},
@@ -278,6 +283,7 @@ int CommandlineFlags::ParseArgv(int argc, char** argv) {
         }
         break;
       case 'f': no_fwd_decls = true; break;
+      case 'g': no_fwd_decls_source_only = true; break;
       case 'x':
         if (strcmp(optarg, "add") == 0) {
           prefix_header_include_policy = CommandlineFlags::kAdd;

--- a/iwyu_globals.h
+++ b/iwyu_globals.h
@@ -105,6 +105,7 @@ struct CommandlineFlags {
   bool update_comments; // Force 'why' comments. No short option.
   bool comments_with_namespace; // Show namespace in 'why' comments.
   bool no_fwd_decls;  // Disable forward declarations.
+  bool no_fwd_decls_source_only;  // Disable forward declarations in source files only.
   bool quoted_includes_first; // Place quoted includes first in sort order.
   bool cxx17ns; // -C: C++17 nested namespace syntax
   int exit_code_error;   // Exit with this code for iwyu violations.

--- a/iwyu_output.cc
+++ b/iwyu_output.cc
@@ -1206,7 +1206,10 @@ void ProcessForwardDeclare(OneUse* use,
   // the headers, suggest that header, and recategorize as a full use. If we can
   // only find a decl in this file, it must be a self-sufficent decl being used,
   // so we can just let IWYU do its work, and there is no need to recategorize.
-  if (!use->ignore_use() && GlobalFlags().no_fwd_decls) {
+  // Note: --no_fwd_decls_source_only only applies to source files.
+  if (!use->ignore_use() && 
+      (GlobalFlags().no_fwd_decls || 
+       (GlobalFlags().no_fwd_decls_source_only && !IsHeaderFile(GetFilePath(use->use_loc()))))) {
     bool promote_to_full_use = true;
     for (const Decl* decl = use->decl(); decl != nullptr;
          decl = decl->getPreviousDecl()) {

--- a/tests/cxx/no_fwd_decls_source_only-d1.h
+++ b/tests/cxx/no_fwd_decls_source_only-d1.h
@@ -1,0 +1,19 @@
+//===--- no_fwd_decls_source_only-d1.h - test input file for iwyu -------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_NO_FWD_DECLS_SOURCE_ONLY_D1_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_NO_FWD_DECLS_SOURCE_ONLY_D1_H_
+
+
+template <typename T>
+class FinalTemplate final {};
+
+class FinalClass final {};
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_NO_FWD_DECLS_SOURCE_ONLY_D1_H_

--- a/tests/cxx/no_fwd_decls_source_only.cc
+++ b/tests/cxx/no_fwd_decls_source_only.cc
@@ -1,0 +1,31 @@
+//===--- no_fwd_decls_source_only.cc - test input file for iwyu ---------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_ARGS: -Xiwyu --no_fwd_decls_source_only -I .
+
+#include "tests/cxx/no_fwd_decls_source_only.h"
+
+void FwdDeclFinal::testFinalTemplate(FinalTemplate<int>* finalTemplate) {
+}
+
+void FwdDeclFinal::testFinalClass(FinalClass* finalClass) {
+}
+
+/**** IWYU_SUMMARY
+
+tests/cxx/no_fwd_decls_source_only.cc should add these lines:
+#include "tests/cxx/no_fwd_decls_source_only-d1.h"
+
+tests/cxx/no_fwd_decls_source_only.cc should remove these lines:
+
+The full include-list for tests/cxx/no_fwd_decls_source_only.cc:
+#include "tests/cxx/no_fwd_decls_source_only.h"
+#include "tests/cxx/no_fwd_decls_source_only-d1.h"  // for FinalClass, FinalTemplate
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/no_fwd_decls_source_only.h
+++ b/tests/cxx/no_fwd_decls_source_only.h
@@ -1,0 +1,36 @@
+//===--- no_fwd_decls_source_only.h - test input file for iwyu ----------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_NO_FWD_DECLS_SOURCE_ONLY_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_NO_FWD_DECLS_SOURCE_ONLY_H_
+
+#include "tests/cxx/no_fwd_decls_source_only-d1.h"
+
+class FwdDeclFinal {
+public:
+  void testFinalTemplate(FinalTemplate<int>* finalTemplate);
+  void testFinalClass(FinalClass* finalClass);
+};
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_NO_FWD_DECLS_SOURCE_ONLY_H_
+
+/**** IWYU_SUMMARY
+
+tests/cxx/no_fwd_decls_source_only.h should add these lines:
+class FinalClass;
+template <typename T> class FinalTemplate;
+
+tests/cxx/no_fwd_decls_source_only.h should remove these lines:
+- #include "tests/cxx/no_fwd_decls_source_only-d1.h"  // lines XX-XX
+
+The full include-list for tests/cxx/no_fwd_decls_source_only.h:
+class FinalClass;
+template <typename T> class FinalTemplate;
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
Ref: [this thread](https://groups.google.com/g/include-what-you-use/c/OmqYn2MELRg/m/QKIDBzC_AwAJ?utm_medium=email&utm_source=footer)

- Added `--no_fwd_decls_source_only` command-line option to suppress forward declarations in `.cpp` files only.
- Updated `PrintHelp` to document the new option.
- Modified `CommandlineFlags` to include the new flag.
- Enhanced `ProcessForwardDeclare` to respect this setting.
- Added tests to verify `no_fwd_decls_source_only` behavior.

### Background

Our project uses complex macros, which sometimes obscure symbol usage from IWYU. As a result, some required symbols are incorrectly treated as candidates for forward declarations. However, in `.cpp` files, we typically include headers directly and do not benefit from forward declarations. This option allows us to avoid unnecessary or incorrect forward declarations in source files, while still retaining them in headers.