### PR TITLE
Forward location for include-uses

### DIFF
--- a/iwyu_location_util.cc
+++ b/iwyu_location_util.cc
@@ -193,6 +193,12 @@ SourceLocation GetLocation(const TemplateArgumentLoc* argloc) {
   return argloc->getLocation();
 }
 
+SourceLocation GetFileStartLoc(OptionalFileEntryRef file) {
+  if (!file)
+    return SourceLocation();
+  return GlobalSourceManager()->translateFileLineCol(*file, 1, 1);
+}
+
 bool IsInScratchSpace(SourceLocation loc) {
   return StartsWith(PrintableLoc(GetSpellingLoc(loc)), "<scratch space>");
 }
@@ -206,10 +212,8 @@ bool IsHeaderFile(OptionalFileEntryRef file) {
 }
 
 bool IsSystemHeader(OptionalFileEntryRef file) {
-  const SourceManager* sm = GlobalSourceManager();
-  FileID file_id = sm->translateFile(*file);
-  SourceLocation loc = sm->getLocForStartOfFile(file_id);
-  return sm->isInSystemHeader(loc);
+  SourceLocation loc = GetFileStartLoc(file);
+  return GlobalSourceManager()->isInSystemHeader(loc);
 }
 
 }  // namespace include_what_you_use

--- a/iwyu_location_util.h
+++ b/iwyu_location_util.h
@@ -192,6 +192,9 @@ const string GetFilePath(const T& obj) {
   return GetFilePath(GetFileEntry(obj));
 }
 
+// Return the first source location inside file, if available.
+clang::SourceLocation GetFileStartLoc(clang::OptionalFileEntryRef file);
+
 //------------------------------------------------------------
 // Some utility, location-based routines.
 

--- a/iwyu_output.h
+++ b/iwyu_output.h
@@ -68,7 +68,8 @@ class OneUse {
   // This constructor is used to track include file uses. See
   // ReportIncludeFileUse for details.
   OneUse(clang::OptionalFileEntryRef included_file,
-         const string& quoted_include);
+         const string& quoted_include,
+         clang::SourceLocation include_loc);
 
   const string& symbol_name() const {
     return symbol_name_;
@@ -323,6 +324,11 @@ class IwyuFileInfo {
   // Input is the include-line as desired: '<string.h>' or '"ads/foo.h"'.
   void ReportIncludeFileUse(clang::OptionalFileEntryRef included_file,
                             const string& quoted_include);
+
+  // Same as above, but include location if we have it available.
+  void ReportIncludeFileUse(clang::OptionalFileEntryRef included_file,
+                            const string& quoted_include,
+                            clang::SourceLocation include_loc);
 
   // This is used when we see a file we want to keep not due to symbol-use
   // reasons.  For example, it can be #included with an "IWYU pragma: keep"

--- a/iwyu_preprocessor.cc
+++ b/iwyu_preprocessor.cc
@@ -523,8 +523,8 @@ void IwyuPreprocessorInfo::MaybeProtectInclude(
 
   if (!protect_reason.empty()) {
     CHECK_(ContainsKey(iwyu_file_info_map_, includer));
-    GetFromFileInfoMap(includer)->ReportIncludeFileUse(includee,
-                                                       include_name_as_written);
+    GetFromFileInfoMap(includer)->ReportIncludeFileUse(
+        includee, include_name_as_written, includer_loc);
     ERRSYM(includer) << "Marked dep: " << GetFilePath(includer)
                      << " needs to keep " << include_name_as_written
                      << " (reason: " << protect_reason << ")\n";


### PR DESCRIPTION
The logging for include-uses has been clumsy and misleading, e.g.

    Marked use of include-file  (from tests/cxx/self_include.cc)
        at <invalid loc>

(No quoted include, no location.)

Pass the location of the #include statement to ReportIncludeUse where it's available. Where it's not, use the first location of the file the include-use is reported on.

Separate 'Marked use of include-file' logging into a separate LogIncludeFileUse function which prints things more relevant to these special uses.

Change IsSystemHeader to use the new GetFileStartLoc, which is also somewhat more friendly -- returns invalid source location instead of aborting for built-in file.