### PR TITLE
Add test on spurious fwd-decl for var template arg

### DIFF
--- a/tests/cxx/variable_template-i1.h
+++ b/tests/cxx/variable_template-i1.h
@@ -22,3 +22,18 @@ int both_args_used_def_provided = [] {
 using ProvidingRefAlias = IndirectClass&;
 
 int GetInt();
+
+template <typename>
+int var_tpl_in_header;
+
+template <typename T>
+void UseVarTplInHeader() {
+  // IWYU should not suggest a forward-declaration of DeclaredInCC here.
+  (void)var_tpl_in_header<T>;
+}
+
+/**** IWYU_SUMMARY
+
+(tests/cxx/variable_template-i1.h has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/variable_template.cc
+++ b/tests/cxx/variable_template.cc
@@ -7,13 +7,15 @@
 //
 //===----------------------------------------------------------------------===//
 
-// IWYU_ARGS: -I . -Wno-undefined-var-template
+// IWYU_ARGS: -I . -Wno-undefined-var-template \
+//            -Xiwyu --check_also="tests/cxx/*-i1.h"
 
 // Tests variable templates.
 
 #include "tests/cxx/direct.h"
 #include "tests/cxx/variable_template-d1.h"
 
+class DeclaredInCC;
 class IndirectClass;
 
 using NonProvidingRefAlias = IndirectClass&;
@@ -173,6 +175,8 @@ void Fn() {
   TplFnUsingVarTpl<IndirectClass>();
   TplFnUsingGetIntIndirectly<IndirectClass>();
   TplFnNoImplInstNeeded<IndirectClass>();
+  // IWYU: UseVarTplInHeader is...*-i1.h
+  UseVarTplInHeader<DeclaredInCC>();
 }
 
 /**** IWYU_SUMMARY
@@ -188,6 +192,7 @@ tests/cxx/variable_template.cc should remove these lines:
 
 The full include-list for tests/cxx/variable_template.cc:
 #include "tests/cxx/indirect.h"  // for IndirectClass, IndirectTemplate
-#include "tests/cxx/variable_template-i1.h"  // for GetInt, ProvidingRefAlias, both_args_used_def_provided, full_use_def_arg_provided
+#include "tests/cxx/variable_template-i1.h"  // for GetInt, ProvidingRefAlias, UseVarTplInHeader, both_args_used_def_provided, full_use_def_arg_provided
+class DeclaredInCC;  // lines XX-XX
 
 ***** IWYU_SUMMARY */


### PR DESCRIPTION
The bug was noticed [here](https://github.com/include-what-you-use/include-what-you-use/pull/1793#discussion_r2280505322) and has been fixed in https://github.com/llvm/llvm-project/commit/1cb47c19f8eca4badd8fb5e1a1b1cf4aaab607b8.