### PR TITLE
Select tpl redecl with def arg needed at use site

### DIFF
--- a/iwyu_ast_util.h
+++ b/iwyu_ast_util.h
@@ -755,6 +755,16 @@ bool IsDefArgSpecified(unsigned i, const clang::FunctionDecl*);
 clang::FunctionDecl* GetRedeclSpecifyingDefArg(unsigned i,
                                                clang::FunctionDecl*);
 
+// Returns the redeclaration specifying default template argument for the i-th
+// parameter. Expects that there is one.
+const clang::TemplateDecl* GetRedeclSpecifyingDefArg(
+    unsigned i, const clang::TemplateDecl*);
+
+// Returns a redeclaration that doesn't depend on any other redeclaration, i.e.
+// the one that doesn't specify any default template argument if there is one,
+// otherwise returns the declaration specifying the last default argument.
+const clang::NamedDecl* GetIndependentRedecl(const clang::NamedDecl*);
+
 // Returns true if the given template parameter declaration does not specify
 // a default argument explicitly but inherits it from some of the previous
 // template declarations. Expects that the given NamedDecl is actually

--- a/tests/cxx/default_tpl_arg-d2.h
+++ b/tests/cxx/default_tpl_arg-d2.h
@@ -41,6 +41,9 @@ template <int, int = 0, int>
 // IWYU: AliasTpl5 is...*default_tpl_arg-i1.h
 using AliasTpl5 = int;
 
+// IWYU: ClassTpl2 is...*default_tpl_arg-i1.h
+ClassTpl2<>& GetClassTpl2Ref();
+
 /**** IWYU_SUMMARY
 
 tests/cxx/default_tpl_arg-d2.h should add these lines:
@@ -50,7 +53,7 @@ tests/cxx/default_tpl_arg-d2.h should remove these lines:
 - #include "tests/cxx/default_tpl_arg-d1.h"  // lines XX-XX
 
 The full include-list for tests/cxx/default_tpl_arg-d2.h:
-#include "tests/cxx/default_tpl_arg-i1.h"  // for AliasTpl5
+#include "tests/cxx/default_tpl_arg-i1.h"  // for AliasTpl5, ClassTpl2
 #include "tests/cxx/indirect.h"  // for IndirectClass
 
 ***** IWYU_SUMMARY */

--- a/tests/cxx/default_tpl_arg-i1.h
+++ b/tests/cxx/default_tpl_arg-i1.h
@@ -10,6 +10,11 @@
 #ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_DEFAULT_TPL_ARG_I1_H_
 #define INCLUDE_WHAT_YOU_USE_TESTS_CXX_DEFAULT_TPL_ARG_I1_H_
 
+// The order of includes is important: it is assumed that clang selects the last
+// declaration during lookup.
+#include "tests/cxx/default_tpl_arg-i2.h"
+#include "tests/cxx/default_tpl_arg-i3.h"
+
 template <typename T>
 struct UninstantiatedTpl {
   T t;
@@ -72,5 +77,20 @@ class SpecializedClassTpl {};
 
 template <typename = int>
 class ClassTplNoDefinition;
+
+template <typename = int, typename>
+class ClassTpl2;
+
+template <typename = int>
+class ClassTplWithDefinition2;
+
+template <typename>
+class ClassTpl4;
+
+template <typename = int>
+class ClassTpl4;
+
+template <typename = int, typename>
+using AliasTpl7 = int;
 
 #endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_DEFAULT_TPL_ARG_I1_H_

--- a/tests/cxx/default_tpl_arg-i2.h
+++ b/tests/cxx/default_tpl_arg-i2.h
@@ -1,0 +1,23 @@
+//===--- default_tpl_arg-i2.h - test input file for iwyu ------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+template <typename, typename = int>
+class ClassTpl2;
+
+template <typename>
+class ClassTplWithDefinition2 {};
+
+template <typename>
+class ClassTplWithDefinition3 {};
+
+template <typename = int>
+class ClassTplWithDefinition7 {};
+
+template <typename, typename = int>
+using AliasTpl7 = int;

--- a/tests/cxx/default_tpl_arg-i3.h
+++ b/tests/cxx/default_tpl_arg-i3.h
@@ -1,0 +1,29 @@
+//===--- default_tpl_arg-i3.h - test input file for iwyu ------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// This header should not be suggested for inclusion into .cc-file so as to be
+// able to test that correct form of template forward-declaration is suggested.
+
+template <typename>
+class ClassTplWithDefinition4;
+
+template <typename = int>
+class ClassTplWithDefinition4 {};
+
+template <typename = int>
+class ClassTplWithDefinition5;
+
+template <typename>
+class ClassTplWithDefinition5 {};
+
+template <typename = int>
+class ClassTplWithDefinition6 {};
+
+template <typename>
+class ClassTplWithDefinition7;

--- a/tests/cxx/default_tpl_arg.cc
+++ b/tests/cxx/default_tpl_arg.cc
@@ -9,7 +9,7 @@
 
 // IWYU_ARGS: -I . -Xiwyu --check_also="tests/cxx/*-d2.h"
 
-// Tests handling default type template arguments. In particular, that IWYU
+// Tests handling default template arguments. In particular, that IWYU
 // doesn't crash when they refer to uninstantiated template specializations.
 
 #include "tests/cxx/default_tpl_arg-d1.h"
@@ -101,6 +101,13 @@ using AliasTpl6 = int;
 // Just to avoid suggestion to remove unused forward-declaration.
 ClassTpl<>* class_tpl_ptr;
 
+// TODO: no need to report in these two cases because the redeclaration that is
+// already present in this file should "pull" the needed one.
+// IWYU: ClassTpl is...*default_tpl_arg-i1.h
+ClassTpl<int>* sufficient_redecl_present_in_this_file1;
+// IWYU: ClassTpl is...*default_tpl_arg-i1.h
+ClassTpl<int, int>* sufficient_redecl_present_in_this_file2;
+
 // IWYU: SpecializedClassTpl is...*default_tpl_arg-i1.h
 SpecializedClassTpl<int>* pscti;
 
@@ -110,6 +117,77 @@ class SpecializedClassTpl<int> {};
 
 // IWYU: ClassTplNoDefinition is...*default_tpl_arg-i1.h
 ClassTplNoDefinition<>* p_class_tpl_no_def;
+
+// IWYU: ClassTpl2 is...*default_tpl_arg-i1.h
+ClassTpl2<>* use_i1_class_tpl_decl;
+// IWYU: ClassTpl2 is...*default_tpl_arg-i2.h
+ClassTpl2<int>* use_i2_class_tpl_decl;
+// TODO: a forward-declaration is allowed for this case.
+// IWYU: ClassTpl2 is...*default_tpl_arg-i2.h
+ClassTpl2<int, int>* all_class_tpl_args_specified_explicitly;
+
+// IWYU: ClassTplWithDefinition2 is...*default_tpl_arg-i1.h
+ClassTplWithDefinition2<>* fwd_decl_use_cls_tpl_with_def1;
+// IWYU: ClassTplWithDefinition2 needs a declaration
+ClassTplWithDefinition2<int>* fwd_decl_use_cls_tpl_with_def2;
+// "*-i1.h" for the default argument, "*-i2.h" for the definition.
+// IWYU: ClassTplWithDefinition2 is...*default_tpl_arg-i1.h
+// IWYU: ClassTplWithDefinition2 is...*default_tpl_arg-i2.h
+ClassTplWithDefinition2<> full_use_cls_tpl_with_def1;
+// IWYU: ClassTplWithDefinition2 is...*default_tpl_arg-i2.h
+ClassTplWithDefinition2<int> full_use_cls_tpl_with_def2;
+
+// Test that IWYU doesn't suggest removing these as unused fwd-declarations.
+template <typename = int>
+class ClassTpl3;
+template <typename = int>
+class ClassTplWithDefinition3;
+
+ClassTpl3<>* class_tpl_3_fwd_decl_use;
+// IWYU: ClassTplWithDefinition3 is...*default_tpl_arg-i2.h
+ClassTplWithDefinition3<> cls_tpl_with_def_3_full_use;
+
+// IWYU: ClassTpl4 needs a declaration
+ClassTpl4<int>* cls_tpl_4_fwd_decl_use;
+// Test correct form of the forward-declaration in the IWYU summary below.
+// IWYU: ClassTplWithDefinition4 needs a declaration
+ClassTplWithDefinition4<int>* cls_tpl_with_def_4_fwd_decl_use;
+// IWYU: ClassTplWithDefinition5 needs a declaration
+ClassTplWithDefinition5<int>* cls_tpl_with_def_5_fwd_decl_use;
+
+template <typename>
+class ClassTplWithDefinition6;
+ClassTplWithDefinition6<int>* cls_tpl_with_def_6_fwd_decl_use;
+
+// IWYU: ClassTplWithDefinition7 is...*default_tpl_arg-i2.h
+ClassTplWithDefinition7<> cls_tpl_with_def_7_full_use1;
+// IWYU: ClassTplWithDefinition7 is...*default_tpl_arg-i2.h
+ClassTplWithDefinition7<>* cls_tpl_with_def_7_fwd_decl_use1;
+// IWYU: ClassTplWithDefinition7 is...*default_tpl_arg-i2.h
+ClassTplWithDefinition7<char> cls_tpl_with_def_7_full_use2;
+// IWYU: ClassTplWithDefinition7 needs a declaration
+ClassTplWithDefinition7<char>* cls_tpl_with_def_7_fwd_decl_use2;
+
+// IWYU: AliasTpl7 is...*default_tpl_arg-i1.h
+AliasTpl7<> i1;
+// IWYU: AliasTpl7 is...*default_tpl_arg-i2.h
+AliasTpl7<int> i2;
+// IWYU: AliasTpl7 is...*default_tpl_arg-i2.h
+AliasTpl7<int, int> i3;
+// IWYU: AliasTpl7 is...*default_tpl_arg-i1.h
+AliasTpl7<>* pi1;
+// IWYU: AliasTpl7 is...*default_tpl_arg-i2.h
+AliasTpl7<int>* pi2;
+// IWYU: AliasTpl7 is...*default_tpl_arg-i2.h
+AliasTpl7<int, int>* pi3;
+
+AliasTpl1<> i4;
+// TODO: no need to report here because the required declaration should be
+// already "pulled" by the one that specifies the second default argument and
+// is present in this file above.
+// IWYU: AliasTpl1 is...*default_tpl_arg-i1.h
+AliasTpl1<int> i5;
+AliasTpl1<int, int> i6;
 
 void Fn() {
   // IWYU: FnWithNonProvidedDefaultTplArg is...*default_tpl_arg-i1.h
@@ -147,22 +225,37 @@ void Fn() {
   // IndirectClass because it is provided by the templates.
   FnWithProvidedDefaultTplArgAndDefaultCallArg2();
   FnWithProvidedDefaultTplArgAndDefaultCallArg3();
+
+  auto& class_tpl_2_ref = GetClassTpl2Ref();
+  // No need to report anything here.
+  [&class_tpl_2_ref] {}();
 }
 
 /**** IWYU_SUMMARY
 
 tests/cxx/default_tpl_arg.cc should add these lines:
 #include "tests/cxx/default_tpl_arg-i1.h"
+#include "tests/cxx/default_tpl_arg-i2.h"
 #include "tests/cxx/indirect.h"
+template <typename> class ClassTpl4;
+template <typename> class ClassTplWithDefinition4;
+template <typename> class ClassTplWithDefinition5;
 
 tests/cxx/default_tpl_arg.cc should remove these lines:
 - #include "tests/cxx/default_tpl_arg-d1.h"  // lines XX-XX
 - #include "tests/cxx/direct.h"  // lines XX-XX
 
 The full include-list for tests/cxx/default_tpl_arg.cc:
-#include "tests/cxx/default_tpl_arg-d2.h"  // for AliasTpl5, FnWithProvidedDefaultTplArg, FnWithProvidedDefaultTplArgAndDefaultCallArg1, FnWithProvidedDefaultTplArgAndDefaultCallArg2, FnWithProvidedDefaultTplArgAndDefaultCallArg3
-#include "tests/cxx/default_tpl_arg-i1.h"  // for AliasTpl1, AliasTpl2, AliasTpl3, AliasTpl4, ClassTpl, ClassTplNoDefinition, ClassTplWithDefinition, FnWithNonProvidedDefaultTplArg, FnWithNonProvidedDefaultTplArgAndDefaultCallArg, NonProvidingAlias, SomeTpl, SpecializedClassTpl, UninstantiatedTpl, VarTpl
+#include "tests/cxx/default_tpl_arg-d2.h"  // for AliasTpl5, FnWithProvidedDefaultTplArg, FnWithProvidedDefaultTplArgAndDefaultCallArg1, FnWithProvidedDefaultTplArgAndDefaultCallArg2, FnWithProvidedDefaultTplArgAndDefaultCallArg3, GetClassTpl2Ref
+#include "tests/cxx/default_tpl_arg-i1.h"  // for AliasTpl1, AliasTpl2, AliasTpl3, AliasTpl4, AliasTpl7, ClassTpl, ClassTpl2, ClassTplNoDefinition, ClassTplWithDefinition, ClassTplWithDefinition2, FnWithNonProvidedDefaultTplArg, FnWithNonProvidedDefaultTplArgAndDefaultCallArg, NonProvidingAlias, SomeTpl, SpecializedClassTpl, UninstantiatedTpl, VarTpl
+#include "tests/cxx/default_tpl_arg-i2.h"  // for AliasTpl7, ClassTpl2, ClassTplWithDefinition2, ClassTplWithDefinition3, ClassTplWithDefinition7
 #include "tests/cxx/indirect.h"  // for IndirectClass, IndirectTemplate
 template <typename = int, typename> class ClassTpl;  // lines XX-XX+2
+template <typename = int> class ClassTpl3;  // lines XX-XX+1
+template <typename = int> class ClassTplWithDefinition3;  // lines XX-XX+1
+template <typename> class ClassTpl4;
+template <typename> class ClassTplWithDefinition4;
+template <typename> class ClassTplWithDefinition5;
+template <typename> class ClassTplWithDefinition6;  // lines XX-XX+1
 
 ***** IWYU_SUMMARY */


### PR DESCRIPTION
Mostly similar to https://github.com/include-what-you-use/include-what-you-use/commit/f39823818b962824c178873fa2fe0c3243f9fb42, but this is for class template and alias template default arguments. This doesn't fix behavior with variable and function templates.

This fixes the case reported in https://github.com/include-what-you-use/include-what-you-use/issues/1763#issuecomment-2949495499.