### PR TITLE
Add parameter pack elements to resugar_map

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -5348,7 +5348,7 @@ class IwyuAstConsumer
     if (!InImplicitCode(current_ast_node())) {
       const TemplateDecl* tpl = type->getTemplateName().getAsTemplateDecl();
       size_t num_written_args = type->template_arguments().size();
-      if (num_written_args < tpl->getTemplateParameters()->size()) {
+      if (num_written_args < GetTplParamNumberWithoutPack(tpl)) {
         // If the type as-written makes use of default arguments, select exactly
         // that redeclaration which specifies the first default argument used.
         ReportDeclForwardDeclareUse(

--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -57,6 +57,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/iterator_range.h"
 #include "llvm/Support/Casting.h"
 
 // TODO: Clean out pragmas as IWYU improves.
@@ -1525,8 +1526,15 @@ const NamedDecl* GetIndependentRedecl(const NamedDecl* decl) {
   // If there is no redeclaration without any explicitly written default
   // arguments, return the one specifying the last argument because it doesn't
   // depend on any other redeclaration.
-  unsigned last_param_idx = redeclarable->getTemplateParameters()->size() - 1;
+  unsigned last_param_idx = GetTplParamNumberWithoutPack(redeclarable) - 1;
   return GetRedeclSpecifyingDefArg(last_param_idx, redeclarable);
+}
+
+unsigned GetTplParamNumberWithoutPack(const TemplateDecl* tpl) {
+  const TemplateParameterList* params = tpl->getTemplateParameters();
+  unsigned size = params->size();
+  CHECK_(size > 0);
+  return params->hasParameterPack() ? size - 1 : size;
 }
 
 // --- Utilities for Type.
@@ -1761,15 +1769,22 @@ static TemplateInstantiationData GetTplInstDataForClassNoComponentTypes(
   // Pull the template arguments out of the specialization type. If this is
   // a ClassTemplateSpecializationDecl specifically, we want to
   // get the arguments therefrom to correctly handle default arguments.
-  llvm::ArrayRef<TemplateArgument> tpl_args = written_tpl_args;
-  unsigned num_args = tpl_args.size();
+  vector<TemplateArgument> tpl_args = written_tpl_args;
 
   if (cls_tpl_decl) {
     const TemplateArgumentList& tpl_arg_list =
         cls_tpl_decl->getTemplateInstantiationArgs();
     tpl_args = tpl_arg_list.asArray();
-    num_args = tpl_arg_list.size();
+
+    CHECK_(!tpl_args.empty());
+    // Make a copy because a reference may be invalidated later.
+    TemplateArgument last = tpl_args.back();
+    if (last.getKind() == TemplateArgument::Pack) {
+      tpl_args.pop_back();
+      tpl_args.insert(tpl_args.end(), last.pack_begin(), last.pack_end());
+    }
   }
+  unsigned num_args = tpl_args.size();
 
   // TemplateSpecializationType only includes explicitly specified
   // types in its args list, so we start with that.  Note that an

--- a/iwyu_ast_util.h
+++ b/iwyu_ast_util.h
@@ -792,6 +792,8 @@ bool IsDefTplArgInherited(const clang::NamedDecl* tpl_param);
 // parameter declaration.
 bool IsDefTplArgSpecified(const clang::NamedDecl* tpl_param);
 
+unsigned GetTplParamNumberWithoutPack(const clang::TemplateDecl*);
+
 // --- Utilities for Type.
 
 // See if a given type is a 'real' elaborated type.  (An

--- a/tests/cxx/template_args.cc
+++ b/tests/cxx/template_args.cc
@@ -256,6 +256,76 @@ void TestParameterPack() {
   TplFnWithParameterPack();
 }
 
+// Test handling class template parameter packs.
+
+template <typename... Args>
+struct TplStructWithParameterPack1 : Args... {};
+
+// IWYU: IndirectClass needs a declaration
+// IWYU: IndirectClass is...*indirect.h
+// IWYU: TplInI1 needs a declaration
+// IWYU: TplInI1 is...*-i1.h
+TplStructWithParameterPack1<IndirectClass, TplInI1<int>> tswpp11;
+
+// IWYU: IndirectClass needs a declaration
+// IWYU: IndirectClass is...*indirect.h
+TplStructWithParameterPack1<IndirectClass> tswpp12;
+
+// Test that IWYU doesn't crash.
+TplStructWithParameterPack1<> tswpp13;
+
+template <typename T, typename... Args>
+struct TplStructWithParameterPack2 : T, Args... {};
+
+// IWYU: IndirectClass needs a declaration
+// IWYU: IndirectClass is...*indirect.h
+// IWYU: IndirectTemplate needs a declaration
+// IWYU: IndirectTemplate is...*indirect.h
+// IWYU: TplInI1 needs a declaration
+// IWYU: TplInI1 is...*-i1.h
+TplStructWithParameterPack2<IndirectClass, IndirectTemplate<int>, TplInI1<int>>
+    // IWYU: IndirectClass is...*indirect.h
+    // IWYU: IndirectTemplate is...*indirect.h
+    // IWYU: TplInI1 is...*-i1.h
+    tswpp21;
+
+// IWYU: IndirectClass needs a declaration
+// IWYU: IndirectClass is...*indirect.h
+// IWYU: IndirectTemplate needs a declaration
+// IWYU: IndirectTemplate is...*indirect.h
+TplStructWithParameterPack2<IndirectClass, IndirectTemplate<int>> tswpp22;
+
+// IWYU: IndirectClass needs a declaration
+// IWYU: IndirectClass is...*indirect.h
+TplStructWithParameterPack2<IndirectClass> tswpp23;
+
+// IWYU: IndirectClass is...*indirect.h
+template <typename T = IndirectClass, typename... Args>
+struct TplStructWithParameterPackAndDefArg : T, Args... {};
+
+// IWYU: IndirectClass needs a declaration
+// IWYU: IndirectClass is...*indirect.h
+// IWYU: IndirectTemplate needs a declaration
+// IWYU: IndirectTemplate is...*indirect.h
+TplStructWithParameterPackAndDefArg<IndirectClass, IndirectTemplate<int>>
+    // IWYU: IndirectClass is...*indirect.h
+    // IWYU: IndirectTemplate is...*indirect.h
+    tswppda1;
+
+// IWYU: IndirectClass needs a declaration
+// IWYU: IndirectClass is...*indirect.h
+TplStructWithParameterPackAndDefArg<IndirectClass> tswppda2;
+
+// Test that IWYU doesn't crash. There should be only one redecl of
+// TplStructWithParameterPackAndDefArg to test it correctly.
+// IWYU: IndirectClass needs a declaration
+TplStructWithParameterPackAndDefArg<IndirectClass>* ptswppda2;
+
+// TODO: probably, no need of IndirectClass here, because it is reported
+// at template declaration.
+// IWYU: IndirectClass is...*indirect.h
+TplStructWithParameterPackAndDefArg<> tswppda3;
+
 // IWYU: TplHost needs a declaration
 // IWYU: TplHost is...*-i1.h
 TplHost::InnerTpl<TplHost> inner_tpl;
@@ -275,7 +345,7 @@ tests/cxx/template_args.cc should remove these lines:
 - #include "tests/cxx/direct.h"  // lines XX-XX
 
 The full include-list for tests/cxx/template_args.cc:
-#include "tests/cxx/indirect.h"  // for IndirectClass
+#include "tests/cxx/indirect.h"  // for IndirectClass, IndirectTemplate
 #include "tests/cxx/template_args-d1.h"  // for ProvidingAlias
 #include "tests/cxx/template_args-d2.h"  // for NonProvidingAlias, NonProvidingFunctionAlias1, NonProvidingFunctionAlias2
 #include "tests/cxx/template_args-i1.h"  // for TplHost, TplInI1


### PR DESCRIPTION
`InstantiatedTemplateVisitor` only reports types presented in `resugar_map`. This change appends template arguments passed to a class template parameter pack to `resugar_map`, thus allowing them to be reported.

This fixes the case reported in https://github.com/include-what-you-use/include-what-you-use/issues/323#issuecomment-3812413057, because the second parameter of `boost::variant` is a parameter pack.

Besides, this fixes some crashes in `GetRedeclSpecifyingDefArg` on handling templates with parameter packs. `GetTplParamNumberWithoutPack` has been introduced so that detecting of defaulted arguments may be performed correctly.

`llvm::iterator_range` is reported now for `zip_equal` return type used in a range-based for loop in `iwyu_ast_util.cc`. It exactly has a template parameter pack, hence its argument types are now reported.