### PR TITLE
Scan alias templates in GetProvidedTypeComponents

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -3434,6 +3434,16 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
     return retval;
   }
 
+  set<const Type*> GetAliasTemplateProvidedTypes(
+      const TemplateSpecializationType* type,
+      const TypeAliasTemplateDecl* al_tpl_decl) const {
+    const TypeAliasDecl* al_decl = al_tpl_decl->getTemplatedDecl();
+    set<const Type*> res = GetProvidedTypes(type->getAliasedType().getTypePtr(),
+                                            GetLocation(al_decl));
+    RemoveAllFrom(GetCanonicalArgComponents(type), &res);
+    return res;
+  }
+
   set<const Type*> blocked_types_;
   set<const Decl*> blocked_for_fwd_decl_;
 
@@ -3471,16 +3481,6 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
   // be reported.
   bool SourceOrTargetTypeIsProvided(const ASTNode* construct_expr_node) const =
       delete;
-
-  set<const Type*> GetAliasTemplateProvidedTypes(
-      const TemplateSpecializationType* type,
-      const TypeAliasTemplateDecl* al_tpl_decl) const {
-    const TypeAliasDecl* al_decl = al_tpl_decl->getTemplatedDecl();
-    set<const Type*> res = GetProvidedTypes(type->getAliasedType().getTypePtr(),
-                                            GetLocation(al_decl));
-    RemoveAllFrom(GetCanonicalArgComponents(type), &res);
-    return res;
-  }
 
   void ReportTypeUseInternal(SourceLocation used_loc, const Type* type,
                              set<const Type*> blocked_types,
@@ -5487,8 +5487,11 @@ class IwyuAstConsumer
 
     TemplateInstantiationData data = GetTplInstData(callee, calling_expr);
 
-    if (parent_type)  // means we're a method of a class
+    if (parent_type) {  // means we're a method of a class
       InsertInto(GetTplInstData(parent_type), &data);
+      InsertAllInto(GetProvidedTypeComponents(parent_type),
+                    &data.provided_types);
+    }
 
     if (IsAutocastExpr(current_ast_node())) {
       const set<const Type*> provided_for_autocast =
@@ -5521,6 +5524,7 @@ class IwyuAstConsumer
     while (nns.getKind() == NestedNameSpecifier::Kind::Type) {
       const Type* host = nns.getAsType();
       InsertAllInto(GetTplInstData(host).provided_types, &res);
+      InsertAllInto(GetProvidedTypeComponents(host), &res);
       nns = host->getPrefix();
     }
 
@@ -5565,15 +5569,20 @@ class IwyuAstConsumer
  private:
   set<const Type*> GetProvidedTypeComponents(const Type* type) const {
     set<const Type*> res;
-    const Type* desugared_until_typedef = Desugar(type);
+    const Type* desugared_until_typedef_or_tpl = Desugar(type);
     if (const auto* typedef_type =
-            dyn_cast_or_null<TypedefType>(desugared_until_typedef)) {
+            dyn_cast_or_null<TypedefType>(desugared_until_typedef_or_tpl)) {
       const TypedefNameDecl* decl = typedef_type->getDecl();
       res = GetProvidedTypes(decl->getUnderlyingType().getTypePtr(),
                              GetLocation(decl));
-      InsertAllInto(GetProvidedByTplArg(desugared_until_typedef), &res);
+    } else if (const auto* tpl_spec =
+                   dyn_cast_or_null<TemplateSpecializationType>(
+                       desugared_until_typedef_or_tpl)) {
+      const NamedDecl* decl = TypeToDeclAsWritten(tpl_spec);
+      if (const auto* al_tpl_decl = dyn_cast<TypeAliasTemplateDecl>(decl))
+        res = GetAliasTemplateProvidedTypes(tpl_spec, al_tpl_decl);
     }
-    // TODO(bolshakov): handle alias templates.
+    InsertAllInto(GetProvidedByTplArg(desugared_until_typedef_or_tpl), &res);
     return res;
   }
 

--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -1901,7 +1901,6 @@ TemplateInstantiationData GetTplInstDataForClass(
     const Type* type, function<set<const Type*>(const Type*)> provided_getter) {
   TemplateInstantiationData result =
       GetTplInstDataForClassNoComponentTypes(type, provided_getter);
-  InsertAllInto(provided_getter(type), &result.provided_types);
   return TemplateInstantiationData{
       ResugarTypeComponents(
           result.resugar_map),  // add in the decomposition of retval

--- a/tests/cxx/alias_template.cc
+++ b/tests/cxx/alias_template.cc
@@ -90,6 +90,21 @@ struct TplWithUsingArgInternals {
 // IWYU: IndirectClass is...*indirect.h
 TplWithUsingArgInternals<IndirectClass> twuai;
 
+template <typename T>
+void TakeByCopyInTplFn(T);
+
+void TestProvisionByTplArg() {
+  // IWYU: IndirectClass needs a declaration
+  // IWYU: IndirectClass is...*indirect.h
+  Identity<IndirectClass> iic;
+  // IWYU: IndirectClass is...*indirect.h
+  TakeByCopyInTplFn(iic);
+
+  Identity<Providing> ip;
+  // Test collecting provided types for SourceOrTargetTypeIsProvided function.
+  TakeByCopyInTplFn(ip);
+}
+
 /**** IWYU_SUMMARY
 
 tests/cxx/alias_template.cc should add these lines:

--- a/tests/cxx/template_args-d2.h
+++ b/tests/cxx/template_args-d2.h
@@ -29,3 +29,6 @@ using NonProvidingAlias = ns_in_d2::NonProvidingTypedef;
 
 using NonProvidingFunctionAlias1 = int(IndirectClass&);
 using NonProvidingFunctionAlias2 = IndirectClass(int);
+
+template <int>
+using NonProvidingPtrAlias = IndirectClass*;

--- a/tests/cxx/template_args.cc
+++ b/tests/cxx/template_args.cc
@@ -370,6 +370,27 @@ constexpr auto inner_tpl_size = sizeof(inner_tpl);
 
 // ---------------------------------------------------------------
 
+// Test provision of types by alias template declaration for template
+// instantiation scan. The class template uses dereferenced parameter type so
+// that there is no directly corresponding argument type for resugar_map, and
+// the type provision info should be obtained by GetProvidedTypeComponents.
+
+template <int>
+// IWYU: IndirectClass is...*indirect.h
+using ProvidingPtrAlias = IndirectClass*;
+
+template <typename T>
+struct UsingDereferenced {
+  T ptr;
+  static constexpr auto s = sizeof(*ptr);
+};
+
+UsingDereferenced<ProvidingPtrAlias<1>> udppa;
+// IWYU: IndirectClass is...*indirect.h
+UsingDereferenced<NonProvidingPtrAlias<1>> udnppa;
+
+// ---------------------------------------------------------------
+
 /**** IWYU_SUMMARY
 
 tests/cxx/template_args.cc should add these lines:
@@ -382,7 +403,7 @@ tests/cxx/template_args.cc should remove these lines:
 The full include-list for tests/cxx/template_args.cc:
 #include "tests/cxx/indirect.h"  // for IndirectClass, IndirectTemplate
 #include "tests/cxx/template_args-d1.h"  // for ProvidingAlias
-#include "tests/cxx/template_args-d2.h"  // for NonProvidingAlias, NonProvidingFunctionAlias1, NonProvidingFunctionAlias2
+#include "tests/cxx/template_args-d2.h"  // for NonProvidingAlias, NonProvidingFunctionAlias1, NonProvidingFunctionAlias2, NonProvidingPtrAlias
 #include "tests/cxx/template_args-i1.h"  // for TplHost, TplInI1
 template <typename F> struct FunctionStruct;  // lines XX-XX
 


### PR DESCRIPTION
Getting provided type components for top-level type has been moved out from `GetTplInstDataForClass` so as to avoid infinite recursion `GetTplInstData` -> `GetTplInstDataForClass` -> `GetProvidedTypeComponents` -> `GetProvidedByTplArg` -> `GetTplInstData`.