### PR TITLE
Fix dependent array size expression in mappings

### DIFF
--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -570,6 +570,7 @@ string GetWrittenQualifiedNameAsString(const NamedDecl* named_decl) {
   PrintingPolicy printing_policy =
       named_decl->getASTContext().getPrintingPolicy();
   printing_policy.SuppressUnwrittenScope = true;
+  printing_policy.PrintAsCanonical = true;
   named_decl->printQualifiedName(ostream, printing_policy);
 
   if (const auto* cls_spec =

--- a/tests/cxx/template_spec_mapping-i1.h
+++ b/tests/cxx/template_spec_mapping-i1.h
@@ -19,6 +19,9 @@ class Tpl<int, 1, OtherTpl> {};
 template <typename T, int I, template <int> typename Other>
 class Tpl<T*, I, Other> {};
 
+template <typename T, int I, int K>
+class Tpl<T[I], K, OtherTpl> {};
+
 template <typename, typename = char>
 class TplWithDefArg {};
 

--- a/tests/cxx/template_spec_mapping.cc
+++ b/tests/cxx/template_spec_mapping.cc
@@ -21,6 +21,9 @@ Tpl<int, 1, OtherTpl> t2;
 // IWYU: OtherTpl is...*-i1.h
 // IWYU: Tpl<:0 *, :1, :2> is...*-i4.h
 Tpl<int*, 1, OtherTpl> t3;
+// IWYU: OtherTpl is...*-i1.h
+// IWYU: Tpl<:0[:1], :2, OtherTpl> is...*-i5.h
+Tpl<int[5], 7, OtherTpl> t4;
 
 // IWYU: TplWithDefArg is...*-i2.h
 TplWithDefArg<int, int> twda1;
@@ -77,6 +80,7 @@ tests/cxx/template_spec_mapping.cc should add these lines:
 #include "tests/cxx/template_spec_mapping-i2.h"
 #include "tests/cxx/template_spec_mapping-i3.h"
 #include "tests/cxx/template_spec_mapping-i4.h"
+#include "tests/cxx/template_spec_mapping-i5.h"
 
 tests/cxx/template_spec_mapping.cc should remove these lines:
 - #include "tests/cxx/template_spec_mapping-d1.h"  // lines XX-XX
@@ -86,5 +90,6 @@ The full include-list for tests/cxx/template_spec_mapping.cc:
 #include "tests/cxx/template_spec_mapping-i2.h"  // for Tpl, TplParamPack1, TplParamPack2, TplSpecDistinguishedByIndices, TplWithDeducibleNTTP, TplWithDefArg, var_tpl
 #include "tests/cxx/template_spec_mapping-i3.h"  // for Tpl, TplParamPack1, TplParamPack2, TplSpecDistinguishedByIndices, TplWithDeducibleNTTP, TplWithDefArg, var_tpl
 #include "tests/cxx/template_spec_mapping-i4.h"  // for Tpl, TplParamPack1, TplSpecDistinguishedByIndices, TplWithDeducibleNTTP, TplWithDefArg, var_tpl
+#include "tests/cxx/template_spec_mapping-i5.h"  // for Tpl
 
 ***** IWYU_SUMMARY */

--- a/tests/cxx/template_spec_mapping.imp
+++ b/tests/cxx/template_spec_mapping.imp
@@ -2,6 +2,7 @@
   { "symbol": ["Tpl", "private", "\"tests/cxx/template_spec_mapping-i2.h\"", "public"] },
   { "symbol": ["Tpl<int, 1, OtherTpl>", "private", "\"tests/cxx/template_spec_mapping-i3.h\"", "public"] },
   { "symbol": ["Tpl<:0 *, :1, :2>", "private", "\"tests/cxx/template_spec_mapping-i4.h\"", "public"] },
+  { "symbol": ["Tpl<:0[:1], :2, OtherTpl>", "private", "\"tests/cxx/template_spec_mapping-i5.h\"", "public"] },
 
   { "symbol": ["TplWithDefArg", "private", "\"tests/cxx/template_spec_mapping-i2.h\"", "public"] },
   { "symbol": ["TplWithDefArg<int *, char>", "private", "\"tests/cxx/template_spec_mapping-i3.h\"", "public"] },


### PR DESCRIPTION
Symbol mappings should not rely on exact names of partial specialization template parameters. To avoid them in dependent array size expressions, the printing policy should be adjusted to canonicalize types.