### PR TITLE
[ci] Use snapshot llvm packages on master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,13 +18,13 @@ jobs:
       fail-fast: false
 
     env:
-      LLVM_TAG: -23
+      LLVM_TAG:
 
     steps:
       - name: Install prerequisites
         run: |
           wget -O- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/llvm-snapshot.asc
-          sudo add-apt-repository "deb http://apt.llvm.org/noble/ llvm-toolchain-noble main"
+          sudo add-apt-repository "deb http://apt.llvm.org/noble/ llvm-toolchain-noble$LLVM_TAG main"
           sudo apt update
           # Remove any base dist LLVM/Clang installations
           sudo apt remove -y \


### PR DESCRIPTION
The snapshot packages have now been published with proper versions.

This effectively reverts 80cb75d689a932ece896440c579caca520c3203b.