### PR TITLE
Don't process include-file uses as symbol uses

### DIFF
--- a/iwyu_output.cc
+++ b/iwyu_output.cc
@@ -1713,7 +1713,7 @@ void IwyuFileInfo::CalculateIwyuViolations(vector<OneUse>* uses) {
       internal::ProcessFullUse(&use, preprocessor_info_, *uses);
   }
   for (OneUse& use : *uses) {
-    if (use.is_full_use() && !use.decl())
+    if (use.is_full_use() && !use.decl() && use.has_symbol_name())
       internal::ProcessSymbolUse(&use, preprocessor_info_);
   }
 

--- a/iwyu_output.h
+++ b/iwyu_output.h
@@ -73,6 +73,9 @@ class OneUse {
   const string& symbol_name() const {
     return symbol_name_;
   }
+  bool has_symbol_name() const {
+    return !symbol_name_.empty();
+  }
   const string& short_symbol_name() const {
     return short_symbol_name_;
   }


### PR DESCRIPTION
ProcessSymbolUse does a lot of processing that assumes it's operating on macro uses.

Include-file uses are not symbol-uses as such, and every step of ProcessSymbolUse would evaluate to no action for include-file uses anyway.

If we need special processing for include-file uses in the future, that should be handled separately.