### PR TITLE
Add `timeval` symbol mappings for alternative headers

### DIFF
--- a/iwyu_include_picker.cc
+++ b/iwyu_include_picker.cc
@@ -240,7 +240,10 @@ const IncludeMapEntry libc_symbol_map[] = {
   { "time_t", kPrivate, "<sys/types.h>", kPublic },
   { "timer_t", kPrivate, "<sys/types.h>", kPublic },
   { "timespec", kPrivate, "<time.h>", kPublic },
-  { "timeval", kPrivate, "<sys/time.h>", kPublic },
+  { "timeval", kPrivate, "<sys/time.h>", kPublic },  // 'canonical' location for timeval
+  { "timeval", kPrivate, "<sys/resource.h>", kPublic },
+  { "timeval", kPrivate, "<sys/select.h>", kPublic },
+  { "timeval", kPrivate, "<utmpx.h>", kPublic },
   { "tm", kPrivate, "<time.h>", kPublic },
   { "u_char", kPrivate, "<sys/types.h>", kPublic },
   { "ucontext_t", kPrivate, "<ucontext.h>", kPublic },


### PR DESCRIPTION
According to [POSIX](https://www.man7.org/linux/man-pages/man3/timeval.3type.html), in addition to `<sys/time.h>`, `struct timeval` is also provided by the following headers: `<sys/resource.h>`, `<sys/select.h>`, and `<utmpx.h>`.

This prevents IWYU from suggesting including `<sys/time.h>` when `timeval` is already available via these headers.

Noticed in https://github.com/bitcoin/bitcoin/pull/34448#discussion_r2754677021.