### PR TITLE
Find provided types behind sugar on type reporting

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -3485,10 +3485,10 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
   void ReportTypeUseInternal(SourceLocation used_loc, const Type* type,
                              set<const Type*> blocked_types,
                              DerefKind deref_kind) {
-    InsertAllInto(this->getDerived().GetProvidedByTplArg(type), &blocked_types);
     // It is important not to lose info about type aliases while desugaring
     // and dereferencing here, because they are handled further.
     type = Desugar(type);
+    InsertAllInto(this->getDerived().GetProvidedByTplArg(type), &blocked_types);
     if (deref_kind == DerefKind::RemoveRefs ||
         deref_kind == DerefKind::RemoveRefsAndPtr) {
       if (const auto* ref_type = dyn_cast_or_null<ReferenceType>(type)) {

--- a/tests/cxx/typedef_in_template.cc
+++ b/tests/cxx/typedef_in_template.cc
@@ -153,6 +153,8 @@ void ArgumentTypeProvision() {
   Identity<Providing>::Type* p2 = nullptr;
   (void)sizeof(*p2);
   p2->Method();
+  decltype(p1) decltype_provided;
+  (void)sizeof(decltype_provided);
 
   // IWYU: NonProviding is...*typedef_in_template-i1.h
   // IWYU: IndirectClass is...*indirect.h
@@ -167,6 +169,10 @@ void ArgumentTypeProvision() {
   (void)sizeof(*n2);
   // IWYU: IndirectClass is...*indirect.h
   n2->Method();
+  // IWYU: IndirectClass is...*indirect.h
+  decltype(n1) decltype_not_provided;
+  // IWYU: IndirectClass is...*indirect.h
+  (void)sizeof(decltype_not_provided);
 
   Identity<Providing>::Inner::Type p3;
 


### PR DESCRIPTION
At the time of writing `GetProvidedByTplArg`, type prefixes were stored in `ElaboratedType` nodes, so `Desugar` should be called after `GetProvidedByTplArg` so as not to cut them out. After https://github.com/llvm/llvm-project/commit/91cdd35008e9ab32dffb7e401cdd7313b3461892, there are no `ElaboratedType` nodes anymore, and `Desugar` can be called before `GetProvidedByTplArg` so that the latter gets qualified typedefs.