### PR TITLE
Fix build with GCC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,7 +135,7 @@ set(LLVM_LINK_COMPONENTS
   AllTargetsInfos
 )
 
-add_library(iwyu
+add_llvm_library(iwyu
   iwyu.cc
   iwyu_ast_util.cc
   iwyu_cache.cc


### PR DESCRIPTION
`llvm_update_compile_flags` CMake function called from `llvm_add_library` adds some compiler flags which are required to build correctly with GCC.

The problem was introduced in 9c7a6a3c08af3ecfc6e0a8716455435c696b7bb2.