### PR TITLE
[clang compat] Remove unused using-declaration

### DIFF
--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -89,7 +89,6 @@ using clang::DeclaratorDecl;
 using clang::DependentNameType;
 using clang::DependentScopeDeclRefExpr;
 using clang::DependentTemplateName;
-using clang::DependentTemplateSpecializationType;
 using clang::ElaboratedTypeKeyword;
 using clang::EnterExpressionEvaluationContext;
 using clang::EnumDecl;


### PR DESCRIPTION
`DependentTemplateSpecializationType` was removed in https://github.com/llvm/llvm-project/commit/ba9d1c41c41d568a798e0a8c38a89d294647c28d. It was not referred to in IWYU except a using-declaration.