### PR TITLE
Remove redundant special filename check

### DIFF
--- a/iwyu_path_util.cc
+++ b/iwyu_path_util.cc
@@ -77,9 +77,6 @@ bool IsHeaderFilename(StringRef path) {
 bool IsQuotedHeaderFilename(StringRef quoted_include) {
   CHECK_(IsQuotedInclude(quoted_include));
 
-  if (IsSpecialFilenameOrStdin(quoted_include))
-    return false;
-
   StringRef path = quoted_include.substr(1, quoted_include.size() - 2);
   return IsHeaderFilename(path);
 }

--- a/unittests/iwyu_path_util_test.cc
+++ b/unittests/iwyu_path_util_test.cc
@@ -50,5 +50,26 @@ TEST(ConvertToQuotedInclude, Basic) {
             ConvertToQuotedInclude("/usr/include/c++/4.3/bits/stl_vector.h"));
 }
 
+TEST(IsQuotedHeaderFilename, Basic) {
+  // Nominal cases.
+  EXPECT_TRUE(IsQuotedHeaderFilename("\"foo.h\""));
+  EXPECT_TRUE(IsQuotedHeaderFilename("\"bar/foo.h\""));
+  EXPECT_TRUE(IsQuotedHeaderFilename("\"foo.inl\""));
+  EXPECT_TRUE(IsQuotedHeaderFilename("\"foo.def\""));
+
+  EXPECT_TRUE(IsQuotedHeaderFilename("<string.h>"));
+  EXPECT_TRUE(IsQuotedHeaderFilename("<bits/stl_vector.h>"));
+  EXPECT_TRUE(IsQuotedHeaderFilename("<string>"));
+
+  // A bit unusual, but considered headers.
+  EXPECT_TRUE(IsQuotedHeaderFilename("\"foo\""));
+  EXPECT_TRUE(IsQuotedHeaderFilename("<foo.xyz>"));
+
+  // Negative cases.
+  EXPECT_FALSE(IsQuotedHeaderFilename("\"foo.c\""));
+  EXPECT_FALSE(IsQuotedHeaderFilename("\"bar/foo.cc\""));
+  EXPECT_FALSE(IsQuotedHeaderFilename("<source.cpp>"));
+}
+
 }  // namespace
 }  // namespace include_what_you_use


### PR DESCRIPTION
IsQuotedInclude returns false if an angle-quoted name is a special
filename. So in order for the special filename check in
IsQuotedHeaderFilename to return true, the CHECK above must already have
failed, which is a contradiction.

Add unittest coverage.