### PR TITLE
[ci] Temporarily pin master to llvm-23

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,13 +18,13 @@ jobs:
       fail-fast: false
 
     env:
-      LLVM_TAG:
+      LLVM_TAG: -23
 
     steps:
       - name: Install prerequisites
         run: |
           wget -O- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/llvm-snapshot.asc
-          sudo add-apt-repository "deb http://apt.llvm.org/noble/ llvm-toolchain-noble$LLVM_TAG main"
+          sudo add-apt-repository "deb http://apt.llvm.org/noble/ llvm-toolchain-noble main"
           sudo apt update
           # Remove any base dist LLVM/Clang installations
           sudo apt remove -y \


### PR DESCRIPTION
The apt.llvm.org snapshot packages have been broken for a long time
now. Explicitly pin the mainline branch to llvm-23 so we can get CI
coverage for IWYU changes until it's fixed.

Plan is to revert this once the snapshot packages are fixed, so we have
a clean baseline with tag suffix on the repo spec.