### PR TITLE
[cmake] Use add_llvm_library consistently

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,7 +135,7 @@ set(LLVM_LINK_COMPONENTS
   AllTargetsInfos
 )
 
-add_library(iwyu
+add_llvm_library(iwyu
   iwyu.cc
   iwyu_ast_util.cc
   iwyu_cache.cc
@@ -233,7 +233,7 @@ if (WIN32)
 endif()
 
 # Build vendored gtest library
-add_library(iwyu-gtest
+add_llvm_library(iwyu-gtest
   vendor/googletest/src/gtest-all.cc
 )
 


### PR DESCRIPTION
When I added library targets in 9c7a6a3c08af3ecfc6e0a8716455435c696b7bb2 and 424512f68f09ed442277ff1bebde2b9a9c145750, it didn't occur to me that they (obviously) must use the same compiler flags as LLVM at large.

This did not lead to any problems on my GCC 13.3.0 system, nor in the Clang-based CI builds, but there were reports of undefined references for `typeinfo for clang::AstConsumer` and mismatched new/delete warnings in Clang headers.

Use add_llvm_library to keep things consistent between LLVM and all IWYU code.

Thanks to @bolshakov-a who noticed that we lost a bunch of GCC flags in the library conversion, and who also proposed this fix.