### PR TITLE
Simplify IsDefArgSpecified

### DIFF
--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -1384,18 +1384,7 @@ const CXXMethodDecl* GetFromLeastDerived(const CXXMethodDecl* decl) {
 
 bool IsDefArgSpecified(unsigned i, const FunctionDecl* func) {
   const ParmVarDecl* param = func->getParamDecl(i);
-  if (!param->hasDefaultArg())
-    return false;
-  if (param->hasUninstantiatedDefaultArg()) {
-    // Some more correct handling can be added if necessary.
-    return false;
-  }
-  // Clang marks a parameter as having default argument even if that argument
-  // is specified in another function redeclaration, so check source locations
-  // to determine if the argument is written explicitly in the current decl.
-  SourceLocation def_arg_loc = param->getDefaultArg()->getExprLoc();
-  return GlobalSourceManager()->isPointWithin(def_arg_loc, func->getBeginLoc(),
-                                              func->getEndLoc());
+  return param->hasDefaultArg() && !param->hasInheritedDefaultArg();
 }
 
 FunctionDecl* GetRedeclSpecifyingDefArg(unsigned i, FunctionDecl* func) {

--- a/tests/cxx/fn_def_args-d1.h
+++ b/tests/cxx/fn_def_args-d1.h
@@ -22,6 +22,7 @@ void FnWithSmearedDefArgs(int = 0, int);
 // No need to report any redeclaration here because no default argument
 // is added.
 void FnWithSmearedDefArgs(int, int);
+void FnWithDefArg2(int, int);
 
 // IWYU: operator new is...*fn_def_args-i2.h
 void* operator new(std::size_t, int, int = 0, int);

--- a/tests/cxx/fn_def_args-i2.h
+++ b/tests/cxx/fn_def_args-i2.h
@@ -19,6 +19,7 @@ void FnWithSmearedDefArgs2(int, int = 0);
 void FnWithSmearedDefArgs3(int, int, int);
 void FnWithSmearedDefArgs3(int, int, int = 0);
 void FnWithDefArg(int = 0);
+void FnWithDefArg2(int, int = 0);
 
 void* operator new(std::size_t, int, int, int = 0);
 


### PR DESCRIPTION
There is no need to analyze source locations: there already is a nice `hasInheritedDefaultArg()` method.

One more test case has been added to check the presence of `param->hasDefaultArg()` call.

No functional change is intended.