### PR TITLE
Move main() out into separate file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,6 +134,7 @@ add_llvm_executable(include-what-you-use
   iwyu_include_picker.cc
   iwyu_lexer_utils.cc
   iwyu_location_util.cc
+  iwyu_main.cc
   iwyu_output.cc
   iwyu_path_util.cc
   iwyu_port.cc

--- a/iwyu.h
+++ b/iwyu.h
@@ -1,0 +1,41 @@
+//===--- iwyu.h - iwyu main module - C++ ----------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "clang/Frontend/FrontendAction.h"
+
+namespace clang {
+namespace driver {
+class ToolChain;
+}
+}  // namespace clang
+
+namespace include_what_you_use {
+
+using clang::ASTConsumer;
+using clang::ASTFrontendAction;
+using clang::CompilerInstance;
+using clang::driver::ToolChain;
+using llvm::StringRef;
+
+// We use an ASTFrontendAction to hook up IWYU with Clang.
+class IwyuAction : public ASTFrontendAction {
+ public:
+  explicit IwyuAction(const ToolChain& toolchain);
+
+ protected:
+  std::unique_ptr<ASTConsumer> CreateASTConsumer(CompilerInstance& compiler,
+                                                 StringRef) override;
+
+ private:
+  // ToolChain is not copyable, but it's owned by Compilation which has the same
+  // lifetime as CompilerInstance, so it should be alive for as long as we are.
+  const ToolChain& toolchain_;
+};
+
+}  // namespace include_what_you_use

--- a/iwyu_main.cc
+++ b/iwyu_main.cc
@@ -1,0 +1,54 @@
+//===--- iwyu_main.cc - iwyu main function --------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cstdlib>
+#include <memory>
+
+#include "iwyu.h"
+#include "iwyu_driver.h"
+#include "iwyu_globals.h"
+#include "llvm/Support/ManagedStatic.h"
+#include "llvm/Support/TargetSelect.h"
+
+// The lambda passed to ExecuteAction mentions FrontendAction, but it shouldn't
+// be needed here.
+// IWYU pragma: no_include "clang/Frontend/FrontendAction.h"
+
+namespace clang {
+namespace driver {
+class ToolChain;
+}  // namespace driver
+}  // namespace clang
+
+int main(int argc, char** argv) {
+  using clang::driver::ToolChain;
+  using include_what_you_use::ExecuteAction;
+  using include_what_you_use::IwyuAction;
+  using include_what_you_use::OptionsParser;
+
+  llvm::llvm_shutdown_obj scoped_shutdown;
+
+  // X86 target is required to parse Microsoft inline assembly, so we hope it's
+  // part of all targets. Clang parser will complain otherwise.
+  llvm::InitializeAllTargetInfos();
+  llvm::InitializeAllTargetMCs();
+  llvm::InitializeAllAsmParsers();
+
+  // The command line should look like
+  //   path/to/iwyu -Xiwyu --verbose=4 [-Xiwyu --other_iwyu_flag]... \
+  //       CLANG_FLAGS... foo.cc
+  OptionsParser options_parser(argc, argv);
+  if (!ExecuteAction(options_parser.clang_argc(), options_parser.clang_argv(),
+                     [](const ToolChain& toolchain) {
+                       return std::make_unique<IwyuAction>(toolchain);
+                     })) {
+    return EXIT_FAILURE;
+  }
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
As a consequence, move the `IwyuAction` declaration out into `iwyu.h` so we can share it between `iwyu_main.cc` and `iwyu.cc`.

This should make it easier to link parts of IWYU into other targets.