### PR TITLE
Set up infrastructure for IWYU unittests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -265,6 +265,32 @@ if (MSVC)
   )
 endif()
 
+# Add unittest target.
+add_llvm_executable(iwyu-unittests
+  unittests/iwyu_unittest_main.cc
+)
+
+target_include_directories(iwyu-unittests PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+target_link_libraries(iwyu-unittests PRIVATE
+  iwyu
+  iwyu-gtest
+)
+
+enable_testing()
+add_test(NAME iwyu-unittests
+  COMMAND $<TARGET_FILE:iwyu-unittests>
+)
+
+# Expose a custom run-unittests target in the generated buildsystem.
+add_custom_target(run-unittests
+  DEPENDS iwyu-unittests
+  COMMAND $<TARGET_FILE:iwyu-unittests>
+  USES_TERMINAL
+)
+
 # Install programs.
 include(GNUInstallDirs)
 install(TARGETS
@@ -295,8 +321,6 @@ endif()
 find_package(Python3 COMPONENTS Interpreter)
 if (Python3_Interpreter_FOUND)
   # Map the various IWYU test scripts to CTest tests.
-  enable_testing()
-
   function(iwyu_add_test name file)
     add_test(NAME ${name}
       COMMAND ${Python3_EXECUTABLE} run_iwyu_tests.py --run-test-file=${file}

--- a/unittests/iwyu_unittest_main.cc
+++ b/unittests/iwyu_unittest_main.cc
@@ -1,0 +1,41 @@
+//===--- iwyu_unittest_main.cc - unittest driver --------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+#if defined(_WIN32)
+#include <windows.h>
+#if defined(_MSC_VER)
+#include <crtdbg.h>
+#endif
+#endif
+
+#include "gtest/gtest.h"
+
+#include "iwyu_globals.h"
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  include_what_you_use::InitGlobalsAndFlagsForTesting();
+
+  // Shamelessly borrowed from LLVM.
+#if defined(_WIN32)
+  // Disable all of the possible ways Windows conspires to make automated
+  // testing impossible.
+  ::SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX);
+#if defined(_MSC_VER)
+  ::_set_error_mode(_OUT_TO_STDERR);
+  _CrtSetReportMode(_CRT_WARN, _CRTDBG_MODE_FILE | _CRTDBG_MODE_DEBUG);
+  _CrtSetReportFile(_CRT_WARN, _CRTDBG_FILE_STDERR);
+  _CrtSetReportMode(_CRT_ERROR, _CRTDBG_MODE_FILE | _CRTDBG_MODE_DEBUG);
+  _CrtSetReportFile(_CRT_ERROR, _CRTDBG_FILE_STDERR);
+  _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE | _CRTDBG_MODE_DEBUG);
+  _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
+#endif  // defined(_MSC_VER)
+#endif  // defined(_WIN32)
+
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Add iwyu-unittests and run-unittests targets.

Add a shared iwyu_unittest_main.cc which sets up IWYU globals before
running tests.

We can now build and run unittests with either of these commands:

    ninja iwyu-unittests && ./bin/iwyu-unittests
    ninja iwyu-unittests && ctest [--output-on-failure] -R "unittest"
    ninja run-unittests

Unittests will automatically be picked up in CI by ctest.

No tests registered for execution yet.
