### PR TITLE
Allow forward-declarations in __gnu_cxx namespace

### DIFF
--- a/iwyu_output.cc
+++ b/iwyu_output.cc
@@ -998,11 +998,8 @@ set<string> CalculateMinimalIncludes(
 // A1) If not a class or a templated class, recategorize as a full use.
 // A2) If a templated class with default template params, recategorize
 //     as a full use (forward-declaring in that case is too error-prone).
-// A3) If a symbol in std, __gnu_cxx, or another system namespace,
-//     recategorize as a full use.  This is entirely a policy
-//     decision: we've decided never to forward-declare anything in
-//     a system namespace, because it's best not to expose the internals
-//     of system headers in user code, if possible.
+// A3) If a symbol in std, recategorize as a full use. The C++ standard forbids
+//     declarations in std namespace in user's code, in general.
 // A4) If the file containing the use has a pragma inhibiting the forward
 //     declaration of the symbol, change the use to a full info use in order
 //     to make sure that the compiler can see some declaration of the symbol.
@@ -1117,15 +1114,13 @@ void ProcessForwardDeclare(OneUse* use,
     // No return here: (A4) or (A5) may cause us to ignore this decl entirely.
   }
 
-  // (A3) If it is in namespace std or a system ns, recategorize as a full use.
-  // We can add new system namespaces here as needed.
+  // (A3) If it is in namespace std, recategorize as a full use.
   // TODO(csilvers): if someone has specialized a class in std, the
   // specialization should be treated as in user-space and
   // forward-declarable.  Check for that case.
-  if (StartsWith(use->symbol_name(), "std::") ||
-      StartsWith(use->symbol_name(), "__gnu_cxx::")) {
+  if (StartsWith(use->symbol_name(), "std::")) {
     VERRS(6) << "Moving " << use->symbol_name()
-             << " from fwd-decl use to full use: in a system namespace "
+             << " from fwd-decl use to full use: in namespace std"
              << " (" << use->PrintableUseLoc() << ")\n";
     use->set_full_use();
     // No return here: (A4) or (A5) may cause us to ignore this decl entirely.

--- a/tests/cxx/system_namespaces-d2.h
+++ b/tests/cxx/system_namespaces-d2.h
@@ -7,8 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// We're not supposed to define anything in std, but we do anyway for this test.
-
 namespace __gnu_cxx {
 class SystemClass { };
 }

--- a/tests/cxx/system_namespaces-d3.h
+++ b/tests/cxx/system_namespaces-d3.h
@@ -7,8 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// We're not supposed to define anything in std, but we do anyway for this test.
-
 namespace notsys_ns {
 template <typename T> class TplClass { };
 }

--- a/tests/cxx/system_namespaces.cc
+++ b/tests/cxx/system_namespaces.cc
@@ -10,7 +10,7 @@
 // IWYU_ARGS: -I .
 
 // Tests that we correctly replace forward declares with #includes for
-// items in a system namespace: std or __gnu_cxx or the like.
+// items in namespace std.
 
 #include "tests/cxx/system_namespaces-d1.h"
 #include "tests/cxx/system_namespaces-d2.h"
@@ -23,22 +23,23 @@ __gnu_cxx::SystemClass* bar = 0;
 typedef int __system_type;
 notsys_ns::TplClass<__system_type>* baz = 0;
 
-
-// The summary is where all the action is on this test.  Only TplClass
-// should be replaceable by a forward-declare, because only it is
-// exposing a symbol in a non-system namespace.
+// The summary is where all the action is on this test. Only std::StdClass
+// should be not replaceable by a forward-declare, because only it is
+// exposing a symbol in the std namespace.
 
 /**** IWYU_SUMMARY
 
 tests/cxx/system_namespaces.cc should add these lines:
+namespace __gnu_cxx { class SystemClass; }
 namespace notsys_ns { template <typename T> class TplClass; }
 
 tests/cxx/system_namespaces.cc should remove these lines:
+- #include "tests/cxx/system_namespaces-d2.h"  // lines XX-XX
 - #include "tests/cxx/system_namespaces-d3.h"  // lines XX-XX
 
 The full include-list for tests/cxx/system_namespaces.cc:
 #include "tests/cxx/system_namespaces-d1.h"  // for StdClass
-#include "tests/cxx/system_namespaces-d2.h"  // for SystemClass
+namespace __gnu_cxx { class SystemClass; }
 namespace notsys_ns { template <typename T> class TplClass; }
 
 ***** IWYU_SUMMARY */


### PR DESCRIPTION
The standard explicitly forbids only declarations in the std namespace in user's code (in the general case).

The reasoning not to expose system header internals seems to me to be wrong. If a user doesn't write a type name explicitly, IWYU should not suggest to forward-declare it anyway (it would be a sign of a bug). And if he does, it is probably normal to require a forward-declaration.