### PR TITLE
[clang compat] Adjust for new createDiagnostics signature

### DIFF
--- a/iwyu_driver.cc
+++ b/iwyu_driver.cc
@@ -394,7 +394,7 @@ bool ExecuteAction(int argc,
       new CompilerInstance(std::move(invocation)));
   // It's tempting to reuse the DiagnosticsEngine we created above, but we need
   // to create a new one to get the options produced by the compiler invocation.
-  compiler->createDiagnostics(*fs);
+  compiler->createDiagnostics();
 
   unique_ptr<FrontendAction> action;
   switch (command.getSource().getKind()) {


### PR DESCRIPTION
https://github.com/llvm/llvm-project/commit/30633f30894129919050f24fdd1f8f6bc46beae0 removed the leading VFS parameter from createDiagnostics.

Update the call.