### PR TITLE
Remove a couple of pragmas from IWYU source code

### DIFF
--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -62,7 +62,6 @@
 // TODO: Clean out pragmas as IWYU improves.
 // IWYU pragma: no_include "clang/AST/StmtIterator.h"
 // IWYU pragma: no_include "clang/Basic/CustomizableOptional.h"
-// IWYU pragma: no_include <iterator>
 // IWYU pragma: no_include <tuple>
 
 using clang::ASTContext;

--- a/iwyu_ast_util.h
+++ b/iwyu_ast_util.h
@@ -31,8 +31,6 @@
 #include "iwyu_use_flags.h"
 #include "llvm/Support/Casting.h"
 
-// IWYU pragma: no_include <iterator>
-
 namespace clang {
 class ASTContext;
 class CXXConstructExpr;


### PR DESCRIPTION
The issue was fixed in 309f9be69030b708bc4193755ddd4985d0947b22.

No functional change.