### PR TITLE
Rename run target for unittests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -284,8 +284,8 @@ add_test(NAME iwyu-unittests
   COMMAND $<TARGET_FILE:iwyu-unittests>
 )
 
-# Expose a custom run-unittests target in the generated buildsystem.
-add_custom_target(run-unittests
+# Expose a custom run target in the generated buildsystem.
+add_custom_target(iwyu-run-unittests
   DEPENDS iwyu-unittests
   COMMAND $<TARGET_FILE:iwyu-unittests>
   USES_TERMINAL


### PR DESCRIPTION
Add an 'iwyu-' prefix to avoid the risk of clashing with LLVM targets when IWYU is built as part of the LLVM CMake system.