### PR TITLE
[ci] Install libc++ before building and running tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,13 +30,15 @@ jobs:
           sudo apt remove -y \
                "libclang*" \
                "clang*" \
-               "llvm*"
+               "llvm*" \
+               "libc++*"
           # Reinstall tagged versions
           sudo apt install -y \
                ninja-build \
                llvm$LLVM_TAG-dev \
                libclang$LLVM_TAG-dev \
-               clang$LLVM_TAG
+               clang$LLVM_TAG \
+               libc++$LLVM_TAG-dev
 
       - name: Capture LLVM major version and install prefix
         run: |


### PR DESCRIPTION
The bugs suite assumed that libc++ was installed, but I forgot to check if it actually was. Since the bug tests are designed to fail, I never noticed that they fail for the wrong reasons -- because libc++ is not installed, not because IWYU mishandles them under libc++.

Install the library so we can use it in bug tests.

Found by @bolshakov-a, thanks!