### PR TITLE
[clang compat] Remove "is replaceable" type trait

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -2187,7 +2187,6 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
       case TypeTrait::UTT_IsTriviallyRelocatable:
       case TypeTrait::UTT_IsTriviallyEqualityComparable:
       case TypeTrait::UTT_IsCppTriviallyRelocatable:
-      case TypeTrait::UTT_IsReplaceable:
       case TypeTrait::UTT_CanPassInRegs:
       case TypeTrait::UTT_HasNothrowConstructor:
       case TypeTrait::UTT_HasNothrowCopy:

--- a/tests/cxx/type_trait.cc
+++ b/tests/cxx/type_trait.cc
@@ -315,17 +315,6 @@ static_assert(!__builtin_is_cpp_trivially_relocatable(Union2&));
 // IWYU: Union2 is...*-i1.h
 static_assert(__builtin_is_cpp_trivially_relocatable(Union2[]));
 // IWYU: Class is...*-i1.h
-static_assert(__builtin_is_replaceable(Class));
-static_assert(__builtin_is_replaceable(Class*));
-static_assert(!__builtin_is_replaceable(Class&));
-// IWYU: Class is...*-i1.h
-static_assert(__builtin_is_replaceable(Class[]));
-// IWYU: Union2 is...*-i1.h
-static_assert(__builtin_is_replaceable(Union2));
-static_assert(!__builtin_is_replaceable(Union2&));
-// IWYU: Union2 is...*-i1.h
-static_assert(__builtin_is_replaceable(Union2[]));
-// IWYU: Class is...*-i1.h
 static_assert(__can_pass_in_regs(Class));
 // IWYU: Union1 is...*-i1.h
 static_assert(__can_pass_in_regs(Union1));


### PR DESCRIPTION
It has been deleted in https://github.com/llvm/llvm-project/commit/1bfa250dbf7cc36e345f97b2f71b01f7e54a8507.