### PR TITLE
[clang compat] Respect new implicit-lifetime semantics

### DIFF
--- a/tests/cxx/type_trait.cc
+++ b/tests/cxx/type_trait.cc
@@ -142,16 +142,16 @@ static_assert(!__is_aggregate(Union2*));
 static_assert(!__is_aggregate(Union2&));
 static_assert(__is_aggregate(Union1[]));
 // IWYU: Class is...*-i1.h
-static_assert(__builtin_is_implicit_lifetime(Class));
+static_assert(!__builtin_is_implicit_lifetime(Class));
 static_assert(__builtin_is_implicit_lifetime(Class*));
 static_assert(!__builtin_is_implicit_lifetime(Class&));
 static_assert(__builtin_is_implicit_lifetime(Class[]));
 // IWYU: Class is...*-i1.h
-static_assert(__builtin_is_implicit_lifetime(ClassNonProviding));
-static_assert(__builtin_is_implicit_lifetime(ClassProviding));
+static_assert(!__builtin_is_implicit_lifetime(ClassNonProviding));
+static_assert(!__builtin_is_implicit_lifetime(ClassProviding));
 static_assert(__builtin_is_implicit_lifetime(ClassArray2NonProviding));
 // IWYU: Union1 is...*-i1.h
-static_assert(__builtin_is_implicit_lifetime(Union1));
+static_assert(!__builtin_is_implicit_lifetime(Union1));
 static_assert(__builtin_is_implicit_lifetime(Union1*));
 static_assert(!__builtin_is_implicit_lifetime(Union1&));
 static_assert(__builtin_is_implicit_lifetime(Union1[]));


### PR DESCRIPTION
https://github.com/llvm/llvm-project/commit/e5bbc9feae3c6b7f377f89abae47fc3819c73f95 changed the semantics of __builtin_is_implicit_lifetime to properly require a trivial constructor. Our test types (Class, Union1) didn't have trivial ctors, and adding them would break a lot of other static_asserts using the same types (is_trivial, etc.).

Reverse the tense of the relevant __builtin_is_implicit_lifetime assertions. This should not affect which types are required.