### PR TITLE
[clang-compat] Handle new CK_HLSLMatrixTruncation

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -1913,6 +1913,7 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
       case clang::CK_HLSLVectorTruncation:
       case clang::CK_HLSLElementwiseCast:
       case clang::CK_HLSLAggregateSplatCast:
+      case clang::CK_HLSLMatrixTruncation:
         break;
 
       // Ignore non-ptr-to-ptr casts.


### PR DESCRIPTION
Clang commit https://github.com/llvm/llvm-project/commit/dd1b4abfb74809481100ed20c5a099f062ef0625 added support for HLSL matrix elements, and added a new cast-kind CK_HLSLMatrixTruncation.

Add it to our cast-kind handler to silence the warning.