### PR TITLE
Remove whitespace collapsing for forward-declares

### DIFF
--- a/iwyu_output.cc
+++ b/iwyu_output.cc
@@ -510,9 +510,6 @@ string MungedForwardDeclareLineForTemplates(const TemplateDecl* decl) {
   // rather on the exact form printed by Clang, so it's safe to make certain
   // assumptions about format.
 
-  // Can remove this after https://github.com/llvm/llvm-project/pull/174197.
-  line = CollapseRepeated(line, ' ');
-
   // Remove any class property specifiers. The final keyword is not allowed on
   // forward-decls. An alignas(x) specifier must match earlier declarations, so
   // forward-decls become more resistant to change without it.

--- a/iwyu_string_util.h
+++ b/iwyu_string_util.h
@@ -206,20 +206,6 @@ inline string FormatISO8601(time_t t) {
   return string(buf);
 }
 
-// Collapses series of neighboring equal characters into one.
-inline string CollapseRepeated(StringRef str, char needle) {
-  string collapsed;
-  collapsed.reserve(str.size());
-
-  char prev_c = 0;
-  for (char c : str) {
-    if (c != needle || c != prev_c)
-      collapsed += c;
-    prev_c = c;
-  }
-  return collapsed;
-}
-
 }  // namespace include_what_you_use
 
 #endif  // INCLUDE_WHAT_YOU_USE_IWYU_STRING_UTIL_H_

--- a/unittests/iwyu_string_util_test.cc
+++ b/unittests/iwyu_string_util_test.cc
@@ -192,12 +192,5 @@ TEST(IwyuStringUtilTest, FormatISO8601) {
   EXPECT_EQ("2026-01-24T21:04:04Z", FormatISO8601(1769288644));
 }
 
-TEST(IwyuStringUtilTest, CollapseRepeated) {
-  EXPECT_EQ("a,b", CollapseRepeated("a,,,,,,,,b", ','));
-  EXPECT_EQ("a b c d e\tf", CollapseRepeated("a   b c  d    e\tf", ' '));
-  EXPECT_EQ("a,b,c,d,e", CollapseRepeated("a,b,c,d,e", ','));
-  EXPECT_EQ("a,b,", CollapseRepeated("a,b,", ','));
-}
-
 }  // namespace
 }  // namespace include_what_you_use


### PR DESCRIPTION
I managed to fix this in Clang's DeclPrinter instead: https://github.com/llvm/llvm-project/commit/41079dac98ece04a3ee555049c5dd1d50523bb61

Once that lands in Debian packages, we can remove the whitespace cleanup in MungedForwardDeclareLineForTemplates and remove the now-unused function.