### PR TITLE
Avoid traversing deduced type of auto type

### DIFF
--- a/tests/cxx/deduced.cc
+++ b/tests/cxx/deduced.cc
@@ -16,6 +16,11 @@
 // IWYU: IndirectClass needs a declaration
 IndirectClass& GetRef();
 
+template <typename T>
+void TplFnNotRequiringFullType(T& t) {
+  [&ref_capture = t] {}();
+}
+
 // IWYU: IndirectClass needs a declaration
 void Fn(IndirectClass& i) {
   auto&& fwd_ref = i;
@@ -26,11 +31,14 @@ void Fn(IndirectClass& i) {
   auto param_copy = i;
   auto& param_ref1 = i;
   decltype(auto) param_ref2 = i;
+  [&ref_capture = i] {}();
 
   // IWYU: IndirectClass is...*indirect.h
   auto value = GetRef();
   auto& ref1 = GetRef();
   decltype(auto) ref2 = GetRef();
+
+  TplFnNotRequiringFullType(i);
 }
 
 /**** IWYU_SUMMARY


### PR DESCRIPTION
Prior to this, IWYU required complete type for the cases like
```cpp
[&ref1 = ref2]{}();
```
It was because IWYU traversed the (implicit) type in the ref1 declaration that appeared to be `AutoType` with the corresponding deduced underlying type, and then traversed that deduced type, but the presence of `AutoType` node broke the analysis inside `CanForwardDeclareType`.

For the most of the other auto type use cases, the AST nodes corresponding to a written auto type, surprisingly, don't have any deduced type, hence the problem did not arise.

I've decided not to special-case `CanForwardDeclareType` but to make `TraverseAutoTypeLoc` more similar to other sugar type traverse methods.

I'm not sure whether `TraverseAutoType` should be overloaded similarly.