### PR TITLE
Support variable template specs in mappings

### DIFF
--- a/docs/IWYUMappings.md
+++ b/docs/IWYUMappings.md
@@ -165,8 +165,8 @@ the first partial specialization can be referred to in a mapping file as
 currently have a proper support for mappings of partial specializations
 of templates being members of other templates.
 
-At present, only class template specializations are supported, not function
-or variable ones.
+At present, only class and variable template specializations are supported, not
+function template ones.
 
 
 ### Mapping refs ###

--- a/tests/cxx/template_spec_mapping-i1.h
+++ b/tests/cxx/template_spec_mapping-i1.h
@@ -61,3 +61,12 @@ class TplParamPack2 {};
 
 template <typename T, typename... Args>
 class TplParamPack2<int, T, Args...> {};
+
+template <typename>
+constexpr int var_tpl = 1;
+
+template <>
+inline constexpr int var_tpl<char> = 2;
+
+template <typename T>
+constexpr int var_tpl<T*> = 3;

--- a/tests/cxx/template_spec_mapping.cc
+++ b/tests/cxx/template_spec_mapping.cc
@@ -63,6 +63,13 @@ TplParamPack2<double, char, float> tpp21;
 // IWYU: TplParamPack2<int, :0, :1...> is...*-i3.h
 TplParamPack2<int, char, float> tpp22;
 
+// IWYU: var_tpl is...*-i2.h
+static_assert(var_tpl<int> == 1);
+// IWYU: var_tpl<char> is...*-i3.h
+static_assert(var_tpl<char> == 2);
+// IWYU: var_tpl<:0 \*> is...*-i4.h
+static_assert(var_tpl<int*> == 3);
+
 /**** IWYU_SUMMARY
 
 tests/cxx/template_spec_mapping.cc should add these lines:
@@ -76,8 +83,8 @@ tests/cxx/template_spec_mapping.cc should remove these lines:
 
 The full include-list for tests/cxx/template_spec_mapping.cc:
 #include "tests/cxx/template_spec_mapping-i1.h"  // for OtherTpl
-#include "tests/cxx/template_spec_mapping-i2.h"  // for Tpl, TplParamPack1, TplParamPack2, TplSpecDistinguishedByIndices, TplWithDeducibleNTTP, TplWithDefArg
-#include "tests/cxx/template_spec_mapping-i3.h"  // for Tpl, TplParamPack1, TplParamPack2, TplSpecDistinguishedByIndices, TplWithDeducibleNTTP, TplWithDefArg
-#include "tests/cxx/template_spec_mapping-i4.h"  // for Tpl, TplParamPack1, TplSpecDistinguishedByIndices, TplWithDeducibleNTTP, TplWithDefArg
+#include "tests/cxx/template_spec_mapping-i2.h"  // for Tpl, TplParamPack1, TplParamPack2, TplSpecDistinguishedByIndices, TplWithDeducibleNTTP, TplWithDefArg, var_tpl
+#include "tests/cxx/template_spec_mapping-i3.h"  // for Tpl, TplParamPack1, TplParamPack2, TplSpecDistinguishedByIndices, TplWithDeducibleNTTP, TplWithDefArg, var_tpl
+#include "tests/cxx/template_spec_mapping-i4.h"  // for Tpl, TplParamPack1, TplSpecDistinguishedByIndices, TplWithDeducibleNTTP, TplWithDefArg, var_tpl
 
 ***** IWYU_SUMMARY */

--- a/tests/cxx/template_spec_mapping.imp
+++ b/tests/cxx/template_spec_mapping.imp
@@ -21,4 +21,8 @@
 
   { "symbol": ["TplParamPack2", "private", "\"tests/cxx/template_spec_mapping-i2.h\"", "public"] },
   { "symbol": ["TplParamPack2<int, :0, :1...>", "private", "\"tests/cxx/template_spec_mapping-i3.h\"", "public"] },
+
+  { "symbol": ["var_tpl", "private", "\"tests/cxx/template_spec_mapping-i2.h\"", "public"] },
+  { "symbol": ["var_tpl<char>", "private", "\"tests/cxx/template_spec_mapping-i3.h\"", "public"] },
+  { "symbol": ["var_tpl<:0 *>", "private", "\"tests/cxx/template_spec_mapping-i4.h\"", "public"] },
 ]


### PR DESCRIPTION
The change in `GetInstantiatedFromDecl` and in `GetDefinitionAsWritten` is required because otherwise, for partially specialized variable templates, an implicitly instantiated specialization of the partial specialization comes into `GetWrittenQualifiedNameAsString` instead of the partial specialization itself.