### PR TITLE
Make all library headers providing all transitives

### DIFF
--- a/iwyu_include_picker.h
+++ b/iwyu_include_picker.h
@@ -281,12 +281,12 @@ class IncludePicker {
 
   // A map of all quoted-includes to whether they're public or private.
   // Files whose visibility cannot be determined by this map nor the one
-  // below are assumed public.
+  // below may be assumed public (see GetVisibility usage).
   VisibilityMap include_visibility_map_;
 
   // A map of paths to whether they're public or private.
   // Files whose visibility cannot be determined by this map nor the one
-  // above are assumed public.
+  // above may be assumed public (see GetVisibility usage).
   // The include_visibility_map_ takes priority over this one.
   VisibilityMap path_visibility_map_;
 

--- a/tests/cxx/block_template_internals-d1.h
+++ b/tests/cxx/block_template_internals-d1.h
@@ -1,0 +1,10 @@
+//===--- block_template_internals-d1.h - test input file for iwyu ---------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/block_template_internals-i1.h"

--- a/tests/cxx/block_template_internals-i1.h
+++ b/tests/cxx/block_template_internals-i1.h
@@ -1,0 +1,15 @@
+//===--- block_template_internals-i1.h - test input file for iwyu ---------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/block_template_internals-i2.h"
+
+template <typename T>
+int TplFn(T t) {
+  return InternalFn(t);
+}

--- a/tests/cxx/block_template_internals-i2.h
+++ b/tests/cxx/block_template_internals-i2.h
@@ -1,0 +1,10 @@
+//===--- block_template_internals-i2.h - test input file for iwyu ---------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/block_template_internals-i3.h"

--- a/tests/cxx/block_template_internals-i3.h
+++ b/tests/cxx/block_template_internals-i3.h
@@ -1,0 +1,10 @@
+//===--- block_template_internals-i3.h - test input file for iwyu ---------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+int InternalFn(int);

--- a/tests/cxx/block_template_internals.cc
+++ b/tests/cxx/block_template_internals.cc
@@ -1,0 +1,25 @@
+//===--- block_template_internals.cc - test input file for iwyu -----------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_ARGS: -Xiwyu --mapping_file=tests/cxx/block_template_internals.imp -I .
+
+// Test that IWYU does not report template implementation details, especially
+// for templates from external libraries.
+
+#include "tests/cxx/block_template_internals-d1.h"
+
+// IWYU should not report InternalFn here. It is assumed to be provided
+// by the public header for TplFn.
+int x = TplFn(1);
+
+/**** IWYU_SUMMARY
+
+(tests/cxx/block_template_internals.cc has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/block_template_internals.imp
+++ b/tests/cxx/block_template_internals.imp
@@ -1,0 +1,3 @@
+[
+  { "symbol": ["TplFn", "private", "\"tests/cxx/block_template_internals-d1.h\"", "public"] },
+]


### PR DESCRIPTION
IWYU has some facilities to avoid exposing external library implementation details to users. Namely, `PublicHeaderIntendsToProvide` function is used to determine if a declaration used inside a template is meant to be provided by a template, especially when it is an external library template. Prior to this change, this usually meant that some of the declarations in the template instantiation chain should be in a public file, or in a file marked as private in some include mapping. Thus, that might not work when where is only a symbol mapping.

It was noticed in https://github.com/include-what-you-use/include-what-you-use/pull/1879#issuecomment-3708365409 that after 309f9be69030b708bc4193755ddd4985d0947b22 the reported internal stuff may be mapped to some other public header. This may be considered as a regression because those headers may provide more than needed. E.g., for the example in that comment, IWYU suggested to include `<memory>`. However, it was not included even transitively in the original code using MS STL.

The issue has been fixed by marking all the headers under any public header as providing all their transitive includes. (Prior to this, only the public headers themselves were considered to do it.) I think it is reasonable because an external library may include only their own headers or headers from some other external library.

Another way to fix the issue could probably be to check headers from symbol mappings inside `PublicHeaderIntendsToProvide`.

A couple of comments in `iwyu_include_picker.h` have been fixed on the way.