### PR TITLE
Extract and use shared ArrayDiff in unittests

### DIFF
--- a/unittests/iwyu_string_util_test.cc
+++ b/unittests/iwyu_string_util_test.cc
@@ -14,6 +14,7 @@
 #include <string>
 
 #include "gtest/gtest.h"
+#include "iwyu_test_helpers.h"
 
 namespace include_what_you_use {
 using std::string;
@@ -58,62 +59,37 @@ TEST(IwyuStringUtilTest, StripWhiteSpace) {
 TEST(IwyuStringUtilTest, SplitOnWhiteSpace) {
   string in = "this is a test";
   vector<string> out = SplitOnWhiteSpace(in, 0);
-  ASSERT_EQ(size_t(4), out.size());
-  EXPECT_EQ(string("this"), out[0]);
-  EXPECT_EQ(string("is"), out[1]);
-  EXPECT_EQ(string("a"), out[2]);
-  EXPECT_EQ(string("test"), out[3]);
+  EXPECT_EQ("", ArrayDiff({"this", "is", "a", "test"}, out));
 
   in = "this is a test";
   out = SplitOnWhiteSpace(in, 2);
-  ASSERT_EQ(size_t(2), out.size());
-  EXPECT_EQ(string("this"), out[0]);
-  EXPECT_EQ(string("is"), out[1]);
+  EXPECT_EQ("", ArrayDiff({"this", "is"}, out));
 
   in = "this is\ta    test";
   out = SplitOnWhiteSpace(in, 0);
-  ASSERT_EQ(size_t(4), out.size());
-  EXPECT_EQ(string("this"), out[0]);
-  EXPECT_EQ(string("is"), out[1]);
-  EXPECT_EQ(string("a"), out[2]);
-  EXPECT_EQ(string("test"), out[3]);
+  EXPECT_EQ("", ArrayDiff({"this", "is", "a", "test"}, out));
 
   in = " this is a test ";
   out = SplitOnWhiteSpace(in, 0);
-  ASSERT_EQ(size_t(4), out.size());
-  EXPECT_EQ(string("this"), out[0]);
-  EXPECT_EQ(string("is"), out[1]);
-  EXPECT_EQ(string("a"), out[2]);
-  EXPECT_EQ(string("test"), out[3]);
+  EXPECT_EQ("", ArrayDiff({"this", "is", "a", "test"}, out));
 }
 
 TEST(IwyuStringUtilTest, SplitOnWhiteSpacePreservingQuotes) {
   string in = "this is <a test>";
   vector<string> out = SplitOnWhiteSpacePreservingQuotes(in, 0);
-  ASSERT_EQ(size_t(3), out.size());
-  EXPECT_EQ(string("this"), out[0]);
-  EXPECT_EQ(string("is"), out[1]);
-  EXPECT_EQ(string("<a test>"), out[2]);
+  EXPECT_EQ("", ArrayDiff({"this", "is", "<a test>"}, out));
 
   in = "this <is a> test";
   out = SplitOnWhiteSpacePreservingQuotes(in, 2);
-  ASSERT_EQ(size_t(2), out.size());
-  EXPECT_EQ(string("this"), out[0]);
-  EXPECT_EQ(string("<is a>"), out[1]);
+  EXPECT_EQ("", ArrayDiff({"this", "<is a>"}, out));
 
   in = "\"this is\"\ta    test";
   out = SplitOnWhiteSpacePreservingQuotes(in, 0);
-  ASSERT_EQ(size_t(3), out.size());
-  EXPECT_EQ(string("\"this is\""), out[0]);
-  EXPECT_EQ(string("a"), out[1]);
-  EXPECT_EQ(string("test"), out[2]);
+  EXPECT_EQ("", ArrayDiff({"\"this is\"", "a", "test"}, out));
 
   in = " this is \"a test\" ";
   out = SplitOnWhiteSpacePreservingQuotes(in, 0);
-  ASSERT_EQ(size_t(3), out.size());
-  EXPECT_EQ(string("this"), out[0]);
-  EXPECT_EQ(string("is"), out[1]);
-  EXPECT_EQ(string("\"a test\""), out[2]);
+  EXPECT_EQ("", ArrayDiff({"this", "is", "\"a test\""}, out));
 }
 
 }  // namespace

--- a/unittests/iwyu_test_helpers.h
+++ b/unittests/iwyu_test_helpers.h
@@ -1,0 +1,64 @@
+//===--- iwyu_test_helpers.h - iwyu unittest helpers --------*- C++ -*-----===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace include_what_you_use {
+using llvm::ArrayRef;
+using llvm::raw_string_ostream;
+using std::string;
+using std::vector;
+
+// Returns a string representing the first element where the arrays actual and
+// expected differ, or "" if they're identical. The arrays can be different
+// types as long as E is implicitly comparable to A (e.g. const char* vs.
+// std::string). All element types must be streamable to raw_ostream.
+template <class E, class A>
+string ArrayDiff(ArrayRef<E> expected, ArrayRef<A> actual) {
+  string diff;
+  raw_string_ostream out(diff);
+
+  // Not interested in paying for including <algorithm> for std::min.
+  size_t min_size =
+      (actual.size() < expected.size()) ? actual.size() : expected.size();
+  for (size_t i = 0; i < min_size; ++i) {
+    if (expected[i] != actual[i]) {
+      out << "Differ at #" << i << ": expected=" << expected[i]
+          << ", actual=" << actual[i];
+      return diff;
+    }
+  }
+  if (expected.size() < actual.size()) {
+    out << "Differ at #" << expected.size()
+        << ": expected at EOF, actual=" << actual[expected.size()];
+    return diff;
+  } else if (actual.size() < expected.size()) {
+    out << "Differ at #" << expected.size()
+        << ": expected=" << expected[actual.size()] << ", actual at EOF";
+    return diff;
+  } else {
+    return "";  // They're equal.
+  }
+}
+
+// Partial specializations to allow for various useful spellings of the
+// expected, not an exhaustive combination of all possible types.
+
+// ArrayDiff({"a", "b"}, vec)
+template <class E, class A, size_t N>
+string ArrayDiff(const E (&expected)[N], const vector<A>& actual) {
+  return ArrayDiff(ArrayRef<E>(expected), ArrayRef<A>(actual));
+}
+
+}  // namespace include_what_you_use


### PR DESCRIPTION
ArrayDiff returns a string representation of the difference between two ArrayRefs, which may in turn wrap vectors, plain arrays, initializer lists, etc.

This is directly based on the VectorDiff in iwyu_include_picker_test.cc, and will replace it when/if I get around to enabling those tests.

The iwyu_string_util_test suite for various Split functions is much better this way.