### PR TITLE
Differentiate explicit specializations in mappings

### DIFF
--- a/docs/IWYUMappings.md
+++ b/docs/IWYUMappings.md
@@ -132,6 +132,42 @@ syntax in the first entry. Track the [following
 bug](https://github.com/include-what-you-use/include-what-you-use/issues/233)
 for updates.
 
+#### Template specializations ####
+
+A bare template name in a symbol mapping corresponds to the primary template,
+i.e. any use of its implicit specialization (and not any implicit specialization
+of its partial specialization) matches the mapping. To map an explicit or
+partial specialization, append the template argument list to the template name.
+Note that, currently, IWYU expects a specific format of template argument lists.
+For example, a list consisting of a pointer to `int` should be written as
+`<int *>` and not as e.g. `<int*>`. When in doubt, run IWYU with verbosity level
+6 on some code using the specialization, and look for a string like `Marked
+full-info use of decl template-name<...> (from ...` to see how IWYU spells
+the template arguments.
+
+To denote a partial specialization, you should replace all the template
+parameters in the template argument list with `:N`, where `N` is the parameter
+number, starting from 0. Note that it is the number of the partial
+specialization template parameter, not of any primary template parameter. For
+example, for such a code:
+
+    template <typename, typename, int>
+    class Tpl;
+
+    template <typename T1, typename T2>
+    class Tpl<T1, T2, 5> {};
+
+    template <typename T>
+    class Tpl<T, T, 5> {};
+
+the first partial specialization can be referred to in a mapping file as
+`Tpl<:0, :1, 5>`, and the second one as `Tpl<:0, :0, 5>`. IWYU does not
+currently have a proper support for mappings of partial specializations
+of templates being members of other templates.
+
+At present, only class template specializations are supported, not function
+or variable ones.
+
 
 ### Mapping refs ###
 

--- a/iwyu_include_picker.cc
+++ b/iwyu_include_picker.cc
@@ -325,8 +325,23 @@ const IncludeMapEntry stdlib_cxx_symbol_map[] = {
   // argument, and sometimes it bleeds through when clang desugars the
   // string/ostream/istream type.
   { "std::char_traits", kPrivate, "<string>", kPublic },
+  { "std::char_traits<char>", kPrivate, "<string>", kPublic },
+  { "std::char_traits<char8_t>", kPrivate, "<string>", kPublic },
+  { "std::char_traits<char16_t>", kPrivate, "<string>", kPublic },
+  { "std::char_traits<char32_t>", kPrivate, "<string>", kPublic },
+  { "std::char_traits<wchar_t>", kPrivate, "<string>", kPublic },
   { "std::char_traits", kPrivate, "<ostream>", kPublic },
+  { "std::char_traits<char>", kPrivate, "<ostream>", kPublic },
+  { "std::char_traits<char8_t>", kPrivate, "<ostream>", kPublic },
+  { "std::char_traits<char16_t>", kPrivate, "<ostream>", kPublic },
+  { "std::char_traits<char32_t>", kPrivate, "<ostream>", kPublic },
+  { "std::char_traits<wchar_t>", kPrivate, "<ostream>", kPublic },
   { "std::char_traits", kPrivate, "<istream>", kPublic },
+  { "std::char_traits<char>", kPrivate, "<istream>", kPublic },
+  { "std::char_traits<char8_t>", kPrivate, "<istream>", kPublic },
+  { "std::char_traits<char16_t>", kPrivate, "<istream>", kPublic },
+  { "std::char_traits<char32_t>", kPrivate, "<istream>", kPublic },
+  { "std::char_traits<wchar_t>", kPrivate, "<istream>", kPublic },
 
   // std::ptrdiff_t is often an architecture specific definition, force the
   // canonical location.

--- a/tests/cxx/badinc.cc
+++ b/tests/cxx/badinc.cc
@@ -208,7 +208,7 @@ typedef I2_Class Cc_I2_Class_Typedef;
 // but '#include' is required as a common rule, as long as I1_Struct
 // isn't forward-declared.
 // IWYU: I1_Struct is...*badinc-i1.h
-// IWYU: OperateOn is...*badinc-i1.h
+// IWYU: OperateOn<I1_Struct> is...*badinc-i1.h
 typedef H_TemplateStruct<I1_Struct> Cc_H_TemplateStruct_I1Class_Typedef;
 
 // IWYU: kI1ConstInt is...*badinc-i1.h
@@ -1323,13 +1323,13 @@ int main() {
   d1_class.a();
   (void)(cc_struct.b);
   (void)(cc_subclass.a());
-  // IWYU: OperateOn is...*badinc-i1.h
+  // IWYU: OperateOn<I1_Struct> is...*badinc-i1.h
   h_template_struct.a();
   // This tests a bug in clang where an implicit template instantiation
   // of a partial specialization gave the wrong location information.
   // In this case, OperateOn<I1_TemplateClass<T> > is in badinc-i1.h,
   // which is what we should report, *not* the OperateOn<T> in badinc.h.
-  // IWYU: OperateOn is...*badinc-i1.h
+  // IWYU: OperateOn<I1_TemplateClass<:0, :0>> is...*badinc-i1.h
   h_template_struct_tplclass_arg.a();
   h_scoped_ptr.get();
   // Not an iwyu violation, since we never use the dereferenced type.

--- a/tests/cxx/default_template_arg_other_file.cc
+++ b/tests/cxx/default_template_arg_other_file.cc
@@ -22,14 +22,14 @@ int main() {
   // TODO(csilvers): IWYU: OperateOn is...*default_template_arg_other_file-i2.h
   // IWYU: MyClass needs a declaration
   TemplateStruct<MyClass> ts;
-  // IWYU: OperateOn is...*default_template_arg_other_file-i2.h
+  // IWYU: OperateOn<MyClass> is...*default_template_arg_other_file-i2.h
   ts.a();
 
   // TODO(csilvers): IWYU: OperateOn is...*default_template_arg_other_file-i2.h
   // IWYU: TplClass needs a declaration
   // IWYU: MyClass needs a declaration
   TemplateStruct<TplClass<MyClass> > ts2;
-  // IWYU: OperateOn is...*default_template_arg_other_file-i2.h
+  // IWYU: OperateOn<TplClass<:0>> is...*default_template_arg_other_file-i2.h
   ts2.a();
 
   // Make sure that we don't require OperateOn when we don't have a

--- a/tests/cxx/explicit_instantiation.cc
+++ b/tests/cxx/explicit_instantiation.cc
@@ -106,7 +106,7 @@ template class ClassWithUsingMethod2<IndirectClass>;
 // the tool.
 // IWYU: TplWithDefArg is...*explicit_instantiation-template.h
 TplWithDefArg<int>* p = nullptr;
-// IWYU: TplWithDefArg is...*explicit_instantiation-template.h
+// IWYU: TplWithDefArg<int, :0> is...*explicit_instantiation-template.h
 extern template class TplWithDefArg<int>;
 
 template <typename>

--- a/tests/cxx/explicit_instantiation2.cc
+++ b/tests/cxx/explicit_instantiation2.cc
@@ -80,6 +80,7 @@ TemplateTemplateArgShortFwd<
 Template<int> t9; // 9
 
 // IWYU: Template needs a declaration
+// IWYU: Template<char> needs a declaration
 template <> class Template<char> {};
 
 TemplateAsDefaultFull<char> t10; // 10

--- a/tests/cxx/iwyu_stricter_than_cpp.cc
+++ b/tests/cxx/iwyu_stricter_than_cpp.cc
@@ -103,7 +103,7 @@ void TestTypedefs() {
   TplDoesNotForwardDeclareAndIncludes tdnfdai(10);
   // IWYU: TplIndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
   TplDoesEverythingRight tdor(11);
-  // IWYU: TplIndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
+  // IWYU: TplIndirectStruct2<float> is...*iwyu_stricter_than_cpp-i2.h
   TplDoesEverythingRightAgain tdora(12);
 
   // But if we're in a forward-declare context, we don't require the
@@ -187,7 +187,7 @@ void TestTypeAliases() {
   TplDoesNotForwardDeclareAndIncludesAl tdnfdai(10);
   // IWYU: TplIndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
   TplDoesEverythingRightAl tdor(11);
-  // IWYU: TplIndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
+  // IWYU: TplIndirectStruct2<float> is...*iwyu_stricter_than_cpp-i2.h
   TplDoesEverythingRightAgainAl tdora(12);
 
   // But if we're in a forward-declare context, we don't require the
@@ -388,7 +388,7 @@ void TestFunctionReturn() {
   const TplIndirectStruct2<int>& tis2 = TplDoesEverythingRightFn();
 
   // IWYU: TplIndirectStruct2 needs a declaration
-  // IWYU: TplIndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
+  // IWYU: TplIndirectStruct2<float> is...*iwyu_stricter_than_cpp-i2.h
   const TplIndirectStruct2<float>& tis2b = TplDoesEverythingRightAgainFn();
 
   // -- With user-defined types as template parameters.

--- a/tests/cxx/precomputed_tpl_args.cc
+++ b/tests/cxx/precomputed_tpl_args.cc
@@ -43,7 +43,7 @@ std::set<IndirectClass> ic_set;
 // This class provides a specialization of less that we should see.
 // IWYU: SpecializationClass needs a declaration
 // IWYU: SpecializationClass is...*precomputed_tpl_args-i1.h
-// IWYU: std::less is...*precomputed_tpl_args-i1.h
+// IWYU: std::less<SpecializationClass> is...*precomputed_tpl_args-i1.h
 std::set<SpecializationClass> sc_set;
 
 // This class provides a specialization of less that we should see,

--- a/tests/cxx/specialization_needs_decl.cc
+++ b/tests/cxx/specialization_needs_decl.cc
@@ -26,7 +26,7 @@ template<> struct TplStruct<float>;
 
 // IWYU: Template needs a declaration
 int f(Template<int>& t) {
-  // IWYU: Template is...*specialization_needs_decl-i1.h
+  // IWYU: Template<int> is...*specialization_needs_decl-i1.h
   return t.x;
 }
 

--- a/tests/cxx/template_spec_mapping-d1.h
+++ b/tests/cxx/template_spec_mapping-d1.h
@@ -1,0 +1,10 @@
+//===--- template_spec_mapping-d1.h - test input file for iwyu ------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/template_spec_mapping-i1.h"

--- a/tests/cxx/template_spec_mapping-i1.h
+++ b/tests/cxx/template_spec_mapping-i1.h
@@ -1,0 +1,63 @@
+//===--- template_spec_mapping-i1.h - test input file for iwyu ------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+template <int>
+class OtherTpl;
+
+template <typename, int, template <int> typename>
+class Tpl {};
+
+template <>
+class Tpl<int, 1, OtherTpl> {};
+
+template <typename T, int I, template <int> typename Other>
+class Tpl<T*, I, Other> {};
+
+template <typename, typename = char>
+class TplWithDefArg {};
+
+template <>
+class TplWithDefArg<int*> {};
+
+// Partial specialization for 'char' as the last argument.
+template <typename T>
+class TplWithDefArg<T> {};
+
+template <long, auto>
+class TplWithDeducibleNTTP {};
+
+template <>
+class TplWithDeducibleNTTP<1, 1> {};
+
+template <>
+class TplWithDeducibleNTTP<1, 1l> {};
+
+template <typename, typename, int>
+class TplSpecDistinguishedByIndices {};
+
+template <typename T1, typename T2>
+class TplSpecDistinguishedByIndices<T1, T2, 5> {};
+
+template <typename T>
+class TplSpecDistinguishedByIndices<T, T, 5> {};
+
+template <typename...>
+class TplParamPack1 {};
+
+template <typename T, typename... Args>
+class TplParamPack1<int, T, Args...> {};
+
+template <typename... Args>
+class TplParamPack1<Args*...> {};
+
+template <typename, typename...>
+class TplParamPack2 {};
+
+template <typename T, typename... Args>
+class TplParamPack2<int, T, Args...> {};

--- a/tests/cxx/template_spec_mapping.cc
+++ b/tests/cxx/template_spec_mapping.cc
@@ -1,0 +1,83 @@
+//===--- template_spec_mapping.cc - test input file for iwyu --------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_ARGS: -Xiwyu --mapping_file=tests/cxx/template_spec_mapping.imp -I .
+
+#include "tests/cxx/template_spec_mapping-d1.h"
+
+// TODO: OtherTpl is forward-declarable.
+// IWYU: OtherTpl is...*-i1.h
+// IWYU: Tpl is...*-i2.h
+Tpl<char, 2, OtherTpl> t1;
+// IWYU: OtherTpl is...*-i1.h
+// IWYU: Tpl<int, 1, OtherTpl> is...*-i3.h
+Tpl<int, 1, OtherTpl> t2;
+// IWYU: OtherTpl is...*-i1.h
+// IWYU: Tpl<:0 \*, :1, :2> is...*-i4.h
+Tpl<int*, 1, OtherTpl> t3;
+
+// IWYU: TplWithDefArg is...*-i2.h
+TplWithDefArg<int, int> twda1;
+// TODO: reporting the primary template due to the presence of a default
+// argument is redundant here.
+// IWYU: TplWithDefArg is...*-i2.h
+// IWYU: TplWithDefArg<int \*, char> is...*-i3.h
+TplWithDefArg<int*> twda3;
+// IWYU: TplWithDefArg is...*-i2.h
+// IWYU: TplWithDefArg<:0, char> is...*-i4.h
+TplWithDefArg<int> twda2;
+
+// IWYU: TplWithDeducibleNTTP is...*-i2.h
+TplWithDeducibleNTTP<2, 3> twdnttp1;
+// IWYU: TplWithDeducibleNTTP<1, 1> is...*-i3.h
+TplWithDeducibleNTTP<1, 1> twdnttp2;
+// IWYU: TplWithDeducibleNTTP<1, 1L> is...*-i4.h
+TplWithDeducibleNTTP<1, 1l> twdnttp3;
+
+// IWYU: TplSpecDistinguishedByIndices is...*-i2.h
+TplSpecDistinguishedByIndices<int, char, 7> tsdbi1;
+// IWYU: TplSpecDistinguishedByIndices<:0, :1, 5> is...*-i3.h
+TplSpecDistinguishedByIndices<int, char, 5> tsdbi2;
+// IWYU: TplSpecDistinguishedByIndices<:0, :0, 5> is...*-i4.h
+TplSpecDistinguishedByIndices<int, int, 5> tsdbi3;
+
+// IWYU: TplParamPack1 is...*-i2.h
+TplParamPack1<long, short> tpp11;
+// IWYU: TplParamPack1<int, :0, :1...> is...*-i3.h
+TplParamPack1<int, char> tpp12;
+// IWYU: TplParamPack1<int, :0, :1...> is...*-i3.h
+TplParamPack1<int, char, float> tpp13;
+// IWYU: TplParamPack1<int, :0, :1...> is...*-i3.h
+TplParamPack1<int, char, float, double> tpp14;
+// IWYU: TplParamPack1<:0 \*...> is...*-i4.h
+TplParamPack1<int*, char*> tpp15;
+
+// IWYU: TplParamPack2 is...*-i2.h
+TplParamPack2<double, char, float> tpp21;
+// IWYU: TplParamPack2<int, :0, :1...> is...*-i3.h
+TplParamPack2<int, char, float> tpp22;
+
+/**** IWYU_SUMMARY
+
+tests/cxx/template_spec_mapping.cc should add these lines:
+#include "tests/cxx/template_spec_mapping-i1.h"
+#include "tests/cxx/template_spec_mapping-i2.h"
+#include "tests/cxx/template_spec_mapping-i3.h"
+#include "tests/cxx/template_spec_mapping-i4.h"
+
+tests/cxx/template_spec_mapping.cc should remove these lines:
+- #include "tests/cxx/template_spec_mapping-d1.h"  // lines XX-XX
+
+The full include-list for tests/cxx/template_spec_mapping.cc:
+#include "tests/cxx/template_spec_mapping-i1.h"  // for OtherTpl
+#include "tests/cxx/template_spec_mapping-i2.h"  // for Tpl, TplParamPack1, TplParamPack2, TplSpecDistinguishedByIndices, TplWithDeducibleNTTP, TplWithDefArg
+#include "tests/cxx/template_spec_mapping-i3.h"  // for Tpl, TplParamPack1, TplParamPack2, TplSpecDistinguishedByIndices, TplWithDeducibleNTTP, TplWithDefArg
+#include "tests/cxx/template_spec_mapping-i4.h"  // for Tpl, TplParamPack1, TplSpecDistinguishedByIndices, TplWithDeducibleNTTP, TplWithDefArg
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/template_spec_mapping.imp
+++ b/tests/cxx/template_spec_mapping.imp
@@ -1,0 +1,24 @@
+[
+  { "symbol": ["Tpl", "private", "\"tests/cxx/template_spec_mapping-i2.h\"", "public"] },
+  { "symbol": ["Tpl<int, 1, OtherTpl>", "private", "\"tests/cxx/template_spec_mapping-i3.h\"", "public"] },
+  { "symbol": ["Tpl<:0 *, :1, :2>", "private", "\"tests/cxx/template_spec_mapping-i4.h\"", "public"] },
+
+  { "symbol": ["TplWithDefArg", "private", "\"tests/cxx/template_spec_mapping-i2.h\"", "public"] },
+  { "symbol": ["TplWithDefArg<int *, char>", "private", "\"tests/cxx/template_spec_mapping-i3.h\"", "public"] },
+  { "symbol": ["TplWithDefArg<:0, char>", "private", "\"tests/cxx/template_spec_mapping-i4.h\"", "public"] },
+
+  { "symbol": ["TplWithDeducibleNTTP", "private", "\"tests/cxx/template_spec_mapping-i2.h\"", "public"] },
+  { "symbol": ["TplWithDeducibleNTTP<1, 1>", "private", "\"tests/cxx/template_spec_mapping-i3.h\"", "public"] },
+  { "symbol": ["TplWithDeducibleNTTP<1, 1L>", "private", "\"tests/cxx/template_spec_mapping-i4.h\"", "public"] },
+
+  { "symbol": ["TplSpecDistinguishedByIndices", "private", "\"tests/cxx/template_spec_mapping-i2.h\"", "public"] },
+  { "symbol": ["TplSpecDistinguishedByIndices<:0, :1, 5>", "private", "\"tests/cxx/template_spec_mapping-i3.h\"", "public"] },
+  { "symbol": ["TplSpecDistinguishedByIndices<:0, :0, 5>", "private", "\"tests/cxx/template_spec_mapping-i4.h\"", "public"] },
+
+  { "symbol": ["TplParamPack1", "private", "\"tests/cxx/template_spec_mapping-i2.h\"", "public"] },
+  { "symbol": ["TplParamPack1<int, :0, :1...>", "private", "\"tests/cxx/template_spec_mapping-i3.h\"", "public"] },
+  { "symbol": ["TplParamPack1<:0 *...>", "private", "\"tests/cxx/template_spec_mapping-i4.h\"", "public"] },
+
+  { "symbol": ["TplParamPack2", "private", "\"tests/cxx/template_spec_mapping-i2.h\"", "public"] },
+  { "symbol": ["TplParamPack2<int, :0, :1...>", "private", "\"tests/cxx/template_spec_mapping-i3.h\"", "public"] },
+]

--- a/tests/cxx/template_specialization.cc
+++ b/tests/cxx/template_specialization.cc
@@ -17,7 +17,7 @@
 
 template<typename T> class Foo;
 
-// IWYU: Foo is...*template_specialization-i2.h
+// IWYU: Foo<int> is...*template_specialization-i2.h
 Foo<int> foo;
 // Even though Foo<int> has a specialization, it doesn't matter
 // because forward-declaring is ok.


### PR DESCRIPTION
Prior to this, IWYU took into account only template names when looking for a symbol in mapping files. So, users could not distinguish between a primary template and its explicit or partial specializations despite they can be placed in separate files. Moreover, some libraries allow users to write their own specializations of some library templates, but IWYU erroneously remapped a use of such a specialization to the primary template if it is mentioned in a mapping file for the library. As an example, if someone writes a specialization of `std::allocator` for his class, IWYU would not report the specialization header because `std::allocator` is mapped to the standard library headers inside `stdlib_cxx_symbol_map` from `iwyu_include_picker.cc`.

Therefore, this change is needed to write the standard library symbol mapping correctly and not to break users who specialize some of its class templates.

This change makes template arguments included in a symbol name. For partial specializations, template parameters used inside template arguments are replaced with `:N`, where `N` is the partial specialization template parameter number. Template parameter depth is not currently included in the placeholder.

Only class template specializations have been supported, not function or variable ones.

Note that if some IWYU users rely on the old behavior, it is a breaking change for them because IWYU will stop mapping explicit specializations to the correct headers until fixing the corresponding mapping files.

The change in `explicit_instantiation2.cc` test reveals that IWYU reports fwd-decl uses from prototypes of implicitly defined copy-ctors (`Template(const Template<char>&)` in this case). I'm not sure if it causes some bug in general, but this PR should not make any regression with this.