### PR TITLE
Don't consider special filenames quoted-includes

### DIFF
--- a/iwyu_include_picker.cc
+++ b/iwyu_include_picker.cc
@@ -1539,8 +1539,8 @@ MappedInclude::MappedInclude(const string& q, const string& p)
   : quoted_include(q)
   , path(p)
 {
-  CHECK_(IsQuotedInclude(quoted_include)) <<
-    "Must be quoted include, was: " << quoted_include;
+  CHECK_(IsSpecialFilename(quoted_include) || IsQuotedInclude(quoted_include))
+      << "Must be special or quoted include, was: " << quoted_include;
 }
 
 bool MappedInclude::HasAbsoluteQuotedInclude() const {


### PR DESCRIPTION
IsQuotedInclude would classify Clang's special filenames as
quoted-includes because they are decorated with angle-brackets.

Strengthen the validation in IsQuotedInclude so that:

* Empty quotes or angle brackets are not quote-includes
* For angle-bracketed values, only non-special filenames can be
  quoted-includes

Adjust MappedInclude constructor, which is occasionally set up to map
the built-in special file.

Also move assertions for IsQuotedInclude before any special-filename
validation, now that they don't depend on each other.
