### PR TITLE
Fix missing include name in @headername mapping

### DIFF
--- a/iwyu_preprocessor.h
+++ b/iwyu_preprocessor.h
@@ -258,8 +258,9 @@ class IwyuPreprocessorInfo : public clang::PPCallbacks,
   // Determine if the comment is a pragma, and if so, process it.
   void HandlePragmaComment(clang::SourceRange comment_range);
 
-  // Process @headername directives in a file.
-  void ProcessHeadernameDirectivesInFile(clang::SourceLocation file_beginning);
+  // Process @headername directives in a file include as include_name.
+  void ProcessHeadernameDirectivesInFile(const string& include_name,
+                                         clang::SourceLocation file_beginning);
 
   // Checks whether it's OK to use the given macro defined in file defined_in.
   void ReportMacroUse(const string& name,


### PR DESCRIPTION
The bug report describes how IWYU fails to resolve the private include
name for libstdc++ bits/unicode-data.h:

    warning: no private include name for @headername mapping

The bits/unicode-data.h header is included via bits/unicode.h from
`<format>` in c++20 mode. What makes it special is the spelling:

    // main.cc
    #include <format>  // angled

    // format
    #include <bits/unicode.h>  // angled

    // bits/unicode.h
    #include "unicode-data.h"  // quoted and no bits/ prefix

Here libstdc++ relies on the conventional rule that the compiler
searches the includer's directory for quoted includes, before scanning
the search path, and will find unicode-data.h in bits/ next to
unicode.h.

We used Clang's HeaderSearchInfo::getIncludeNameForHeader, which is
supposed to return a good include name for a file entry. But it turns
out it only captures the include name in a limited set of cases, and
particularly does not register it for the implicit-includer-directory
case: https://github.com/llvm/llvm-project/issues/174482.

As the bug report notes, it's hard to come up with good semantics for
that function.

I eventually realized that we already listen to all preprocessor events,
and have the current include name available. Use our own data instead of
reaching out to Clang.

Fixes #1811.
