### PR TITLE
Avoid wrong template fwd-decl due to explicit spec

### DIFF
--- a/tests/cxx/default_tpl_arg-i1.h
+++ b/tests/cxx/default_tpl_arg-i1.h
@@ -67,4 +67,7 @@ using AliasTpl5 = int;
 template <int, int>
 using AliasTpl6 = int;
 
+template <typename T = int>
+class SpecializedClassTpl {};
+
 #endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_DEFAULT_TPL_ARG_I1_H_

--- a/tests/cxx/default_tpl_arg.cc
+++ b/tests/cxx/default_tpl_arg.cc
@@ -101,6 +101,13 @@ using AliasTpl6 = int;
 // Just to avoid suggestion to remove unused forward-declaration.
 ClassTpl<>* class_tpl_ptr;
 
+// IWYU: SpecializedClassTpl is...*default_tpl_arg-i1.h
+SpecializedClassTpl<int>* pscti;
+
+template <>
+// IWYU: SpecializedClassTpl is...*default_tpl_arg-i1.h
+class SpecializedClassTpl<int> {};
+
 void Fn() {
   // IWYU: FnWithNonProvidedDefaultTplArg is...*default_tpl_arg-i1.h
   // IWYU: IndirectClass is...*indirect.h
@@ -151,7 +158,7 @@ tests/cxx/default_tpl_arg.cc should remove these lines:
 
 The full include-list for tests/cxx/default_tpl_arg.cc:
 #include "tests/cxx/default_tpl_arg-d2.h"  // for AliasTpl5, FnWithProvidedDefaultTplArg, FnWithProvidedDefaultTplArgAndDefaultCallArg1, FnWithProvidedDefaultTplArgAndDefaultCallArg2, FnWithProvidedDefaultTplArgAndDefaultCallArg3
-#include "tests/cxx/default_tpl_arg-i1.h"  // for AliasTpl1, AliasTpl2, AliasTpl3, AliasTpl4, ClassTpl, ClassTplWithDefinition, FnWithNonProvidedDefaultTplArg, FnWithNonProvidedDefaultTplArgAndDefaultCallArg, NonProvidingAlias, SomeTpl, UninstantiatedTpl, VarTpl
+#include "tests/cxx/default_tpl_arg-i1.h"  // for AliasTpl1, AliasTpl2, AliasTpl3, AliasTpl4, ClassTpl, ClassTplWithDefinition, FnWithNonProvidedDefaultTplArg, FnWithNonProvidedDefaultTplArgAndDefaultCallArg, NonProvidingAlias, SomeTpl, SpecializedClassTpl, UninstantiatedTpl, VarTpl
 #include "tests/cxx/indirect.h"  // for IndirectClass, IndirectTemplate
 template <typename = int, typename> class ClassTpl;  // lines XX-XX+2
 

--- a/tests/cxx/explicit_instantiation.cc
+++ b/tests/cxx/explicit_instantiation.cc
@@ -15,6 +15,13 @@
 #include "tests/cxx/explicit_instantiation-template_direct.h"
 #include "tests/cxx/explicit_instantiation-template2.h"
 
+// The explicit instantiation of a specialization only needs a declaration
+// of the base template.
+template <>
+// IWYU: Template needs a declaration
+class Template<char*> {};
+extern template class Template<char*>;
+
 // Test that all explicit instantiations variants of the base template
 // require the full type:
 
@@ -34,8 +41,8 @@ template class Template<double>;
 
 
 // The explicit instantiation of a specialization only needs a declaration
-// of the base template
-// IWYU: Template needs a declaration
+// of the base template, but it should already be present because there are
+// other Template specializations defined in this file above.
 template<> class Template<char> {};
 extern template class Template<char>;
 

--- a/tests/cxx/reexport_overridden-d1.h
+++ b/tests/cxx/reexport_overridden-d1.h
@@ -62,6 +62,7 @@ class Derived1 : public Base {
   void TakeAliasedInBaseParam(IndirectClass) override;
 
   void TakeTemplate(IndirectTemplate<IndirectClass>) override;
+  void TakeSpecializedTemplate(IndirectTemplate<int>&) override;
 
   // IWYU: TemplatePtrAlias is...*reexport_overridden-i3.h
   void TakeAliasedTemplatePtr(TemplatePtrAlias) override;

--- a/tests/cxx/reexport_overridden-i1.h
+++ b/tests/cxx/reexport_overridden-i1.h
@@ -29,6 +29,7 @@ class Base {
   virtual void TakeNoConvParam(IndirectClass);
   virtual void TakeAliasedInBaseParam(Alias);
   virtual void TakeTemplate(IndirectTemplate<IndirectClass>);
+  virtual void TakeSpecializedTemplate(IndirectTemplate<int>&);
   virtual void TakeAliasedTemplatePtr(TemplatePtrAlias);
   virtual void TakePulledInOtherNSInDerived(IndirectClass);
   virtual OuterTpl<IndirectClass>::Inner GetNestedInTpl();

--- a/tests/cxx/reexport_overridden.cc
+++ b/tests/cxx/reexport_overridden.cc
@@ -77,12 +77,24 @@ void Derived1::TakeNoConvParam(Alias arg) {
 void Derived1::TakeTemplate(IndirectTemplate<IndirectClass>) {
 }
 
+void Derived1::TakeSpecializedTemplate(IndirectTemplate<int>& r) {
+  // No need to forward-declare IndirectTemplate.
+  IndirectTemplate<int>& r2 = r;
+}
+
 // IWYU: TemplatePtrAlias is...*reexport_overridden-i3.h
 void Derived1::TakeAliasedTemplatePtr(TemplatePtrAlias p1) {
   // No need to forward-declare IndirectTemplate or IndirectClass.
   IndirectTemplate<IndirectClass>* p2 = p1;
   IndirectClass* p = nullptr;
 }
+
+// This explicit specialization definition is not fully used, therefore may be
+// placed at the very bottom so as not to mess the analysis with the presence
+// of a definition providing the class template declaration.
+template <>
+// IWYU: IndirectTemplate needs a declaration
+class IndirectTemplate<int> {};
 
 void Fn() {
   // Test that IWYU uses the most basic method declarations for


### PR DESCRIPTION
Prior to this, `SpecializedClassTpl<int>* pscti;` followed by an explicit specialization of the template caused a forward-declaration suggestion even if the primary template has default template arguments, which resulted in uncompilable code. Despite at A2 stage it was recategorized to full use, at B2 stage it was recategorized back to fwd-decl use because the referred declaration was after the use. An analogous problem with explicit instantiations was solved in #1556 by means of `GetInstantiatedFromDecl` call, but it did not work with explicit specializations because they are not instantiated.

The main change is in `VisitTemplateSpecializationType`. It reports now primary template declarations for fwd-decl uses and not any specialization. For the full use reporting, the `GetInstantiatedFromDecl` removal should not change behavior because it is anyway called later inside `GetDefinitionAsWritten` call from `ReportFullSymbolUse`.

The change in `iwyu_output.cc` is just to maintain the behavior proposed in #735. Including a file containing any template specialization definition is considered like including the primary template defining file for the purpose of determining if a forward-declaration should be suggested. Note that explicit instantiation declarations are considered as definitions. Not sure if a short-circuiting of implicit instantiations is worth placing for optimization.
`DeclIsVisibleToUseInSameFile` call has been replaced with `IsBeforeInSameFile` because the former returns true also when the locations coincide, and class template explicit specializations would be considered as primary template forward-decl providers for itself.