### PR TITLE
Strengthen ConvertToQuotedInclude invariants

### DIFF
--- a/iwyu_output.cc
+++ b/iwyu_output.cc
@@ -320,15 +320,15 @@ OneUse::OneUse(OptionalFileEntryRef included_file, const string& quoted_include)
       short_symbol_name_(),
       decl_(nullptr),
       decl_file_(included_file),
-      decl_filepath_(quoted_include),
+      decl_filepath_(GetFilePath(included_file)),
       use_loc_(SourceLocation()),
       use_kind_(kFullUse),
       use_flags_(UF_None),
       ignore_use_(false),
       is_iwyu_violation_(false) {
-  CHECK_(IsQuotedInclude(decl_filepath_))
+  CHECK_(IsQuotedInclude(quoted_include))
       << "OneUse: bad quoted_include: " << quoted_include;
-  suggested_header_ = decl_filepath_;
+  suggested_header_ = quoted_include;
 }
 
 void OneUse::reset_decl(const NamedDecl* decl) {

--- a/iwyu_path_util.cc
+++ b/iwyu_path_util.cc
@@ -183,6 +183,7 @@ bool StripPathPrefix(string* path, StringRef prefix_path) {
 // quoted include, such as <stdio.h>.
 string ConvertToQuotedInclude(StringRef filepath,
                               StringRef includer_path) {
+  CHECK_(!IsQuotedInclude(filepath));
   // includer_path must be given as an absolute path.
   CHECK_(includer_path.empty() || IsAbsolutePath(includer_path));
 


### PR DESCRIPTION
The file path passed to ConvertToQuotedInclude must not already be a quoted include.

Add an assertion to force that fact.

This triggered a failure for include uses, where a quoted include was
incorrectly stored as a file path, and then passed back to
ConvertToQuotedInclude in ProcessSymbolUse, producing a double-quoted
include. Change the OneUse constructor to store the right values in the
right places.
