### PR TITLE
Do not suggest forward-decls for implicit code

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -3102,7 +3102,8 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
 
     // If we are forward-declarable, so are our template arguments.
     if (CanForwardDeclareType(current_ast_node())) {
-      ReportDeclForwardDeclareUse(CurrentLoc(), decl);
+      if (!current_ast_node()->template GetAncestorAs<Decl>()->isImplicit())
+        ReportDeclForwardDeclareUse(CurrentLoc(), decl);
       current_ast_node()->set_in_forward_declare_context(true);
     } else {
       if (type->isTypeAlias())
@@ -5098,6 +5099,10 @@ class IwyuAstConsumer
     // needed: just forward-declare.
     if (CanForwardDeclareType(current_ast_node()) && !is_provided) {
       current_ast_node()->set_in_forward_declare_context(true);
+
+      if (current_ast_node()->GetAncestorAs<Decl>()->isImplicit())
+        return Base::VisitTagType(type);
+
       if (compiler()->getLangOpts().CPlusPlus) {
         // In C++, if we're already elaborated ('class Foo x') but not
         // a qualified name ('class ns::Foo x', 'class Class::Nested x') or

--- a/tests/cxx/no_fwd_for_implicit-direct.h
+++ b/tests/cxx/no_fwd_for_implicit-direct.h
@@ -1,4 +1,4 @@
-//===--- fn.h - iwyu test -------------------------------------------------===//
+//===--- no_fwd_for_implicit-direct.h - test input file for iwyu ----------===//
 //
 //                     The LLVM Compiler Infrastructure
 //

--- a/tests/cxx/no_fwd_for_implicit.cc
+++ b/tests/cxx/no_fwd_for_implicit.cc
@@ -1,4 +1,4 @@
-//===--- 1774.cc - iwyu test ----------------------------------------------===//
+//===--- no_fwd_for_implicit.cc - test input file for iwyu ----------------===//
 //
 //                     The LLVM Compiler Infrastructure
 //
@@ -7,18 +7,22 @@
 //
 //===----------------------------------------------------------------------===//
 
-// IWYU_XFAIL
+// IWYU_ARGS: -I .
 
-#include "fn.h"
+// Tests that IWYU does not suggest adding a forward-declaration when the type
+// is not explicitly written in the source.
+
+#include "tests/cxx/no_fwd_for_implicit-direct.h"
 
 int main() {
   auto& class_ref = GetClass();
   auto& tpl_ref = GetTpl();
+  // IWYU should report fwd-decl uses neither of Class nor of Tpl.
   [&class_ref, &tpl_ref] {}();
 }
 
 /**** IWYU_SUMMARY
 
-(tests/bugs/1774/1774.cc has correct #includes/fwd-decls)
+(tests/cxx/no_fwd_for_implicit.cc has correct #includes/fwd-decls)
 
 ***** IWYU_SUMMARY */


### PR DESCRIPTION
There is no need to change `VisitUsingType` because using-types inside implicit code are already skipped in `TraverseType` and `TraverseTypeLoc`.

Another way to fix it might be to move `ReportDeclForwardDeclareUse` calls into `Visit...TypeLoc` functions which are not called for implicit code (due to `IwyuAstConsumer::TraverseTypeLoc` logic). But this breaks fwd-declaring of types from dynamic exception specifications because they are `Type`s in the AST and not `TypeLoc`s (there is [a `TODO` inside `RecursiveASTVisitor`](https://github.com/llvm/llvm-project/blob/a549e73cad60336d8e9c0622ae7ad86aa65ef4ce/clang/include/clang/AST/RecursiveASTVisitor.h#L1417)).

This fixes #1774.