### PR TITLE
Improve blocking implicit typedef reports

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -5246,7 +5246,8 @@ class IwyuAstConsumer
     if (CanIgnoreCurrentASTNode())
       return true;
     // TypedefType::getDecl() returns the place where the typedef is defined.
-    ReportDeclUse(CurrentLoc(), type->getDecl());
+    if (!InImplicitCode(current_ast_node()))
+      ReportDeclUse(CurrentLoc(), type->getDecl());
     return Base::VisitTypedefType(type);
   }
 

--- a/tests/cxx/no_implicit_typedef_reporting.cc
+++ b/tests/cxx/no_implicit_typedef_reporting.cc
@@ -33,6 +33,9 @@ void Fn() {
 
   // Test use in instantiated template.
   Template<decltype(Struct::typedefed), Struct> tpl;
+
+  // Test use in a lambda capture.
+  [i = s.typedefed] {}();
 }
 
 /**** IWYU_SUMMARY


### PR DESCRIPTION
The only reason why it has not been done by means of replacing `VisitTypedefType` with `VisitTypedefTypeLoc` is dynamic exception specifications, which use `Type`s and not `TypeLoc`s. But they were removed in C++17, so I'm not sure if testing them is needed.