### PR TITLE
Make '<stdin>' a special filename

### DIFF
--- a/iwyu_output.cc
+++ b/iwyu_output.cc
@@ -310,7 +310,7 @@ OneUse::OneUse(const string& symbol_name, OptionalFileEntryRef dfn_file,
       is_iwyu_violation_(false) {
   CHECK_(dfn_file && "OneUse: dfn_file must be set");
   CHECK_(!decl_filepath_.empty() && "OneUse: dfn_file must have a name");
-  CHECK_(decl_filepath_ == "<stdin>" || !IsQuotedInclude(decl_filepath_))
+  CHECK_(IsSpecialFilename(decl_filepath_) || !IsQuotedInclude(decl_filepath_))
       << ": OneUse: dfn_file must have a real name, was: " << decl_filepath_;
 }
 

--- a/iwyu_path_util.cc
+++ b/iwyu_path_util.cc
@@ -90,8 +90,7 @@ string Basename(StringRef path) {
 
 string GetCanonicalName(string file_path) {
   // Clang special filenames are already canonical.
-  // <stdin> is not a special filename, but it's canonical too.
-  if (IsSpecialFilename(file_path) || file_path == "<stdin>")
+  if (IsSpecialFilename(file_path))
     return file_path;
 
   // All known special filenames which look like quoted-includes are handled
@@ -223,6 +222,12 @@ string AddQuotes(string include_name, bool angled) {
       return "<" + include_name + ">";
   }
   return "\"" + include_name + "\"";
+}
+
+bool IsSpecialFilename(StringRef name) {
+  return (name == "<built-in>" || name == "<command line>" ||
+          name == "<scratch space>" || name == "<inline asm>" ||
+          name == "<stdin>");
 }
 
 string PathJoin(StringRef dirpath, StringRef relative_path) {

--- a/iwyu_path_util.h
+++ b/iwyu_path_util.h
@@ -87,17 +87,14 @@ string ConvertToQuotedInclude(StringRef filepath,
 // Returns true if the string is a quoted include.
 bool IsQuotedInclude(StringRef s);
 
-// Returns true if argument is one of the special filenames used by Clang for
-// implicit buffers ("<built-in>", "<command-line>", etc).
-inline bool IsSpecialFilename(StringRef name) {
-  return (name == "<built-in>" || name == "<command line>" ||
-          name == "<scratch space>" || name == "<inline asm>");
-}
-
 // Returns include name enclosed in double quotes or angle quotes, depending on
 // the angled flag. An include name is the unquoted relative name that would be
 // used on an include line, e.g. lib/mytype.h or stdio.h.
 string AddQuotes(string include_name, bool angled);
+
+// Returns true if argument is one of the special filenames used by Clang for
+// implicit buffers ("<built-in>", "<command-line>", etc).
+bool IsSpecialFilename(StringRef name);
 
 // Append path to dirpath.
 string PathJoin(StringRef dirpath, StringRef relative_path);


### PR DESCRIPTION
Clang sets the filename for source text coming from stdin to `<stdin>`. In most places where IsSpecialFilename was checked, stdin was also checked separately.

Consider it a special filename and simplify callers. Move
IsSpecialFilename out-of-line.

Allow any special filename in OneUse constructor, not just `<stdin>`.