### PR TITLE
[cmake] Use vanilla add_library for static libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,7 +135,8 @@ set(LLVM_LINK_COMPONENTS
   AllTargetsInfos
 )
 
-add_llvm_library(iwyu BUILDTREE_ONLY
+add_library(iwyu
+  OBJECT
   iwyu.cc
   iwyu_ast_util.cc
   iwyu_cache.cc
@@ -152,6 +153,7 @@ add_llvm_library(iwyu BUILDTREE_ONLY
   iwyu_regex.cc
   iwyu_verrs.cc
 )
+llvm_update_compile_flags(iwyu)
 
 add_llvm_executable(include-what-you-use
   iwyu_main.cc
@@ -233,9 +235,11 @@ if (WIN32)
 endif()
 
 # Build vendored gtest library
-add_llvm_library(iwyu-gtest BUILDTREE_ONLY
+add_library(iwyu-gtest
+  OBJECT
   vendor/googletest/src/gtest-all.cc
 )
+llvm_update_compile_flags(iwyu-gtest)
 
 target_include_directories(iwyu-gtest
   PUBLIC


### PR DESCRIPTION
The add_llvm_library macro has a lot of customization and
parameterization to fit libraries into the LLVM conventions.

Unfortunately the macro forces libraries to be built as SHARED if the
BUILD_SHARED_LIBS option is on, no matter if we explicitly specify
STATIC. This in turn led to packaging failures, because the shared
libraries were not installed.

Switch to using vanilla add_library, and make the libraries OBJECT
libraries, which is the cheapest kind (we have no use for proper static
libraries either). Use the llvm_update_compile_flags functions to make
exception and RTTI flags consistent with LLVM.

This reverts b828e17 and also e9a08a9, which is no longer necessary.

Fixes #1961.