### PR TITLE
Report enumerations for __PRETTY_FUNCTION__

### DIFF
--- a/tests/cxx/enums-i1.h
+++ b/tests/cxx/enums-i1.h
@@ -12,4 +12,6 @@
 
 enum IndirectEnum1 { A, B, C };
 
+constexpr IndirectEnum1 g_ie1 = A;
+
 #endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_ENUMS_I1_H_

--- a/tests/cxx/enums-i2.h
+++ b/tests/cxx/enums-i2.h
@@ -12,4 +12,8 @@
 
 enum class IndirectEnum2 : int { A, B, C };
 
+enum class IndirectEnum8 { A, B, C };
+
+enum IndirectEnum9 : int { A9, B9, C9 };
+
 #endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_ENUMS_I2_H_

--- a/tests/cxx/enums_ms_mode-direct.h
+++ b/tests/cxx/enums_ms_mode-direct.h
@@ -1,0 +1,10 @@
+//===--- enums_ms_mode-direct.h - test input file for iwyu ----------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/enums_ms_mode-indirect.h"

--- a/tests/cxx/enums_ms_mode-indirect.h
+++ b/tests/cxx/enums_ms_mode-indirect.h
@@ -1,0 +1,10 @@
+//===--- enums_ms_mode-indirect.h - test input file for iwyu --------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+enum class IndirectScopedEnum { A, B, C };

--- a/tests/cxx/enums_ms_mode.cc
+++ b/tests/cxx/enums_ms_mode.cc
@@ -1,0 +1,63 @@
+//===--- enums_ms_mode.cc - test input file for iwyu ----------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_ARGS: -I . -fms-extensions
+
+// Tests Microsoft-specific aspects of enumeration handling. In particular,
+// tests that MSVC predefined variable __FUNCSIG__ triggers suggestions
+// to provide complete enum definition if any enumeration item is present
+// in the function template arguments.
+
+#include "tests/cxx/enums_ms_mode-direct.h"
+
+template <auto E>
+auto GetLFunctionStr() {
+  return L__FUNCTION__;
+}
+
+template <auto E>
+auto GetFuncDNameStr() {
+  return __FUNCDNAME__;
+}
+
+template <auto E>
+auto GetFuncSigStr() {
+  return __FUNCSIG__;
+}
+
+template <auto E>
+auto GetLFuncSigStr() {
+  return L__FUNCSIG__;
+}
+
+void Fn() {
+  // IWYU: IndirectScopedEnum needs a declaration
+  constexpr IndirectScopedEnum ie{};
+  GetLFunctionStr<ie>();
+  GetFuncDNameStr<ie>();
+  // The complete enum definition is required to produce correct strings
+  // containing the item name as written.
+  // IWYU: IndirectScopedEnum is...*-indirect.h
+  GetFuncSigStr<ie>();
+  // IWYU: IndirectScopedEnum is...*-indirect.h
+  GetLFuncSigStr<ie>();
+}
+
+/**** IWYU_SUMMARY
+
+tests/cxx/enums_ms_mode.cc should add these lines:
+#include "tests/cxx/enums_ms_mode-indirect.h"
+
+tests/cxx/enums_ms_mode.cc should remove these lines:
+- #include "tests/cxx/enums_ms_mode-direct.h"  // lines XX-XX
+
+The full include-list for tests/cxx/enums_ms_mode.cc:
+#include "tests/cxx/enums_ms_mode-indirect.h"  // for IndirectScopedEnum
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
Into some function-local predefined variables, compilers insert function template arguments. Some libraries like [MagicEnum](https://github.com/Neargye/magic_enum) make use of this to perform compile-time reflection on enumerations, allowing e.g. getting the written names of enumeration items. To actually have item names instead of number values, the complete enum type info must be present.