### PR TITLE
Suppress inline namespaces completely

### DIFF
--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -55,6 +55,7 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/PointerUnion.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/STLForwardCompat.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/iterator_range.h"
@@ -181,6 +182,7 @@ using llvm::isa;
 using llvm::range_size;
 using llvm::raw_ostream;
 using llvm::raw_string_ostream;
+using llvm::to_underlying;
 using llvm::zip_equal;
 using std::function;
 using std::pair;
@@ -587,6 +589,8 @@ string GetWrittenQualifiedNameAsString(const NamedDecl* named_decl,
       named_decl->getASTContext().getPrintingPolicy();
   printing_policy.SuppressUnwrittenScope = true;
   printing_policy.PrintAsCanonical = true;
+  printing_policy.SuppressInlineNamespace =
+      to_underlying(PrintingPolicy::SuppressInlineNamespaceMode::All);
   named_decl->printQualifiedName(ostream, printing_policy);
 
   if (const auto* cls_spec =

--- a/tests/cxx/overload_fn_mapping-i1.h
+++ b/tests/cxx/overload_fn_mapping-i1.h
@@ -14,6 +14,8 @@ namespace ns {
 class Class {};
 
 using ::B;
+
+void Fn();
 }  // namespace ns
 
 using ConstLong = const long;
@@ -46,6 +48,11 @@ int FnTakesAll(int);
 namespace ns {
 int FnFromNs();
 int FnFromNs(Class);
+
+inline namespace inl {
+class C {};
+int FnFromNs(const C&);
+}  // namespace inl
 }  // namespace ns
 
 bool operator==(const A&, const A&);

--- a/tests/cxx/overload_fn_mapping.cc
+++ b/tests/cxx/overload_fn_mapping.cc
@@ -79,6 +79,14 @@ void User() {
   // IWYU: ns::Class is...*-i1.h
   // IWYU: ns::FnFromNs(ns::Class) is...*-i3.h
   ns::FnFromNs(ns::Class{});
+  // IWYU: ns::C is...*-i1.h
+  ns::C c;
+  // IWYU: ns::FnFromNs(const ns::C &) is...*-i4.h
+  FnFromNs(c);
+  // IWYU: ns::FnFromNs(const ns::C &) is...*-i4.h
+  ns::FnFromNs(c);
+  // IWYU: ns::FnFromNs(const ns::C &) is...*-i4.h
+  ns::inl::FnFromNs(c);
 
   // IWYU: A is...*-i1.h
   A a1, a2;
@@ -144,7 +152,7 @@ tests/cxx/overload_fn_mapping.cc should remove these lines:
 - #include "tests/cxx/overload_fn_mapping-d1.h"  // lines XX-XX
 
 The full include-list for tests/cxx/overload_fn_mapping.cc:
-#include "tests/cxx/overload_fn_mapping-i1.h"  // for A, B, Class, Tpl
+#include "tests/cxx/overload_fn_mapping-i1.h"  // for A, B, C, Class, Tpl
 #include "tests/cxx/overload_fn_mapping-i10.h"  // for Fn
 #include "tests/cxx/overload_fn_mapping-i11.h"  // for Fn
 #include "tests/cxx/overload_fn_mapping-i12.h"  // for Fn
@@ -160,7 +168,7 @@ The full include-list for tests/cxx/overload_fn_mapping.cc:
 #include "tests/cxx/overload_fn_mapping-i21.h"  // for Fn
 #include "tests/cxx/overload_fn_mapping-i22.h"  // for Fn
 #include "tests/cxx/overload_fn_mapping-i3.h"  // for Fn, FnFromNs, FnTakesAll, TplFn, operator==
-#include "tests/cxx/overload_fn_mapping-i4.h"  // for Fn, TplFn, operator==
+#include "tests/cxx/overload_fn_mapping-i4.h"  // for Fn, FnFromNs, TplFn, operator==
 #include "tests/cxx/overload_fn_mapping-i5.h"  // for Fn, TplFn, operator==
 #include "tests/cxx/overload_fn_mapping-i6.h"  // for Fn
 #include "tests/cxx/overload_fn_mapping-i7.h"  // for Fn

--- a/tests/cxx/overload_fn_mapping.imp
+++ b/tests/cxx/overload_fn_mapping.imp
@@ -26,6 +26,7 @@
 
   { "symbol": ["ns::FnFromNs", "private", "\"tests/cxx/overload_fn_mapping-i2.h\"", "public"] },
   { "symbol": ["ns::FnFromNs(ns::Class)", "private", "\"tests/cxx/overload_fn_mapping-i3.h\"", "public"] },
+  { "symbol": ["ns::FnFromNs(const ns::C &)", "private", "\"tests/cxx/overload_fn_mapping-i4.h\"", "public"] },
 
   { "symbol": ["operator==(const A &, const A &)", "private", "\"tests/cxx/overload_fn_mapping-i2.h\"", "public"] },
   { "symbol": ["operator==(const B &, const B &)", "private", "\"tests/cxx/overload_fn_mapping-i3.h\"", "public"] },


### PR DESCRIPTION
This is required for standard library symbol mappings because implementers may place declarations into some unspecified inline namespaces inside `std`. Moreover, this makes IWYU more stable because, prior to this, it put or did not put inline namespace names into symbol names depending on whether there is any name conflict or not.