### PR TITLE
[ci] Use CMAKE_PREFIX_PATH to explicitly target LLVM version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
                 -DCMAKE_EXPORT_COMPILE_COMMANDS=on \
                 -DCMAKE_C_COMPILER=clang$LLVM_TAG \
                 -DCMAKE_CXX_COMPILER=clang++$LLVM_TAG \
+                -DCMAKE_PREFIX_PATH=$LLVM_PREFIX \
                 -DCMAKE_INSTALL_PREFIX=./ \
                 -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=on \
                 ../


### PR DESCRIPTION
I keep encouraging people to do this, but I apparently didn't think to do it myself :)

It used to work anyway, because our CI build explicitly uninstalls all existing LLVM and Clang packages before installing the one we want, so there's only a single hit in CMake's probing.