### PR TITLE
Revert "Don't process include-file uses as symbol uses"

### DIFF
--- a/iwyu_output.cc
+++ b/iwyu_output.cc
@@ -1713,7 +1713,7 @@ void IwyuFileInfo::CalculateIwyuViolations(vector<OneUse>* uses) {
       internal::ProcessFullUse(&use, preprocessor_info_, *uses);
   }
   for (OneUse& use : *uses) {
-    if (use.is_full_use() && !use.decl() && use.has_symbol_name())
+    if (use.is_full_use() && !use.decl())
       internal::ProcessSymbolUse(&use, preprocessor_info_);
   }
 

--- a/iwyu_output.h
+++ b/iwyu_output.h
@@ -73,9 +73,6 @@ class OneUse {
   const string& symbol_name() const {
     return symbol_name_;
   }
-  bool has_symbol_name() const {
-    return !symbol_name_.empty();
-  }
   const string& short_symbol_name() const {
     return short_symbol_name_;
   }


### PR DESCRIPTION
I started building on this and noticed there are cases where non-include-file uses do not actually have a symbol name (case in point tests/cxx/lambda_fwd_decl.cc).

I believe we still want to process symbol uses for unnamed symbols.

This reverts commit d0888b691db98cad0a51222f252b34a3889bfb07.