### PR TITLE
[ci] Use new apt key handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: Install prerequisites
         run: |
-          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+          wget -O- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/llvm-snapshot.asc
           sudo add-apt-repository "deb http://apt.llvm.org/noble/ llvm-toolchain-noble$LLVM_TAG main"
           sudo apt update
           # Remove any base dist LLVM/Clang installations


### PR DESCRIPTION
The apt-key tool is deprecated, now we're expected to write a file into /etc/apt/trusted.gpg.d instead.