### PR TITLE
Add explicit regex syntax for test diagnostic assertions

### DIFF
--- a/tests/cxx/badinc.cc
+++ b/tests/cxx/badinc.cc
@@ -186,7 +186,7 @@ typedef I1_Class Cc_typedef_array[kI1ConstInt];
 // definition even of I2_Class, since we don't know if clients will be
 // using the no-arg Cc_tpl_typedef ctor, which requires the full
 // definition of I2_Class.
-// IWYU: I1_TemplateClass is...*badinc-i1.h.*#included\.
+// IWYU: I1_TemplateClass is...*badinc-i1.h...*#included.
 // IWYU: I1_Class is...*badinc-i1.h
 // IWYU: I2_Class is...*badinc-i2.h
 // IWYU: I2_Class::~I2_Class is...*badinc-i2-inl.h
@@ -494,20 +494,20 @@ int I2_Class::CcFileFn() { return 1; }
 template<typename FOO> int I2_TemplateClass<FOO>::CcFileFn() {
   // IWYU: I2_TemplateClass is...*badinc-i2.h
   // IWYU: I2_TemplateClass needs a declaration
-  // IWYU: I2_TemplateClass::I2_TemplateClass<.*> is...*badinc-i2-inl.h
+  // IWYU: I2_TemplateClass::I2_TemplateClass<{{.*}}> is...*badinc-i2-inl.h
   I2_TemplateClass<int>* ptr = new I2_TemplateClass<int>(42, "hi");  // NewExpr
 
   // IWYU: I2_TemplateClass is...*badinc-i2.h
-  // IWYU: I2_TemplateClass::I2_TemplateClass<.*> is...*badinc-i2-inl.h
-  // IWYU: I2_TemplateClass::~I2_TemplateClass<.*> is...*badinc-i2-inl.h
+  // IWYU: I2_TemplateClass::I2_TemplateClass<{{.*}}> is...*badinc-i2-inl.h
+  // IWYU: I2_TemplateClass::~I2_TemplateClass<{{.*}}> is...*badinc-i2-inl.h
   I2_TemplateClass<int> x(42, "hi");  // CXXConstructExpr
   (void)x;
 
-  // IWYU: I2_TemplateClass::~I2_TemplateClass<.*> is...*badinc-i2-inl.h
+  // IWYU: I2_TemplateClass::~I2_TemplateClass<{{.*}}> is...*badinc-i2-inl.h
   // IWYU: I2_TemplateClass is...*badinc-i2.h
   delete ptr;  // CXXDeleteExpr
 
-  // IWYU: I2_TemplateClass::~I2_TemplateClass<.*> is...*badinc-i2-inl.h
+  // IWYU: I2_TemplateClass::~I2_TemplateClass<{{.*}}> is...*badinc-i2-inl.h
   // IWYU: I2_TemplateClass is...*badinc-i2.h
   delete this;  // CXXDeleteExpr
 
@@ -578,7 +578,7 @@ H_TemplateStruct<I1_Struct, Cc_Struct> h_template_struct2;
 H_TemplateStruct<I1_TemplateClass<int> > h_template_struct_tplclass_arg;
 // TODO(csilvers): this should be attributed to the .h, since it comes
 // via a default template argument.
-// IWYU: I2_TemplateClass::~I2_TemplateClass<.*> is...*badinc-i2-inl.h
+// IWYU: I2_TemplateClass::~I2_TemplateClass<{{.*}}> is...*badinc-i2-inl.h
 H_TemplateTemplateClass<> h_templatetemplateclass;
 // IWYU: I2_Class is...*badinc-i2.h
 // IWYU: I2_Class needs a declaration
@@ -820,8 +820,8 @@ I2_InlFileTemplateClass<int> i2_inlfiletemplateclass;
 // IWYU: I2_Class::~I2_Class is...*badinc-i2-inl.h
 I2_Class i2_class_with_inl_constructor("calling ctor in badinc-i2-inl.h");
 // IWYU: I2_TemplateClass is...*badinc-i2.h
-// IWYU: I2_TemplateClass::I2_TemplateClass<.*> is...*badinc-i2-inl.h
-// IWYU: I2_TemplateClass::~I2_TemplateClass<.*> is...*badinc-i2-inl.h
+// IWYU: I2_TemplateClass::I2_TemplateClass<{{.*}}> is...*badinc-i2-inl.h
+// IWYU: I2_TemplateClass::~I2_TemplateClass<{{.*}}> is...*badinc-i2-inl.h
 I2_TemplateClass<int> i2_template_class_with_inl_constructor(4, "inl ctor");
 // We don't need a fwd-decl of I2_TypedefOnly_Class; we get that via badinc.h
 // IWYU: I1_Class needs a declaration
@@ -935,15 +935,15 @@ template class I1_TemplateClass<I1_ClassPtr>;
 int i2_tpl_class_a = i2_template_class_with_inl_constructor.a();
 // IWYU: I2_TemplateClass needs a declaration
 // IWYU: I2_TemplateClass is...*badinc-i2.h
-// IWYU: I2_TemplateClass::I2_TemplateClass<.*> is...*badinc-i2-inl.h
-// IWYU: I2_TemplateClass::~I2_TemplateClass<.*> is...*badinc-i2-inl.h
+// IWYU: I2_TemplateClass::I2_TemplateClass<{{.*}}> is...*badinc-i2-inl.h
+// IWYU: I2_TemplateClass::~I2_TemplateClass<{{.*}}> is...*badinc-i2-inl.h
 // IWYU: I2_TemplateClass::InlFileTemplateClassFn is...*badinc-i2-inl.h
 typedef I2_TemplateClass<int> Cc_typedef_implicit_instantiation;
 // Make sure we can do the same typedef multiple times.
 // IWYU: I2_TemplateClass needs a declaration
 // IWYU: I2_TemplateClass is...*badinc-i2.h
-// IWYU: I2_TemplateClass::I2_TemplateClass<.*> is...*badinc-i2-inl.h
-// IWYU: I2_TemplateClass::~I2_TemplateClass<.*> is...*badinc-i2-inl.h
+// IWYU: I2_TemplateClass::I2_TemplateClass<{{.*}}> is...*badinc-i2-inl.h
+// IWYU: I2_TemplateClass::~I2_TemplateClass<{{.*}}> is...*badinc-i2-inl.h
 // IWYU: I2_TemplateClass::InlFileTemplateClassFn is...*badinc-i2-inl.h
 typedef I2_TemplateClass<int> Cc_typedef_implicit_instantiation2;
 // IWYU: I1_ClassPtr is...*badinc-i1.h
@@ -1017,7 +1017,7 @@ class CC_TemplateClass {
   typedef I1_TemplateClass<A> i1_typedef;
 
   // Let's throw in per-class operator new/delete.
-  // IWYU: size_t is...*((<stddef.h>)|(stdio.h)|(string.h)|(time.h)|(wchar.h))
+  // IWYU: size_t is...*{{<(stddef|stdio|string|time|wchar)\.h>}}
   void* operator new(size_t size) {
     B b;
     (void)b;
@@ -1052,7 +1052,7 @@ int main() {
   // IWYU: I2_Class needs a declaration
   I2_Class* local_i2_class_ptr = 0;  // ptr-only in this .cc, non-ptr in .h
   // IWYU: I2_TemplateClass is...*badinc-i2.h
-  // IWYU: I2_TemplateClass::~I2_TemplateClass<.*> is...*badinc-i2-inl.h
+  // IWYU: I2_TemplateClass::~I2_TemplateClass<{{.*}}> is...*badinc-i2-inl.h
   I2_TemplateClass<int> local_i2_template_class(1);
   // IWYU: I1_PtrDereferenceStruct needs a declaration
   const I1_PtrDereferenceStruct* const local_i1_ptrdereference_struct = 0;
@@ -1334,7 +1334,7 @@ int main() {
   h_scoped_ptr.get();
   // Not an iwyu violation, since we never use the dereferenced type.
   (void)(*h_scoped_ptr);
-  // IWYU: I1_Class is...*badinc-i1.h ?
+  // IWYU: I1_Class is...*badinc-i1.h
   (*h_scoped_ptr).a();
   // IWYU: I1_Class is...*badinc-i1.h
   h_scoped_ptr->a();

--- a/tests/cxx/badinc.h
+++ b/tests/cxx/badinc.h
@@ -291,8 +291,8 @@ typedef std::set<I2_Enum> H_I2Enum_Set;
 typedef std::vector<I2_Class> H_I2Class_Vector_Unused;
 // IWYU: I2_TemplateClass needs a declaration
 // IWYU: I2_TemplateClass is...*badinc-i2.h
-// IWYU: I2_TemplateClass::I2_TemplateClass<.*> is...*badinc-i2-inl.h
-// IWYU: I2_TemplateClass::~I2_TemplateClass<.*> is...*badinc-i2-inl.h
+// IWYU: I2_TemplateClass::I2_TemplateClass<{{.*}}> is...*badinc-i2-inl.h
+// IWYU: I2_TemplateClass::~I2_TemplateClass<{{.*}}> is...*badinc-i2-inl.h
 // IWYU: I2_TemplateClass::InlFileTemplateClassFn is...*badinc-i2-inl.h
 // IWYU: I2_Enum is...*badinc-i2.h
 typedef I2_TemplateClass<I2_Enum> H_TemplateTypedef;
@@ -368,7 +368,7 @@ H_TemplateClass<D3_Enum> h_d3_template_class(D31);
 H_TemplateClass<I2_Enum> h_i2_template_class(I22);
 // TODO(csilvers): this should be attributed to the .h, since it comes
 // via a default template argument.
-// IWYU: I2_TemplateClass::~I2_TemplateClass<.*> is...*badinc-i2-inl.h
+// IWYU: I2_TemplateClass::~I2_TemplateClass<{{.*}}> is...*badinc-i2-inl.h
 H_TemplateTemplateClass<> h_templatetemlpate_class;
 H_TemplateTemplateClass<H_TemplateClass> h_i2_templatetemlpate_class;
 

--- a/tests/cxx/comment_pragmas-d7.h
+++ b/tests/cxx/comment_pragmas-d7.h
@@ -26,7 +26,7 @@
 #include "tests/cxx/indirect.h"  // IWYU pragma: keep
 // IWYU pragma: end_exports
 
-// IWYU: Unknown or malformed pragma \(foo\)
+// IWYU: Unknown or malformed pragma (foo)
 // IWYU pragma: foo
 
 // IWYU: Suggested include must be a quoted header

--- a/tests/cxx/expl_inst_select.cc
+++ b/tests/cxx/expl_inst_select.cc
@@ -24,12 +24,12 @@ extern template class Template<int>;
 // Use of an explicit instantiation for which there is both a declaration and
 // definition in the include closure should prefer a declaration.
 // IWYU: Template is...*expl_inst_select-i1.h
-// IWYU: Template is...*expl_inst_select-i2.h.*for explicit instantiation
+// IWYU: Template is...*expl_inst_select-i2.h...*for explicit instantiation
 Template<short> ts;
 
 // Use of an explicit instantiation for which there is only a definition.
 // IWYU: Template is...*expl_inst_select-i1.h
-// IWYU: Template is...*expl_inst_select-i3.h.*for explicit instantiation
+// IWYU: Template is...*expl_inst_select-i3.h...*for explicit instantiation
 Template<double> td;
 
 // No 'for explicit instantiation' diagnostic for use of an instantiation

--- a/tests/cxx/explicit_instantiation2.cc
+++ b/tests/cxx/explicit_instantiation2.cc
@@ -36,7 +36,7 @@
 
 
 // IWYU: Template is...*explicit_instantiation-template.h
-// IWYU: Template is...*template_bool.h.*for explicit instantiation
+// IWYU: Template is...*template_bool.h...*for explicit instantiation
 Template<bool> t1a; // 1a
 
 // IWYU: Template is...*explicit_instantiation-template.h
@@ -48,7 +48,7 @@ template class Template<bool>;  // 2
 Template<bool> t1b; // 1b
 
 // IWYU: Template is...*explicit_instantiation-template.h
-// IWYU: Template is...*template_short.h.*for explicit instantiation
+// IWYU: Template is...*template_short.h...*for explicit instantiation
 FullUseArg<
     // IWYU: Template needs a declaration
     Template<short>>
@@ -61,11 +61,11 @@ FwdDeclUseArg<
     t4; // 4
 
 // IWYU: Template is...*explicit_instantiation-template.h
-// IWYU: Template is...*template_short.h.*for explicit instantiation
+// IWYU: Template is...*template_short.h...*for explicit instantiation
 TemplateAsDefaultFull<> t5; // 5
 TemplateAsDefaultFwd<> t6; // 6
 
-// IWYU: Template is...*template_short.h.*for explicit instantiation
+// IWYU: Template is...*template_short.h...*for explicit instantiation
 TemplateTemplateArgShortFull<
     // IWYU: Template is...*explicit_instantiation-template.h
     Template>

--- a/tests/cxx/fn_def_args.cc
+++ b/tests/cxx/fn_def_args.cc
@@ -37,10 +37,10 @@ void Fn() {
   FnWithSmearedDefArgs2();
 
   // IWYU: FnWithSmearedDefArgs2 is...*-i2.h
-  // IWYU: ns::FnWithSmearedDefArgs2 is...*-i3.h.*for using decl
+  // IWYU: ns::FnWithSmearedDefArgs2 is...*-i3.h...*for using decl
   ns::FnWithSmearedDefArgs2(1);
   // IWYU: FnWithSmearedDefArgs2 is...*-i1.h
-  // IWYU: ns::FnWithSmearedDefArgs2 is...*-i3.h.*for using decl
+  // IWYU: ns::FnWithSmearedDefArgs2 is...*-i3.h...*for using decl
   ns::FnWithSmearedDefArgs2();
 
   // An appropriate redeclaration is present in this file.

--- a/tests/cxx/implicit_ctor-d1.h
+++ b/tests/cxx/implicit_ctor-d1.h
@@ -14,15 +14,15 @@
 // reference to it.  This is because the class has an implicit
 // constructor.
 
-// IWYU: IndirectWithImplicitCtor is...*implicit_ctor-i2.h.*for autocast
+// IWYU: IndirectWithImplicitCtor is...*implicit_ctor-i2.h...*for autocast
 int ImplicitCtorFn(IndirectWithImplicitCtor);
 
-// IWYU: IndirectWithImplicitCtor is...*implicit_ctor-i2.h.*for autocast
+// IWYU: IndirectWithImplicitCtor is...*implicit_ctor-i2.h...*for autocast
 int ImplicitCtorRefFn(const IndirectWithImplicitCtor&);
 
 // Reporting types for "autocast" for header-defined functions still makes sense
 // as opposed to function definitions in source files.
-// IWYU: IndirectWithImplicitCtor is...*implicit_ctor-i2.h.*for autocast
+// IWYU: IndirectWithImplicitCtor is...*implicit_ctor-i2.h...*for autocast
 inline int InlineImplicitCtorRefFn(const IndirectWithImplicitCtor&) {
   return 1;
 }
@@ -46,7 +46,7 @@ int NoAutocastFn(
 
 // Test that IWYU finds the definition among redeclarations which contains
 // an implicit ctor and requires the complete type here.
-// IWYU: MultipleRedeclStruct is...*implicit_ctor-i2.h.*for autocast
+// IWYU: MultipleRedeclStruct is...*implicit_ctor-i2.h...*for autocast
 void TakeMultipleRedeclStruct(MultipleRedeclStruct);
 
 /**** IWYU_SUMMARY

--- a/tests/cxx/iwyu_stricter_than_cpp-autocast.h
+++ b/tests/cxx/iwyu_stricter_than_cpp-autocast.h
@@ -26,10 +26,10 @@ struct IndirectStruct2;
 
 void FnValues(
     // Requires the full type because it does not obey rule (1)
-    // IWYU: IndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h.*for autocast
+    // IWYU: IndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h...*for autocast
     IndirectStruct1 ic1,
     // This also does not obey rule (1): it's -d1 that does the fwd-declaring.
-    // IWYU: IndirectStructForwardDeclaredInD1 is...*iwyu_stricter_than_cpp-i1.h.*for autocast
+    // IWYU: IndirectStructForwardDeclaredInD1 is...*iwyu_stricter_than_cpp-i1.h...*for autocast
     struct IndirectStructForwardDeclaredInD1 icfdid1,
     // Requires the full type because it does not obey rule (2)
     DirectStruct1 dc1,
@@ -39,17 +39,17 @@ void FnValues(
     IndirectStruct2 ic2);
 
 void FnRefs(
-    // IWYU: IndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h.*for autocast
+    // IWYU: IndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h...*for autocast
     const IndirectStruct1& ic1,
-    // IWYU: IndirectStructForwardDeclaredInD1 is...*iwyu_stricter_than_cpp-i1.h.*for autocast
+    // IWYU: IndirectStructForwardDeclaredInD1 is...*iwyu_stricter_than_cpp-i1.h...*for autocast
     const struct IndirectStructForwardDeclaredInD1& icfdid1,
     const DirectStruct3& dc1, const struct DirectStruct4& dc2,
     const IndirectStruct2& ic2);
 
 inline void HeaderDefinedFnRefs(
-    // IWYU: IndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h.*for autocast
+    // IWYU: IndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h...*for autocast
     const IndirectStruct1& ic1,
-    // IWYU: IndirectStructForwardDeclaredInD1 is...*iwyu_stricter_than_cpp-i1.h.*for autocast
+    // IWYU: IndirectStructForwardDeclaredInD1 is...*iwyu_stricter_than_cpp-i1.h...*for autocast
     const struct IndirectStructForwardDeclaredInD1& icfdid1,
     const DirectStruct5& dc1, const struct DirectStruct6& dc2,
     const IndirectStruct2& ic2) {
@@ -64,30 +64,30 @@ struct TplIndirectStruct2;
 
 void TplFnValues(
     // IWYU: TplIndirectStruct1 needs a declaration
-    // IWYU: TplIndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h.*for autocast
+    // IWYU: TplIndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h...*for autocast
     TplIndirectStruct1<char> ic1,
     // IWYU: TplIndirectStructForwardDeclaredInD1 needs a declaration
-    // IWYU: TplIndirectStructForwardDeclaredInD1 is...*iwyu_stricter_than_cpp-i1.h.*for autocast
+    // IWYU: TplIndirectStructForwardDeclaredInD1 is...*iwyu_stricter_than_cpp-i1.h...*for autocast
     struct TplIndirectStructForwardDeclaredInD1<char> icfdid1,
     TplDirectStruct1<char> dc1, struct TplDirectStruct2<char> dc2,
     TplIndirectStruct2<char> ic2);
 
 void TplFnRefs(
     // IWYU: TplIndirectStruct1 needs a declaration
-    // IWYU: TplIndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h.*for autocast
+    // IWYU: TplIndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h...*for autocast
     const TplIndirectStruct1<char>& ic1,
     // IWYU: TplIndirectStructForwardDeclaredInD1 needs a declaration
-    // IWYU: TplIndirectStructForwardDeclaredInD1 is...*iwyu_stricter_than_cpp-i1.h.*for autocast
+    // IWYU: TplIndirectStructForwardDeclaredInD1 is...*iwyu_stricter_than_cpp-i1.h...*for autocast
     const struct TplIndirectStructForwardDeclaredInD1<char>& icfdid1,
     const TplDirectStruct3<char>& dc1, const struct TplDirectStruct4<char>& dc2,
     const TplIndirectStruct2<char>& ic2);
 
 inline void HeaderDefinedTplFnRefs(
     // IWYU: TplIndirectStruct1 needs a declaration
-    // IWYU: TplIndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h.*for autocast
+    // IWYU: TplIndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h...*for autocast
     const TplIndirectStruct1<char>& ic1,
     // IWYU: TplIndirectStructForwardDeclaredInD1 needs a declaration
-    // IWYU: TplIndirectStructForwardDeclaredInD1 is...*iwyu_stricter_than_cpp-i1.h.*for autocast
+    // IWYU: TplIndirectStructForwardDeclaredInD1 is...*iwyu_stricter_than_cpp-i1.h...*for autocast
     const struct TplIndirectStructForwardDeclaredInD1<char>& icfdid1,
     const TplDirectStruct5<char>& dc1, const struct TplDirectStruct6<char>& dc2,
     const TplIndirectStruct2<char>& ic2) {
@@ -100,34 +100,34 @@ template <typename TFullTypeUsed, typename TForwardDeclarable>
 struct TplIndirectStruct3;
 
 void TplFnValues(
-    // IWYU: IndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h.*for autocast
+    // IWYU: IndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h...*for autocast
     TplIndirectStruct3<IndirectStruct1, IndirectStruct2>
         only_argument_type_provided,
     TplIndirectStruct3<IndirectStruct2, IndirectStruct2> all_forward_declared,
-    // IWYU: IndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h.*for autocast
+    // IWYU: IndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h...*for autocast
     TplDirectStruct7<IndirectStruct1, IndirectStruct2>
         all_needed_types_provided,
     TplDirectStruct7<IndirectStruct2, IndirectStruct2> only_template_provided);
 
 void TplFnRefs(
-    // IWYU: IndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h.*for autocast
+    // IWYU: IndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h...*for autocast
     const TplIndirectStruct3<IndirectStruct1, IndirectStruct2>&
         only_argument_type_provided,
     const TplIndirectStruct3<IndirectStruct2, IndirectStruct2>&
         all_forward_declared,
-    // IWYU: IndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h.*for autocast
+    // IWYU: IndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h...*for autocast
     const TplDirectStruct7<IndirectStruct1, IndirectStruct2>&
         all_needed_types_provided,
     const TplDirectStruct7<IndirectStruct2, IndirectStruct2>&
         only_template_provided);
 
 inline void HeaderDefinedTplFnRefs(
-    // IWYU: IndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h.*for autocast
+    // IWYU: IndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h...*for autocast
     const TplIndirectStruct3<IndirectStruct1, IndirectStruct2>&
         only_argument_type_provided,
     const TplIndirectStruct3<IndirectStruct2, IndirectStruct2>&
         all_forward_declared,
-    // IWYU: IndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h.*for autocast
+    // IWYU: IndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h...*for autocast
     const TplDirectStruct7<IndirectStruct1, IndirectStruct2>&
         all_needed_types_provided,
     const TplDirectStruct7<IndirectStruct2, IndirectStruct2>&
@@ -149,20 +149,20 @@ struct AutocastStruct {
 // IWYU should not print the comment "for autocast" when the type info is
 // mandatory.
 inline void Fn(
-    // IWYU: IndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h.*#included\.
+    // IWYU: IndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h...*#included.
     TplDirectStruct7<decltype(IndirectStruct1::c), IndirectStruct2>) {
 }
 
 // Test that IWYU finds constructors even if they are not instantiated.
 
 // IWYU: NonInstantiated needs a declaration
-// IWYU: NonInstantiated is...*iwyu_stricter_than_cpp-i1.h.*for autocast
+// IWYU: NonInstantiated is...*iwyu_stricter_than_cpp-i1.h...*for autocast
 void Fn(NonInstantiated<char>);
 
 // IWYU: NoAutocastForSpec needs a declaration
 void Fn(NoAutocastForSpec<char>);
 
-// TODO: IWYU: AutocastInPartialSpec is...*iwyu_stricter_than_cpp-i1.h.*for autocast
+// TODO: IWYU: AutocastInPartialSpec is...*iwyu_stricter_than_cpp-i1.h...*for autocast
 // IWYU: AutocastInPartialSpec needs a declaration
 void Fn(AutocastInPartialSpec<char*>);
 

--- a/tests/cxx/iwyu_stricter_than_cpp-fnreturn.h
+++ b/tests/cxx/iwyu_stricter_than_cpp-fnreturn.h
@@ -19,11 +19,11 @@
 // --- Return values of functions.
 
 // Requires the full type because it does not obey rule (1)
-// IWYU: IndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h.*for fn return type
+// IWYU: IndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h...*for fn return type
 IndirectStruct1 DoesNotForwardDeclareFn();
 
 // This also does not obey rule (1): it's -d1 that does the fwd-declaring.
-// IWYU: IndirectStructForwardDeclaredInD1 is...*iwyu_stricter_than_cpp-i1.h.*for fn return type
+// IWYU: IndirectStructForwardDeclaredInD1 is...*iwyu_stricter_than_cpp-i1.h...*for fn return type
 struct IndirectStructForwardDeclaredInD1 DoesNotForwardDeclareProperlyFn();
 
 // Requires the full type because it does not obey rule (2)
@@ -40,7 +40,7 @@ IndirectStruct2 DoesEverythingRightFn();
 // --- Now do it all again, with templates!
 
 // IWYU: TplIndirectStruct1 needs a declaration
-// IWYU: TplIndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h.*for fn return type
+// IWYU: TplIndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h...*for fn return type
 TplIndirectStruct1<int> TplDoesNotForwardDeclareFn();
 
 // A bit of an asymmetry with the non-tpl case: 'struct
@@ -48,7 +48,7 @@ TplIndirectStruct1<int> TplDoesNotForwardDeclareFn();
 // forward-declared because it's elaborated, but template types need
 // to be forward-declared even when they're elaborated.
 // IWYU: TplIndirectStructForwardDeclaredInD1 needs a declaration
-// IWYU: TplIndirectStructForwardDeclaredInD1 is...*iwyu_stricter_than_cpp-i1.h.*for fn return type
+// IWYU: TplIndirectStructForwardDeclaredInD1 is...*iwyu_stricter_than_cpp-i1.h...*for fn return type
 struct TplIndirectStructForwardDeclaredInD1<int>
 TplDoesNotForwardDeclareProperlyFn();
 
@@ -70,13 +70,13 @@ TplIndirectStruct2<float> TplDoesEverythingRightAgainFn();
 template <typename TFullTypeUsed, typename TForwardDeclarable>
 struct TplIndirectStruct3;
 
-// IWYU: IndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h.*for fn return type
+// IWYU: IndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h...*for fn return type
 TplIndirectStruct3<IndirectStruct1, IndirectStruct2>
 TplOnlyArgumentTypeProvidedFn();
 
 TplIndirectStruct3<IndirectStruct2, IndirectStruct2> TplAllForwardDeclaredFn();
 
-// IWYU: IndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h.*for fn return type
+// IWYU: IndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h...*for fn return type
 TplDirectStruct7<IndirectStruct1, IndirectStruct2>
 TplAllNeededTypesProvidedFn();
 
@@ -94,7 +94,7 @@ struct FnreturnStruct {
 };
 
 // IWYU should not print the comment "for fn return type" when the type info is mandatory.
-// IWYU: IndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h.*#included\.
+// IWYU: IndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h...*#included.
 decltype(IndirectStruct1::c) FnReturningTypeOfMember();
 
 

--- a/tests/cxx/reexport_overridden-d1.h
+++ b/tests/cxx/reexport_overridden-d1.h
@@ -34,7 +34,7 @@ class Derived1 : public Base {
 
   // The using-declaration should be reported but the forward-declaration
   // should not.
-  // IWYU: ns::FwdRetType is...*reexport_overridden-i3.h.*for using decl
+  // IWYU: ns::FwdRetType is...*reexport_overridden-i3.h...*for using decl
   ns::FwdRetType ReturnPulledInOtherNSInDerived() override;
 
   // Unused argument available from Base.
@@ -69,7 +69,7 @@ class Derived1 : public Base {
 
   // The using-declaration should be reported but the forward-declaration
   // should not.
-  // IWYU: ns::IndirectClass is...*reexport_overridden-i3.h.*for using decl
+  // IWYU: ns::IndirectClass is...*reexport_overridden-i3.h...*for using decl
   void TakePulledInOtherNSInDerived(ns::IndirectClass) override;
 
   // IWYU should not suggest IndirectClass fwd-declaration here.

--- a/tests/cxx/template_spec_mapping.cc
+++ b/tests/cxx/template_spec_mapping.cc
@@ -19,7 +19,7 @@ Tpl<char, 2, OtherTpl> t1;
 // IWYU: Tpl<int, 1, OtherTpl> is...*-i3.h
 Tpl<int, 1, OtherTpl> t2;
 // IWYU: OtherTpl is...*-i1.h
-// IWYU: Tpl<:0 \*, :1, :2> is...*-i4.h
+// IWYU: Tpl<:0 *, :1, :2> is...*-i4.h
 Tpl<int*, 1, OtherTpl> t3;
 
 // IWYU: TplWithDefArg is...*-i2.h
@@ -27,7 +27,7 @@ TplWithDefArg<int, int> twda1;
 // TODO: reporting the primary template due to the presence of a default
 // argument is redundant here.
 // IWYU: TplWithDefArg is...*-i2.h
-// IWYU: TplWithDefArg<int \*, char> is...*-i3.h
+// IWYU: TplWithDefArg<int *, char> is...*-i3.h
 TplWithDefArg<int*> twda3;
 // IWYU: TplWithDefArg is...*-i2.h
 // IWYU: TplWithDefArg<:0, char> is...*-i4.h
@@ -55,7 +55,7 @@ TplParamPack1<int, char> tpp12;
 TplParamPack1<int, char, float> tpp13;
 // IWYU: TplParamPack1<int, :0, :1...> is...*-i3.h
 TplParamPack1<int, char, float, double> tpp14;
-// IWYU: TplParamPack1<:0 \*...> is...*-i4.h
+// IWYU: TplParamPack1<:0 *...> is...*-i4.h
 TplParamPack1<int*, char*> tpp15;
 
 // IWYU: TplParamPack2 is...*-i2.h
@@ -67,7 +67,7 @@ TplParamPack2<int, char, float> tpp22;
 static_assert(var_tpl<int> == 1);
 // IWYU: var_tpl<char> is...*-i3.h
 static_assert(var_tpl<char> == 2);
-// IWYU: var_tpl<:0 \*> is...*-i4.h
+// IWYU: var_tpl<:0 *> is...*-i4.h
 static_assert(var_tpl<int*> == 3);
 
 /**** IWYU_SUMMARY


### PR DESCRIPTION
99+% of our assertions follow this form:

    // IWYU: SomeType is...*someheader.h
    // IWYU: SomeType needs a declaration

Under the hood the expected diagnostic text after '// IWYU:' is
turned into a regular expression which is then matched against actual
IWYU diagnostics.

We've had some minor friction with this in the past, e.g. having to
escape parentheses and periods, such as:

    // IWYU: Unknown or malformed pragma \(foo\)
    // IWYU: I1_TemplateClass is...*badinc-i1.h.*#included\.

This has not been a pressing issue so far, but we're now considering
reporting full function signatures instead of just function names, and
escaping C++ function argument lists makes them nearly unreadable:

    // IWYU: printf\(const char \*, \.\.\.\) is...*<stdio.h>
    // IWYU: I2_Class::~I2_Class\(\) is...*badinc-i2-inl.h
    // IWYU: puts\(const char \*\) is...*stdio.h
    // IWYU: Fn\(const unsigned int \(\*\)\[5\]\[7\]\) is...*-i22.h

So turn the implementation around, and treat everything as literal text,
except:

- `{{pattern}}`
- `...*`, which is now an alias for `{{.*}}`

The `{{pattern}}` syntax and some of its implementation is inspired by
LLVM's FileCheck tool, which is used to verify most of Clang's
diagnostics, and so has a good track record for C++ code.

The examples above would now be spelled as:

    // IWYU: SomeType is...*someheader.h
    // IWYU: SomeType needs a declaration
    // IWYU: Unknown or malformed pragma (foo)
    // IWYU: I1_TemplateClass is...*badinc-i1.h...*#included.
    // IWYU: printf(const char *, ...) is...*<stdio.h>
    // IWYU: I2_Class::~I2_Class() is...*badinc-i2-inl.h
    // IWYU: puts(const char *) is...*stdio.h
    // IWYU: Fn(const unsigned int (*)[5][7]) is...*-i22.h

We had a limited number of wildcard matches, and mostly for template
argument lists. They used to be spelled:

    // IWYU: I2_TemplateClass::I2_TemplateClass<.*> is...*badinc-i2-inl.h

but now require a bit more syntax:

    // IWYU: I2_TemplateClass::I2_TemplateClass<{{.*}}> is...*badinc-i2-inl.h
    // or, with alias
    // IWYU: I2_TemplateClass::I2_TemplateClass<...*> is...*badinc-i2-inl.h

Update all affected tests to use the new format.