### PR TITLE
Make IsHeaderFile more reliable

### DIFF
--- a/iwyu_location_util.cc
+++ b/iwyu_location_util.cc
@@ -199,10 +199,10 @@ bool IsInScratchSpace(SourceLocation loc) {
 
 bool IsHeaderFile(OptionalFileEntryRef file) {
   if (!file) {
-    // Not sure what's going on, but we're not in a header.
+    // A null file is considered <built-in> -- not a header.
     return false;
   }
-  return !GlobalSourceManager()->isMainFile(file->getFileEntry());
+  return IsHeaderFilename(file->getName());
 }
 
 bool IsSystemHeader(OptionalFileEntryRef file) {

--- a/iwyu_preprocessor.cc
+++ b/iwyu_preprocessor.cc
@@ -507,9 +507,9 @@ void IwyuPreprocessorInfo::MaybeProtectInclude(
     }
 
   // We also always keep #includes of .c files: iwyu doesn't touch those.
-  // TODO(csilvers): instead of IsHeaderFilename, check if the file has
-  // any "non-inlined" definitions.
-  } else if (!IsHeaderFilename(GetFilePath(includee))) {
+  // TODO(csilvers): instead of IsHeaderFile, check if the file has any
+  // "non-inlined" definitions.
+  } else if (!IsHeaderFile(includee)) {
     protect_reason = ".cc include";
 
   // If the includee is marked as pch-in-code, it can never be removed.


### PR DESCRIPTION
Our original implementation used SourceManager::isMainFile to decide whether a file was a header or not. Any file except the main file were considered a header.

We use the IsHeader predicates to make policy decisions around the conventional use of headers in C languages, and those decisions should depend on the name of the file, not its role in compilation.

There were two problems with the old implementation:

* Using the flags '-xc-header foo.h' to analyze a header file would not classify foo.h as a header internally (because it's the main file)
* Including a .c file using '#include "foo.c"' would falsely classify that .c file as a header (because it's _not_ the main file)

Reimplement IsHeader in terms of IsHeaderFilename, now that the latter has clearer semantics. This means any filename not in the set of known source-file extensions will be classified as a header.

This improvement makes it possible to use IsHeaderFile rather than IsHeaderFilename(GetFilePath()) in MaybeProtectInclude to detect .c includes, so update that.