### PR TITLE
Don't quote any special filenames in ConvertToQuotedInclude

### DIFF
--- a/iwyu_path_util.cc
+++ b/iwyu_path_util.cc
@@ -186,7 +186,7 @@ string ConvertToQuotedInclude(StringRef filepath,
   // includer_path must be given as an absolute path.
   CHECK_(includer_path.empty() || IsAbsolutePath(includer_path));
 
-  if (filepath == "<built-in>")
+  if (IsSpecialFilenameOrStdin(filepath))
     return filepath.str();
 
   // Get path into same format as header search paths: Absolute and normalized.


### PR DESCRIPTION
If any special filename is passed to ConvertToQuotedInclude, it should be roundtripped as-is.

We used to do this for the special `<built-in>` special filename, but extend it to all of them, including `<stdin>`.

It might be possible to extend this to an assertion that disallows special filenames, but it's not entirely clear to me if there are e.g. mappings to and from special filenames, so just generalize existing behavior for now.