### PR TITLE
[clang compat] Use getDecl instead of deprecated getOriginalDecl

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -5282,7 +5282,7 @@ class IwyuAstConsumer
           // The full definition is reported to support the cases when fwd-decl
           // uses are recategorized to full uses.
           ReportDeclForwardDeclareUse(
-              CurrentLoc(), type->getOriginalDecl()->getDefinitionOrSelf());
+              CurrentLoc(), type->getDecl()->getDefinitionOrSelf());
         }
       } else {
         // In C, all struct references are elaborated, so we really never need
@@ -5301,14 +5301,14 @@ class IwyuAstConsumer
           // The full definition is reported to support the cases when fwd-decl
           // uses are recategorized to full uses.
           ReportDeclForwardDeclareUse(
-              CurrentLoc(), type->getOriginalDecl()->getDefinitionOrSelf());
+              CurrentLoc(), type->getDecl()->getDefinitionOrSelf());
         }
       }
       return Base::VisitTagType(type);
     }
 
     // OK, seems to be a use that requires the full type.
-    ReportDeclUse(CurrentLoc(), type->getOriginalDecl(), comment);
+    ReportDeclUse(CurrentLoc(), type->getDecl(), comment);
     return Base::VisitTagType(type);
   }
 

--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -1583,15 +1583,15 @@ static const NamedDecl* TypeToDeclImpl(const Type* type, bool as_written) {
                  type->getAs<InjectedClassNameType>()) {
     // TODO(bolshakov): is getDefinitionOrSelf() needed here? Is this branch
     // useful at all?
-    return icn_type->getOriginalDecl()->getDefinitionOrSelf();
+    return icn_type->getDecl()->getDefinitionOrSelf();
   } else if (as_written && template_decl &&
              isa<TypeAliasTemplateDecl, BuiltinTemplateDecl>(template_decl)) {
     // A template type alias
     return template_decl;
   } else if (const RecordType* record_type = type->getAs<RecordType>()) {
-    return record_type->getOriginalDecl()->getDefinitionOrSelf();
+    return record_type->getDecl()->getDefinitionOrSelf();
   } else if (const TagType* tag_type = DynCastFrom(type)) {
-    return tag_type->getOriginalDecl();  // probably just enums
+    return tag_type->getDecl();  // probably just enums
   } else if (template_decl) {
     // A non-concrete template class, such as 'Myclass<T>'
     return template_decl;
@@ -1747,7 +1747,7 @@ TemplateInstantiationData GetTplInstDataForClass(
 }
 
 bool CanBeOpaqueDeclared(const EnumType* type) {
-  return type->getOriginalDecl()->isFixed();
+  return type->getDecl()->isFixed();
 }
 
 vector<const Type*> GetCanonicalArgComponents(
@@ -1974,8 +1974,8 @@ bool CompatibilityChecker::CouldBeCompatible(QualType lhs,
   } else if (const auto* rhs_enum = rhs->getAs<EnumType>()) {
     if (const auto* lhs_enum = lhs->getAs<EnumType>()) {
       // IWYU transforms opaque decls to definitions inside ReportFullSymbolUse.
-      const EnumDecl* rhs_decl = rhs_enum->getOriginalDecl();
-      const EnumDecl* lhs_decl = lhs_enum->getOriginalDecl();
+      const EnumDecl* rhs_decl = rhs_enum->getDecl();
+      const EnumDecl* lhs_decl = lhs_enum->getDecl();
       // TODO(bolshakov): handle unnamed enums?
       if (lhs_decl->getIdentifier() != rhs_decl->getIdentifier())
         return false;

--- a/iwyu_output.cc
+++ b/iwyu_output.cc
@@ -538,7 +538,7 @@ OneIncludeOrForwardDeclareLine::OneIncludeOrForwardDeclareLine(
     : is_desired_(true),
       is_present_(true),
       is_elaborated_type_(true),
-      fwd_decl_(type_loc.getTypePtr()->getOriginalDecl()) {
+      fwd_decl_(type_loc.getTypePtr()->getDecl()) {
   const SourceRange decl_lines = type_loc.getLocalSourceRange();
   start_linenum_ = GetLineNumber(GetInstantiationLoc(decl_lines.getBegin()));
   end_linenum_ = GetLineNumber(GetInstantiationLoc(decl_lines.getEnd()));


### PR DESCRIPTION
TagType::getOriginalDecl was a transit name to ease some large-scale refactoring in clang.

The correct semantics have been restored to getDecl, and getOriginalDecl is just left as a deprecated alias:
https://github.com/llvm/llvm-project/commit/b516dcc998d06c97d874af543489887f7e5a680c

Use getDecl consistently.