### PR TITLE
Upgrade Deprecated GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
           echo "LLVM_PREFIX=${LLVM_PREFIX}" | tee -a $GITHUB_ENV
 
       - name: Check out branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Work around broken packaging
         run: |
@@ -125,7 +125,7 @@ jobs:
 
       - name: Upload PR comment payload
         if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pr-comments
           path: ./pr-comments

--- a/.github/workflows/pr-comments-bot.yml
+++ b/.github/workflows/pr-comments-bot.yml
@@ -35,7 +35,7 @@ jobs:
                jq
 
       - name: Download PR comments payloads
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Also include a GitHub Dependabot monthly check to automatically open a Pull Request to upgrade Actions, which will help keep IWYU's CI Actions up-to-date going forward.

See issue:
<https://github.com/include-what-you-use/include-what-you-use/issues/1944>

Closes #1944 