### PR TITLE
[cmake] Suppress install targets for library targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,7 +135,7 @@ set(LLVM_LINK_COMPONENTS
   AllTargetsInfos
 )
 
-add_llvm_library(iwyu
+add_llvm_library(iwyu BUILDTREE_ONLY
   iwyu.cc
   iwyu_ast_util.cc
   iwyu_cache.cc
@@ -233,7 +233,7 @@ if (WIN32)
 endif()
 
 # Build vendored gtest library
-add_llvm_library(iwyu-gtest
+add_llvm_library(iwyu-gtest BUILDTREE_ONLY
   vendor/googletest/src/gtest-all.cc
 )
 


### PR DESCRIPTION
The add_llvm_library macro apparently adds install targets automatically unless told otherwise.

This led to CMake self-check errors when build IWYU as part of LLVM, complaining that the library include dirs pointed into the build directory:

    CMake Error in .../include-what-you-use/CMakeLists.txt:
      Target "iwyu" INTERFACE_INCLUDE_DIRECTORIES property contains path:

        ".../llvm-project/llvm/include"

      which is prefixed in the source directory.

We didn't plan to install these libraries, they are only for internal use.

Add the BUILDTREE_ONLY argument to let LLVM's CMake wrapping know.