### PR TITLE
[clang compat] Change type_info tag kind

### DIFF
--- a/tests/cxx/clmode.cc
+++ b/tests/cxx/clmode.cc
@@ -27,13 +27,13 @@ type_info* pt = nullptr;
 
 tests/cxx/clmode.cc should add these lines:
 #include "tests/cxx/indirect.h"
-class type_info;
+struct type_info;
 
 tests/cxx/clmode.cc should remove these lines:
 - #include "tests/cxx/direct.h"  // lines XX-XX
 
 The full include-list for tests/cxx/clmode.cc:
 #include "tests/cxx/indirect.h"  // for IndirectClass
-class type_info;
+struct type_info;
 
 ***** IWYU_SUMMARY */


### PR DESCRIPTION
https://github.com/llvm/llvm-project/commit/2e404d1f800c804b5088ad1f54f24738efbdf9cd changed the kind of `type_info` implicitly added in the MSVC compatibility mode from class to struct.

This should be merged after #1793.