### PR TITLE
Report tpl decl specifying missing default arg

### DIFF
--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -116,6 +116,7 @@ using clang::MemberPointerType;
 using clang::NamedDecl;
 using clang::NamespaceDecl;
 using clang::NestedNameSpecifier;
+using clang::NonTypeTemplateParmDecl;
 using clang::ObjCObjectType;
 using clang::OpaqueValueExpr;
 using clang::OptionalFileEntryRef;
@@ -147,6 +148,7 @@ using clang::TemplateName;
 using clang::TemplateParameterList;
 using clang::TemplateSpecializationKind;
 using clang::TemplateSpecializationType;
+using clang::TemplateTemplateParmDecl;
 using clang::TemplateTypeParmDecl;
 using clang::TranslationUnitDecl;
 using clang::Type;
@@ -1396,6 +1398,31 @@ bool IsDefArgSpecified(unsigned i, const FunctionDecl* func) {
   SourceLocation def_arg_loc = param->getDefaultArg()->getExprLoc();
   return GlobalSourceManager()->isPointWithin(def_arg_loc, func->getBeginLoc(),
                                               func->getEndLoc());
+}
+
+bool IsDefTplArgInherited(const NamedDecl* tpl_param) {
+  if (const auto* type_param = dyn_cast<TemplateTypeParmDecl>(tpl_param))
+    return type_param->defaultArgumentWasInherited();
+  if (const auto* nttp = dyn_cast<NonTypeTemplateParmDecl>(tpl_param))
+    return nttp->defaultArgumentWasInherited();
+  if (const auto* tpl_tpl_param = dyn_cast<TemplateTemplateParmDecl>(tpl_param))
+    return tpl_tpl_param->defaultArgumentWasInherited();
+  CHECK_UNREACHABLE_("Not a template parameter");
+}
+
+bool IsDefTplArgSpecified(const NamedDecl* tpl_param) {
+  if (const auto* type_param = dyn_cast<TemplateTypeParmDecl>(tpl_param)) {
+    return type_param->hasDefaultArgument() &&
+           !type_param->defaultArgumentWasInherited();
+  }
+  if (const auto* nttp = dyn_cast<NonTypeTemplateParmDecl>(tpl_param))
+    return nttp->hasDefaultArgument() && !nttp->defaultArgumentWasInherited();
+  if (const auto* tpl_tpl_param =
+          dyn_cast<TemplateTemplateParmDecl>(tpl_param)) {
+    return tpl_tpl_param->hasDefaultArgument() &&
+           !tpl_tpl_param->defaultArgumentWasInherited();
+  }
+  CHECK_UNREACHABLE_("Not a template parameter");
 }
 
 FunctionDecl* GetRedeclSpecifyingDefArg(unsigned i, FunctionDecl* func) {

--- a/iwyu_ast_util.h
+++ b/iwyu_ast_util.h
@@ -755,6 +755,17 @@ bool IsDefArgSpecified(unsigned i, const clang::FunctionDecl*);
 clang::FunctionDecl* GetRedeclSpecifyingDefArg(unsigned i,
                                                clang::FunctionDecl*);
 
+// Returns true if the given template parameter declaration does not specify
+// a default argument explicitly but inherits it from some of the previous
+// template declarations. Expects that the given NamedDecl is actually
+// a template parameter declaration.
+bool IsDefTplArgInherited(const clang::NamedDecl* tpl_param);
+
+// Returns true if the given template parameter declaration specifies a default
+// argument explicitly. Expects that the given NamedDecl is actually a template
+// parameter declaration.
+bool IsDefTplArgSpecified(const clang::NamedDecl* tpl_param);
+
 // --- Utilities for Type.
 
 // See if a given type is a 'real' elaborated type.  (An

--- a/tests/cxx/default_tpl_arg-d2.h
+++ b/tests/cxx/default_tpl_arg-d2.h
@@ -7,6 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "tests/cxx/default_tpl_arg-d1.h"
 #include "tests/cxx/indirect.h"
 
 // Use of this function template instantiated with the default argument doesn't
@@ -35,3 +36,21 @@ template <typename T = IndirectClass>
 void FnWithProvidedDefaultTplArgAndDefaultCallArg3(T = {}) {
   T t;
 }
+
+template <int, int = 0, int>
+// IWYU: AliasTpl5 is...*default_tpl_arg-i1.h
+using AliasTpl5 = int;
+
+/**** IWYU_SUMMARY
+
+tests/cxx/default_tpl_arg-d2.h should add these lines:
+#include "tests/cxx/default_tpl_arg-i1.h"
+
+tests/cxx/default_tpl_arg-d2.h should remove these lines:
+- #include "tests/cxx/default_tpl_arg-d1.h"  // lines XX-XX
+
+The full include-list for tests/cxx/default_tpl_arg-d2.h:
+#include "tests/cxx/default_tpl_arg-i1.h"  // for AliasTpl5
+#include "tests/cxx/indirect.h"  // for IndirectClass
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/default_tpl_arg-i1.h
+++ b/tests/cxx/default_tpl_arg-i1.h
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_DEFAULT_TPL_ARG_I1_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_DEFAULT_TPL_ARG_I1_H_
+
 template <typename T>
 struct UninstantiatedTpl {
   T t;
@@ -30,3 +33,38 @@ void FnWithNonProvidedDefaultTplArgAndDefaultCallArg(T* = nullptr) {
 }
 
 using NonProvidingAlias = IndirectClass;
+
+template <typename, typename = int>
+class ClassTpl;
+
+template <typename, typename = int>
+class ClassTplWithDefinition;
+
+template <typename, typename = int>
+extern int VarTpl;
+
+template <typename, typename = int>
+using AliasTpl1 = int;
+
+template <typename, typename = int>
+void FnTpl();
+
+template <int, int = 0>
+using AliasTpl2 = int;
+
+template <int>
+class SomeTpl;
+
+template <template <int> typename, template <int> typename = SomeTpl>
+using AliasTpl3 = int;
+
+template <typename, int = 0>
+using AliasTpl4 = int;
+
+template <int, int, int = 0>
+using AliasTpl5 = int;
+
+template <int, int>
+using AliasTpl6 = int;
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_DEFAULT_TPL_ARG_I1_H_

--- a/tests/cxx/default_tpl_arg.cc
+++ b/tests/cxx/default_tpl_arg.cc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// IWYU_ARGS: -I .
+// IWYU_ARGS: -I . -Xiwyu --check_also="tests/cxx/*-d2.h"
 
 // Tests handling default type template arguments. In particular, that IWYU
 // doesn't crash when they refer to uninstantiated template specializations.
@@ -43,6 +43,63 @@ struct Outer2 {
 // of an internal template on instantiation side.
 // IWYU: IndirectTemplate needs a declaration
 Outer2<int, IndirectTemplate<int>> o2;
+
+template <typename = int, typename>
+// IWYU: ClassTpl is...*default_tpl_arg-i1.h
+class ClassTpl;
+
+// Test that IWYU doesn't remap the required declaration to the definition and
+// hence reports it here.
+template <typename = int, typename>
+// IWYU: ClassTplWithDefinition is...*default_tpl_arg-i1.h
+class ClassTplWithDefinition {};
+
+template <typename = int, typename>
+// IWYU: VarTpl is...*default_tpl_arg-i1.h
+extern int VarTpl;
+
+// No need to report anything here.
+template <typename, typename>
+using AliasTpl1 = int;
+template <int, int>
+using AliasTpl2 = int;
+template <template <int> typename, template <int> typename>
+using AliasTpl3 = int;
+
+template <typename = int, typename>
+// IWYU: AliasTpl1 is...*default_tpl_arg-i1.h
+using AliasTpl1 = int;
+
+template <typename = int, typename>
+void FnTpl();
+
+template <int = 0, int>
+// IWYU: AliasTpl2 is...*default_tpl_arg-i1.h
+using AliasTpl2 = int;
+
+// IWYU: SomeTpl is...*default_tpl_arg-i1.h
+template <template <int> typename = SomeTpl, template <int> typename>
+// IWYU: AliasTpl3 is...*default_tpl_arg-i1.h
+using AliasTpl3 = int;
+
+template <typename = int, int>
+// IWYU: AliasTpl4 is...*default_tpl_arg-i1.h
+using AliasTpl4 = int;
+
+// The needed redeclaration is in a directly included file.
+template <int = 0, int, int>
+using AliasTpl5 = int;
+
+// This redeclaration doesn't require any previous declaration to be present.
+template <int, int = 0>
+using AliasTpl6 = int;
+
+// The required redeclaration is the previous one.
+template <int = 0, int>
+using AliasTpl6 = int;
+
+// Just to avoid suggestion to remove unused forward-declaration.
+ClassTpl<>* class_tpl_ptr;
 
 void Fn() {
   // IWYU: FnWithNonProvidedDefaultTplArg is...*default_tpl_arg-i1.h
@@ -93,8 +150,9 @@ tests/cxx/default_tpl_arg.cc should remove these lines:
 - #include "tests/cxx/direct.h"  // lines XX-XX
 
 The full include-list for tests/cxx/default_tpl_arg.cc:
-#include "tests/cxx/default_tpl_arg-d2.h"  // for FnWithProvidedDefaultTplArg, FnWithProvidedDefaultTplArgAndDefaultCallArg1, FnWithProvidedDefaultTplArgAndDefaultCallArg2, FnWithProvidedDefaultTplArgAndDefaultCallArg3
-#include "tests/cxx/default_tpl_arg-i1.h"  // for FnWithNonProvidedDefaultTplArg, FnWithNonProvidedDefaultTplArgAndDefaultCallArg, NonProvidingAlias, UninstantiatedTpl
+#include "tests/cxx/default_tpl_arg-d2.h"  // for AliasTpl5, FnWithProvidedDefaultTplArg, FnWithProvidedDefaultTplArgAndDefaultCallArg1, FnWithProvidedDefaultTplArgAndDefaultCallArg2, FnWithProvidedDefaultTplArgAndDefaultCallArg3
+#include "tests/cxx/default_tpl_arg-i1.h"  // for AliasTpl1, AliasTpl2, AliasTpl3, AliasTpl4, ClassTpl, ClassTplWithDefinition, FnWithNonProvidedDefaultTplArg, FnWithNonProvidedDefaultTplArgAndDefaultCallArg, NonProvidingAlias, SomeTpl, UninstantiatedTpl, VarTpl
 #include "tests/cxx/indirect.h"  // for IndirectClass, IndirectTemplate
+template <typename = int, typename> class ClassTpl;  // lines XX-XX+2
 
 ***** IWYU_SUMMARY */


### PR DESCRIPTION
The change is similar to https://github.com/include-what-you-use/include-what-you-use/commit/90bf93b6955c7d8c04a98d5eb032f124af6f2b06 but it is for default template arguments.