### PR TITLE
Treat stdin separately from special files where appropriate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,10 @@ jobs:
           cd ./build
           CTEST_OUTPUT_ON_FAILURE=1 ctest -j 6
 
+      - name: Test include-what-you-use (stdin)
+        run: |
+          ./iwyu-run-stdin-tests.bash ./build/bin/include-what-you-use
+
       - name: Check if any known bugs were fixed
         run: |
           ./run_iwyu_tests.py --extra-suite=bugs bugs -- ./build/bin/include-what-you-use

--- a/iwyu-run-stdin-tests.bash
+++ b/iwyu-run-stdin-tests.bash
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+##===--- iwyu-run-stdin-tests.bash - run minimal stdin tests --------------===##
+#
+#                     The LLVM Compiler Infrastructure
+#
+# This file is distributed under the University of Illinois Open Source
+# License. See LICENSE.TXT for details.
+#
+##===----------------------------------------------------------------------===##
+
+# This is a stupidly minimal test runner to execute include-what-you-use over a
+# set of files input via stdin. It doesn't verify anything other than that
+# include-what-you-use completes without error (e.g. due to CHECK_ failures).
+# TODO: port this special run-mode into the real test runner.
+
+set -o pipefail
+
+if [ -n "$1" ]; then
+    iwyu="$(realpath $1)"
+else
+    iwyu="$(which include-what-you-use)"
+fi
+
+run_iwyu() {
+    local input="$1"
+    echo ">>> Running $iwyu -I . -xc++ - < $input:"
+    "$iwyu" -I . -xc++ - < "$input"
+}
+
+# Always run from root
+cd "$(git rev-parse --show-toplevel)"
+
+num_fail=0
+num_pass=0
+num_tests=0
+
+for input in tests/stdin/*.cc; do
+    if ! run_iwyu "$input" ; then
+        echo "FAILED: $input"
+        num_fail=$((num_fail+1))
+    else
+        num_pass=$((num_pass+1))
+    fi
+    num_tests=$((num_tests+1))
+    echo
+done
+
+echo "$((num_tests)) tests executed, $num_pass passed, $num_fail failed"
+exit $num_fail

--- a/iwyu_include_picker.cc
+++ b/iwyu_include_picker.cc
@@ -1539,7 +1539,8 @@ MappedInclude::MappedInclude(const string& q, const string& p)
   : quoted_include(q)
   , path(p)
 {
-  CHECK_(IsSpecialFilename(quoted_include) || IsQuotedInclude(quoted_include))
+  CHECK_(IsSpecialFilenameOrStdin(quoted_include) ||
+         IsQuotedInclude(quoted_include))
       << "Must be special or quoted include, was: " << quoted_include;
 }
 

--- a/iwyu_location_util.h
+++ b/iwyu_location_util.h
@@ -237,12 +237,26 @@ inline bool IsSpecialFile(clang::OptionalFileEntryRef file) {
   return IsSpecialFilename(file->getName());
 }
 
+// Returns true if argument is one of the special files or the semi-special file
+// "<stdin>". A null value is considered the same as "<built-in>".
+inline bool IsSpecialFileOrStdin(clang::OptionalFileEntryRef file) {
+  if (!file)
+    return true;
+  return IsSpecialFilenameOrStdin(file->getName());
+}
+
 // Returns true if obj is in a special file, as defined above.
 // Note that it also returns true for objects at invalid locations, as they
 // resolve to a null file.
 template <typename T>
 inline bool IsInSpecialFile(const T& obj) {
   return IsSpecialFile(GetFileEntry(obj));
+}
+
+// Returns true if obj is in a special file or stdin, as defined above.
+template <typename T>
+inline bool IsInSpecialFileOrStdin(const T& obj) {
+  return IsSpecialFileOrStdin(GetFileEntry(obj));
 }
 
 // Returns true if file is a header file (defined as not the main source file).

--- a/iwyu_output.cc
+++ b/iwyu_output.cc
@@ -310,8 +310,9 @@ OneUse::OneUse(const string& symbol_name, OptionalFileEntryRef dfn_file,
       is_iwyu_violation_(false) {
   CHECK_(dfn_file && "OneUse: dfn_file must be set");
   CHECK_(!decl_filepath_.empty() && "OneUse: dfn_file must have a name");
-  CHECK_(IsSpecialFilename(decl_filepath_) || !IsQuotedInclude(decl_filepath_))
-      << ": OneUse: dfn_file must have a real name, was: " << decl_filepath_;
+  CHECK_(!IsQuotedInclude(decl_filepath_))
+      << ": OneUse: dfn_file must not be a quoted include, was: "
+      << decl_filepath_;
 }
 
 OneUse::OneUse(OptionalFileEntryRef included_file, const string& quoted_include)

--- a/iwyu_path_util.cc
+++ b/iwyu_path_util.cc
@@ -59,7 +59,7 @@ const vector<HeaderSearchPath>& HeaderSearchPaths() {
 bool IsHeaderFilename(StringRef path) {
   CHECK_(!IsQuotedInclude(path));
 
-  if (IsSpecialFilename(path))
+  if (IsSpecialFilenameOrStdin(path))
     return false;
 
   // Some headers don't have an extension (e.g. <string>).
@@ -77,7 +77,7 @@ bool IsHeaderFilename(StringRef path) {
 bool IsQuotedHeaderFilename(StringRef quoted_include) {
   CHECK_(IsQuotedInclude(quoted_include));
 
-  if (IsSpecialFilename(quoted_include))
+  if (IsSpecialFilenameOrStdin(quoted_include))
     return false;
 
   StringRef path = quoted_include.substr(1, quoted_include.size() - 2);
@@ -97,7 +97,7 @@ string GetCanonicalName(string file_path) {
   CHECK_(!IsQuotedInclude(file_path));
 
   // Clang special filenames are already canonical.
-  if (IsSpecialFilename(file_path))
+  if (IsSpecialFilenameOrStdin(file_path))
     return file_path;
 
   file_path = NormalizeFilePath(file_path);
@@ -218,7 +218,7 @@ bool IsQuotedInclude(StringRef s) {
     return false;
 
   if (s.front() == '<' && s.back() == '>')
-    return !IsSpecialFilename(s);
+    return !IsSpecialFilenameOrStdin(s);
 
   return (s.front() == '"' && s.back() == '"');
 }
@@ -232,8 +232,11 @@ string AddQuotes(string include_name, bool angled) {
 
 bool IsSpecialFilename(StringRef name) {
   return (name == "<built-in>" || name == "<command line>" ||
-          name == "<scratch space>" || name == "<inline asm>" ||
-          name == "<stdin>");
+          name == "<scratch space>" || name == "<inline asm>");
+}
+
+bool IsSpecialFilenameOrStdin(StringRef name) {
+  return name == "<stdin>" || IsSpecialFilename(name);
 }
 
 string PathJoin(StringRef dirpath, StringRef relative_path) {

--- a/iwyu_path_util.h
+++ b/iwyu_path_util.h
@@ -96,6 +96,10 @@ string AddQuotes(string include_name, bool angled);
 // implicit buffers ("<built-in>", "<command-line>", etc).
 bool IsSpecialFilename(StringRef name);
 
+// Returns true if argument is one of the special filenames or the semi-special
+// "<stdin>" used by Clang for inputs read from stdin.
+bool IsSpecialFilenameOrStdin(StringRef name);
+
 // Append path to dirpath.
 string PathJoin(StringRef dirpath, StringRef relative_path);
 

--- a/iwyu_preprocessor.cc
+++ b/iwyu_preprocessor.cc
@@ -465,7 +465,7 @@ void IwyuPreprocessorInfo::MaybeProtectInclude(
     SourceLocation includer_loc, OptionalFileEntryRef includee,
     const string& include_name_as_written) {
   OptionalFileEntryRef includer = GetFileEntry(includer_loc);
-  if (IsSpecialFile(includer))
+  if (IsSpecialFileOrStdin(includer))
     return;
 
   string protect_reason;
@@ -575,7 +575,7 @@ void IwyuPreprocessorInfo::FinalizeProtectedIncludes() {
 void IwyuPreprocessorInfo::AddDirectInclude(
     SourceLocation includer_loc, OptionalFileEntryRef includee,
     const string& include_name_as_written) {
-  if (IsSpecialFile(includee))
+  if (IsSpecialFileOrStdin(includee))
     return;
 
   // For files we're going to be reporting IWYU errors for, we need

--- a/tests/stdin/direct.h
+++ b/tests/stdin/direct.h
@@ -1,0 +1,16 @@
+//===--- direct.h - test input file for iwyu ------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_STDIN_DIRECT_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_STDIN_DIRECT_H_
+
+#include "tests/stdin/indirect.h"
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_STDIN_DIRECT_H_
+

--- a/tests/stdin/indirect.h
+++ b/tests/stdin/indirect.h
@@ -1,0 +1,17 @@
+//===--- indirect.h - test input file for iwyu ----------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_STDIN_INDIRECT_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_STDIN_INDIRECT_H_
+
+class Class {};
+
+#define MACRO 1
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_STDIN_INDIRECT_H_

--- a/tests/stdin/macro.cc
+++ b/tests/stdin/macro.cc
@@ -1,0 +1,12 @@
+//===--- macro.cc - test input file for iwyu ------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/stdin/direct.h"
+
+int i = MACRO;

--- a/tests/stdin/minimal.cc
+++ b/tests/stdin/minimal.cc
@@ -1,0 +1,10 @@
+//===--- minimal.cc - test input file for iwyu ----------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+int i;

--- a/tests/stdin/use_class.cc
+++ b/tests/stdin/use_class.cc
@@ -1,0 +1,12 @@
+//===--- use_class.cc - test input file for iwyu --------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/stdin/direct.h"
+
+Class c;


### PR DESCRIPTION
In 492f292b42365d4be2630e17e7bab84006595fe7, I folded `"<stdin>"` into the
set of special filenames recognized by IsSpecialFilename.

This broke the following IWYU invocation:

    $ echo "int i;" | include-what-you-use -xc -
    .../iwyu_preprocessor.cc:1070: Assertion failed: main_file_ && "Main file should be present"
    Aborted (core dumped)

Remove `"<stdin>"` from the special filenames and add a new predicate,
IsSpecialFilenameOrStdin, which includes it. Add similar wrappers
IsSpecialFileOrStdin and IsInSpecialFileOrStdin.

Carefully pick one or the other for all existing uses of Is.*SpecialFile
to get the best semantics. Include stdin if there's any uncertainty.

Consistently treat stdin as not a headerfile and not a quoted-include.

Our current test suite has no mechanism for testing inputs read from
stdin. Add a new Bash-based test runner and a new tests/stdin suite
containing inputs suitable for triggering issues with stdin inputs.

There is no facility for content assertions or anything, we just check
that the include-what-you-use invocation doesn't fail.

The tests/stdin/minimal.cc testcase was failing on master before this
patch.