### PR TITLE
Fix crash on function template with default args

### DIFF
--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -1538,6 +1538,8 @@ bool IsDefTplArgSpecified(const NamedDecl* tpl_param) {
 }
 
 FunctionDecl* GetRedeclSpecifyingDefArg(unsigned i, FunctionDecl* func) {
+  if (func->isFunctionTemplateSpecialization())
+    return func;
   for (FunctionDecl* redecl : func->redecls()) {
     if (IsDefArgSpecified(i, redecl))
       return redecl;

--- a/iwyu_ast_util.h
+++ b/iwyu_ast_util.h
@@ -768,7 +768,9 @@ const clang::CXXMethodDecl* GetFromLeastDerived(const clang::CXXMethodDecl*);
 bool IsDefArgSpecified(unsigned i, const clang::FunctionDecl*);
 
 // Returns the redeclaration specifying default argument for the i-th parameter.
-// Expects that there is one.
+// Expects that there is one. For function template specializations, this
+// returns the given decl because default function argumens should be specified
+// in the first template declaration and not in any specialization redecl.
 clang::FunctionDecl* GetRedeclSpecifyingDefArg(unsigned i,
                                                clang::FunctionDecl*);
 

--- a/tests/cxx/fn_def_args-i1.h
+++ b/tests/cxx/fn_def_args-i1.h
@@ -11,3 +11,15 @@
 
 void FnWithSmearedDefArgs2(int = 0, int);
 void FnWithSmearedDefArgs3(int, int = 0, int);
+
+template <typename T>
+void FnTplWithDefArg(int) {
+}
+template <>
+void FnTplWithDefArg<float>(int) {
+}
+
+template <typename T>
+void* operator new(std::size_t, T, int) noexcept {
+  return nullptr;
+}

--- a/tests/cxx/fn_def_args-i2.h
+++ b/tests/cxx/fn_def_args-i2.h
@@ -23,4 +23,10 @@ void FnWithDefArg2(int, int = 0);
 
 void* operator new(std::size_t, int, int, int = 0);
 
+template <typename T>
+void FnTplWithDefArg(int = 0);
+
+template <typename T>
+void* operator new(std::size_t, T, int = 0) noexcept;
+
 #endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_FN_DEF_ARGS_I2_H_

--- a/tests/cxx/fn_def_args.cc
+++ b/tests/cxx/fn_def_args.cc
@@ -57,6 +57,21 @@ void Fn() {
   // IWYU: operator new(unsigned long, int, int, int) is...*-i2.h
   new (1, 1) int;
   new (1) int;
+
+  // The definition from '-i1.h' should (probably) already provide '-i2.h'
+  // for the default argument.
+  // IWYU: FnTplWithDefArg(int) is...*-i1.h
+  FnTplWithDefArg<char>();
+  // IWYU: FnTplWithDefArg(int) is...*-i1.h
+  FnTplWithDefArg<char>(1);
+  // IWYU: FnTplWithDefArg(int) is...*-i1.h
+  FnTplWithDefArg<float>();
+  // IWYU: FnTplWithDefArg(int) is...*-i1.h
+  FnTplWithDefArg<float>(1);
+  // IWYU: operator new(unsigned long, :0, int) is...*-i1.h
+  new ('a', 1) int;
+  // IWYU: operator new(unsigned long, :0, int) is...*-i1.h
+  new ('a') int;
 }
 
 /**** IWYU_SUMMARY
@@ -70,7 +85,7 @@ tests/cxx/fn_def_args.cc should remove these lines:
 
 The full include-list for tests/cxx/fn_def_args.cc:
 #include "tests/cxx/fn_def_args-d1.h"  // for FnWithSmearedDefArgs, Struct, operator new
-#include "tests/cxx/fn_def_args-i1.h"  // for FnWithSmearedDefArgs2, FnWithSmearedDefArgs3
+#include "tests/cxx/fn_def_args-i1.h"  // for FnTplWithDefArg, FnWithSmearedDefArgs2, FnWithSmearedDefArgs3, operator new
 #include "tests/cxx/fn_def_args-i2.h"  // for FnWithDefArg, FnWithSmearedDefArgs, FnWithSmearedDefArgs2, operator new
 #include "tests/cxx/fn_def_args-i3.h"  // for FnWithSmearedDefArgs2
 


### PR DESCRIPTION
`GetRedeclSpecifyingDefArg` returns now the given decl for function template specializations because it should anyway be passed into `HandleFunctionCall` for scanning implicit instantiations and reporting the complete template definition for them. Reporting the template redeclaration specifying the default argument at the call site is questionable because it should be the first redeclaration in a translation unit and hence the resulting code may not compile depending on the order of include directives.

This fixes the crash reported in #1938.