### PR TITLE
Strengthen semantics of IsHeaderFile

### DIFF
--- a/iwyu_output.cc
+++ b/iwyu_output.cc
@@ -1657,7 +1657,7 @@ void CalculateIwyuForFullUse(OneUse* use,
   // iwyu will say 'replace the #include of y.h with an #include of
   // x.cc,' which the code below will then strip.  The end result is
   // z.cc will not #include anything, and will fail to compile.
-  if (!IsHeaderFile(use->suggested_header()) &&
+  if (!IsQuotedHeaderFilename(use->suggested_header()) &&
       !ContainsKey(actual_includes, use->suggested_header())) {
     VERRS(6) << "Ignoring use of " << use->symbol_name()
              << " (" << use->PrintableUseLoc() << "): #including .cc\n";
@@ -1726,10 +1726,10 @@ void IwyuFileInfo::CalculateIwyuViolations(vector<OneUse>* uses) {
       quoted_file_, direct_includes(), associated_desired_includes, uses);
 
   // (C4) Remove .cc files from desired-includes unless they're in actual-inc.
-  for (const string& header_name : desired_set_cover) {
-    if (IsHeaderFile(header_name) ||
-        ContainsKey(direct_includes(), header_name))
-      desired_includes_.insert(header_name);
+  for (const string& quoted_include : desired_set_cover) {
+    if (IsQuotedHeaderFilename(quoted_include) ||
+        ContainsKey(direct_includes(), quoted_include))
+      desired_includes_.insert(quoted_include);
   }
   desired_includes_have_been_calculated_ = true;
 

--- a/iwyu_path_util.cc
+++ b/iwyu_path_util.cc
@@ -55,20 +55,29 @@ const vector<HeaderSearchPath>& HeaderSearchPaths() {
   return *header_search_paths;
 }
 
-bool IsHeaderFile(StringRef path) {
-  if (EndsWith(path, "\"") || EndsWith(path, ">"))
-    path = path.substr(0, path.size() - 1);
+bool IsHeaderFilename(StringRef path) {
+  if (IsSpecialFilename(path))
+    return false;
+
+  CHECK_(!IsQuotedInclude(path));
 
   // Some headers don't have an extension (e.g. <string>), or have an
   // unusual one (the compiler doesn't care), so it's safer to
   // enumerate non-header extensions instead.
-  //  for (size_t i = 0; i < llvm::array_lengthof(source_extensions); ++i) {
   for (const char* source_extension : source_extensions) {
-    if (EndsWith(path, source_extension))
+    if (path.ends_with(source_extension))
       return false;
   }
-
   return true;
+}
+
+bool IsQuotedHeaderFilename(StringRef quoted_include) {
+  if (IsSpecialFilename(quoted_include))
+    return false;
+
+  CHECK_(IsQuotedInclude(quoted_include));
+  StringRef path = quoted_include.substr(1, quoted_include.size() - 2);
+  return IsHeaderFilename(path);
 }
 
 string Basename(StringRef path) {

--- a/iwyu_path_util.h
+++ b/iwyu_path_util.h
@@ -36,9 +36,11 @@ struct HeaderSearchPath {
 void SetHeaderSearchPaths(const vector<HeaderSearchPath>& search_paths);
 const vector<HeaderSearchPath>& HeaderSearchPaths();
 
-// Returns true if 'path' is a path of a (possibly enclosed in double
-// quotes or <>) C++ header file.
-bool IsHeaderFile(StringRef path);
+// Returns true if 'path' is a path of a C++ header file.
+bool IsHeaderFilename(StringRef path);
+
+// Returns true if 'quoted_include' contains a path of a C++ header file.
+bool IsQuotedHeaderFilename(StringRef quoted_include);
 
 // If the path has a slash, return the part after the last slash,
 // else return the input path.

--- a/iwyu_preprocessor.cc
+++ b/iwyu_preprocessor.cc
@@ -507,9 +507,9 @@ void IwyuPreprocessorInfo::MaybeProtectInclude(
     }
 
   // We also always keep #includes of .c files: iwyu doesn't touch those.
-  // TODO(csilvers): instead of IsHeaderFile, check if the file has
+  // TODO(csilvers): instead of IsHeaderFilename, check if the file has
   // any "non-inlined" definitions.
-  } else if (!IsHeaderFile(GetFilePath(includee))) {
+  } else if (!IsHeaderFilename(GetFilePath(includee))) {
     protect_reason = ".cc include";
 
   // If the includee is marked as pch-in-code, it can never be removed.


### PR DESCRIPTION
IsHeaderFile used to accept both quoted includes and plain paths.

It also did not handle Clang's special filenames, none of which refer to headers, but would be classified as such because they don't have a file extension.

Split the function into IsHeaderFilename and IsQuotedHeaderFilename, where the latter unpacks quoted-includes. Add assertions to uphold the assumptions about quoted-includes vs. paths. Detect special filenames in both functions.

Remove a left-over commented-out loop from
137907952c20c3b8df7114c41b4651adac7547fe.

No functional change in the current test suite.