### PR TITLE
Disable use of cxxabi.h in googletest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -257,6 +257,13 @@ if (iwyu_cxx_supports_covered_switch_default)
   )
 endif()
 
+# gtest: Disable use of cxxabi.h, which can cause conflict between libc++abi and
+# libsupc++. See https://github.com/llvm/llvm-project/issues/121300.
+target_compile_options(iwyu-gtest
+  PUBLIC
+  -DGTEST_HAS_CXXABI_H_=0
+)
+
 # gtest: Use portable exception semantics for MSVC.
 if (MSVC)
   target_compile_options(iwyu-gtest


### PR DESCRIPTION
For some reason, sometimes, in some environments the googletest build fails because libsupc++ (from GCC) and libc++abi (from LLVM) have different return types for the __cxa_init_primary_exception function.

Force googletest not to use cxxabi.h to avoid the problem.

Fixes issue #1941.