### PR TITLE
Print template forward-decls without alignas keyword

### DIFF
--- a/iwyu_string_util.h
+++ b/iwyu_string_util.h
@@ -226,6 +226,20 @@ inline string FormatISO8601(time_t t) {
   return string(buf);
 }
 
+// Collapses series of neighboring equal characters into one.
+inline string CollapseRepeated(StringRef str, char needle) {
+  string collapsed;
+  collapsed.reserve(str.size());
+
+  char prev_c = 0;
+  for (char c : str) {
+    if (c != needle || c != prev_c)
+      collapsed += c;
+    prev_c = c;
+  }
+  return collapsed;
+}
+
 }  // namespace include_what_you_use
 
 #endif  // INCLUDE_WHAT_YOU_USE_IWYU_STRING_UTIL_H_

--- a/tests/cxx/fwd_decl_print-d1.h
+++ b/tests/cxx/fwd_decl_print-d1.h
@@ -26,6 +26,7 @@ class DerivedClass : public Class {};
 class [[nodiscard]] ClassWithStdAttr {};
 class __attribute__((warn_unused_result)) ClassWithGNUAttr {};
 
-// Class types with implicit attributes.
+// Class types with keyword attributes.
 class alignas(8) ClassWithAlignAs {};
+class alignas(alignof(bool)) ClassWithAlignAsExpr {};
 class ClassWithFinal final {};

--- a/tests/cxx/fwd_decl_print-d2.h
+++ b/tests/cxx/fwd_decl_print-d2.h
@@ -30,9 +30,12 @@ class [[nodiscard]] TemplateWithStdAttr {};
 template <class T>
 class __attribute__((warn_unused_result)) TemplateWithGNUAttr {};
 
-// Templates with implicit attributes.
+// Templates with keyword attributes.
 template <class T>
 class alignas(8) TemplateWithAlignAs {};
+
+template <class T>
+class alignas(alignof(T)) TemplateWithAlignAsExpr {};
 
 template <class T>
 class TemplateWithFinal final {};

--- a/tests/cxx/fwd_decl_print.cc
+++ b/tests/cxx/fwd_decl_print.cc
@@ -28,13 +28,13 @@ ns1::StructInNamespace* s2;
 // Derived class types.
 DerivedClass* dc1;
 
-// Class types with explicit and implicit attributes (attrs should not be
-// included in fwd decl).
+// Class types with different kinds of attributes (no attrs should be included
+// in fwd decl).
 ClassWithStdAttr* ac1;
 ClassWithGNUAttr* ac2;
-// alignas can be included, but doesn't have to.
 ClassWithAlignAs* ac3;
-ClassWithFinal* ac4;
+ClassWithAlignAsExpr* ac4;
+ClassWithFinal* ac5;
 
 // Simple templates.
 Template<int>* t1;
@@ -43,15 +43,13 @@ ns1::TemplateInNamespace<char>* t2;
 // Derived templates
 DerivedTemplate<int>* dt1;
 
-// Templates with explicit and implicit attributes (attrs should not be included
-// in fwd decl).
+// Templates with different kinds of attributes (no attrs should be included in
+// fwd decl).
 TemplateWithStdAttr<int>* at1;
 TemplateWithGNUAttr<int>* at2;
-// alignas can be included, but doesn't have to.
-// TODO: make this consistent between tag types and templates; we currently
-// print alignas for templates. Should probably not.
 TemplateWithAlignAs<int>* at3;
-TemplateWithFinal<int>* at4;
+TemplateWithAlignAsExpr<int>* at4;
+TemplateWithFinal<int>* at5;
 
 // Templates with requires constraints.
 TemplateWithSimpleAdHocRequires<void**>* rt1;
@@ -67,6 +65,7 @@ TemplateWithRequiresClause<int>* rt3;
 tests/cxx/fwd_decl_print.cc should add these lines:
 class Class;
 class ClassWithAlignAs;
+class ClassWithAlignAsExpr;
 class ClassWithFinal;
 class ClassWithGNUAttr;
 class ClassWithStdAttr;
@@ -79,10 +78,11 @@ namespace ns1 { template <class T> class TemplateInNamespace; }
 struct Struct;
 template <class T> class DerivedTemplate;
 template <class T> class Template;
+template <class T> class TemplateWithAlignAs;
+template <class T> class TemplateWithAlignAsExpr;
 template <class T> class TemplateWithFinal;
 template <class T> class TemplateWithGNUAttr;
 template <class T> class TemplateWithStdAttr;
-template <class T> class alignas(8)  TemplateWithAlignAs;
 template <typename T> requires Addable<T> class TemplateWithRequiresClause;
 template <typename T> requires requires (T a) { a; } class TemplateWithSimpleAdHocRequires;
 template <typename T> requires requires (T a) { sizeof(decltype(*a)) > 6 ? true : false; a - a; &a; } class TemplateWithComplexAdHocRequires;
@@ -94,6 +94,7 @@ tests/cxx/fwd_decl_print.cc should remove these lines:
 The full include-list for tests/cxx/fwd_decl_print.cc:
 class Class;
 class ClassWithAlignAs;
+class ClassWithAlignAsExpr;
 class ClassWithFinal;
 class ClassWithGNUAttr;
 class ClassWithStdAttr;
@@ -106,10 +107,11 @@ namespace ns1 { template <class T> class TemplateInNamespace; }
 struct Struct;
 template <class T> class DerivedTemplate;
 template <class T> class Template;
+template <class T> class TemplateWithAlignAs;
+template <class T> class TemplateWithAlignAsExpr;
 template <class T> class TemplateWithFinal;
 template <class T> class TemplateWithGNUAttr;
 template <class T> class TemplateWithStdAttr;
-template <class T> class alignas(8)  TemplateWithAlignAs;
 template <typename T> requires Addable<T> class TemplateWithRequiresClause;
 template <typename T> requires requires (T a) { a; } class TemplateWithSimpleAdHocRequires;
 template <typename T> requires requires (T a) { sizeof(decltype(*a)) > 6 ? true : false; a - a; &a; } class TemplateWithComplexAdHocRequires;


### PR DESCRIPTION
C++ has two specifiers in c++11 (some new may arrive in C++26): final
and alignas(...). They are modelled as attributes in Clang, and printed
by the DeclPrinter.

Generalize our forward-decl printer to replace both 'alignas(...)' and
'final' using a regular expression.

Collapse repeated spaces to cover for ugly formatting from Clang.

Try to improve the comments in this function to make it clearer what
we're doing.
