### PR TITLE
Add symbol mapping for std::nullptr_t

### DIFF
--- a/iwyu_include_picker.cc
+++ b/iwyu_include_picker.cc
@@ -343,8 +343,10 @@ const IncludeMapEntry stdlib_cxx_symbol_map[] = {
 
 // Symbol -> include mappings for GNU libstdc++
 const IncludeMapEntry libstdcpp_symbol_map[] = {
-  // GCC defines std::declval in <type_traits>, but the canonical location is <utility>
+  // std::declval is defined in <type_traits>, but provided by <utility>
   { "std::declval", kPrivate, "<utility>", kPublic },
+  // std::nullptr_t is defined in <bits/c++config.h>, but provided by <cstddef>
+  {"std::nullptr_t", kPrivate, "<cstddef>", kPublic},
 };
 
 const IncludeMapEntry libc_include_map[] = {


### PR DESCRIPTION
std::nullptr_t in libstdc++ is defined in the private, arch-specific header bits/c++config.h. That header has a @headername directive pointing to `<version>`, which is only defined for C++20, and doesn't really provide std::nullptr_t.

I can't think of a principled way to fix this, so add a simple libstdc++ symbol mapping for std::nullptr_t to `<cstddef>`.

Drive-by improvement of the comment for std::declval for consistency.

Fixes #1791.