### PR TITLE
Fix bug test for #1250

### DIFF
--- a/tests/bugs/1250/1250.cc
+++ b/tests/bugs/1250/1250.cc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// IWYU_ARGS: -stdlib=libc++
+// IWYU_ARGS: -stdlib=libstdc++
 // IWYU_XFAIL
 
 #include "1250.h"


### PR DESCRIPTION
It is libstdc++ on which IWYU output is not ideal, not libc++. The test failed due to absence of libc++ on the server.