### PR TITLE
Collect argument types from nested name specifiers

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -5386,7 +5386,8 @@ class IwyuAstConsumer
     // If we're not in a forward-declare context, use of a template
     // specialization requires having the full type information.
     if (!can_fwd_decl || type->isTypeAlias()) {
-      const TemplateInstantiationData data = GetTplInstData(type);
+      TemplateInstantiationData data = GetTplInstData(type);
+      InsertAllInto(GetProvidedTypeComponents(type), &data.provided_types);
       instantiated_template_visitor_.ScanInstantiatedType(
           current_ast_node(), data.resugar_map, data.provided_types);
     }

--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -1888,13 +1888,41 @@ TemplateInstantiationData GetTplInstDataForClassNoComponentTypes(
     const clang::Type* type,
     std::function<set<const clang::Type*>(const clang::Type*)>
         provided_getter) {
-  const auto* tpl_spec_type = type->getAs<TemplateSpecializationType>();
-  if (!tpl_spec_type)
-    return TemplateInstantiationData{};
-  const NamedDecl* decl = TypeToDeclAsWritten(tpl_spec_type);
-  const auto* cls_tpl_decl = dyn_cast<ClassTemplateSpecializationDecl>(decl);
-  return GetTplInstDataForClassNoComponentTypes(
-      tpl_spec_type->template_arguments(), cls_tpl_decl, provided_getter);
+  TemplateInstantiationData res;
+  // Collect type template arguments from all the parts of a probably qualified
+  // name (like Level1<Arg1>::Level2<Arg2>::Level3<Arg3>).
+  const Type* part = type;
+  while (part) {
+    if (const auto* typedef_type = part->getAs<TypedefType>()) {
+      // Underlying types of aliases may in turn be qualified or unqualified
+      // template specialization types.
+      const Type* underlying = typedef_type->desugar().getTypePtr();
+      InsertInto(
+          GetTplInstDataForClassNoComponentTypes(underlying, provided_getter),
+          &res);
+    }
+
+    if (const auto* tpl_spec_type = part->getAs<TemplateSpecializationType>()) {
+      const NamedDecl* decl = TypeToDeclAsWritten(tpl_spec_type);
+      const auto* cls_tpl_decl =
+          dyn_cast<ClassTemplateSpecializationDecl>(decl);
+      TemplateInstantiationData data = GetTplInstDataForClassNoComponentTypes(
+          tpl_spec_type->template_arguments(), cls_tpl_decl, provided_getter);
+      InsertInto(data, &res);
+
+      if (tpl_spec_type->isTypeAlias()) {
+        const Type* underlying = tpl_spec_type->desugar().getTypePtr();
+        InsertInto(
+            GetTplInstDataForClassNoComponentTypes(underlying, provided_getter),
+            &res);
+      }
+    }
+
+    NestedNameSpecifier nns = part->getPrefix();
+    part = nns.getKind() == NestedNameSpecifier::Kind::Type ? nns.getAsType()
+                                                            : nullptr;
+  }
+  return res;
 }
 
 TemplateInstantiationData GetTplInstDataForClass(

--- a/tests/cxx/template_args-d2.h
+++ b/tests/cxx/template_args-d2.h
@@ -32,3 +32,11 @@ using NonProvidingFunctionAlias2 = IndirectClass(int);
 
 template <int>
 using NonProvidingPtrAlias = IndirectClass*;
+
+template <typename T>
+struct Host;
+
+using HostNonProvidingAlias = Host<IndirectClass>;
+
+template <typename>
+using HostNonProvidingAliasTpl = Host<IndirectClass>;

--- a/tests/cxx/template_args-i1.h
+++ b/tests/cxx/template_args-i1.h
@@ -16,3 +16,5 @@ struct TplHost {
   template <typename>
   struct InnerTpl {};
 };
+
+class Class {};

--- a/tests/cxx/template_args.cc
+++ b/tests/cxx/template_args.cc
@@ -391,6 +391,116 @@ UsingDereferenced<NonProvidingPtrAlias<1>> udnppa;
 
 // ---------------------------------------------------------------
 
+class Class;
+
+template <typename T>
+struct Host {
+  template <typename>
+  struct Nested1 {
+    T t;
+  };
+
+  template <typename U>
+  struct Nested2 {
+    U u;
+  };
+
+  struct Intermediate1 {
+    template <typename>
+    struct Nested {
+      T t;
+    };
+  };
+
+  template <typename U>
+  struct Level1 {
+    template <typename>
+    struct Level2 {
+      T t;
+      U u;
+    };
+  };
+
+  typedef Level1<Class> Level1NonProviding;
+  template <typename>
+  using Level1NonProvidingAlTpl = Level1<Class>;
+};
+
+// IWYU: IndirectClass is...*indirect.h
+using HostProvidingAlias = Host<IndirectClass>;
+
+template <typename>
+// IWYU: IndirectClass is...*indirect.h
+using HostProvidingAliasTpl = Host<IndirectClass>;
+
+using NestedWithClass = Host<Class>::Intermediate1;
+
+template <typename T>
+using AliasTplToTypedef = typename Host<T>::Level1NonProviding;
+
+void TestMultiLevelArgs() {
+  // IWYU: IndirectClass needs a declaration
+  // IWYU: IndirectClass is...*indirect.h
+  (void)sizeof(Host<IndirectClass>::Nested1<int>);
+  // IWYU: IndirectClass needs a declaration
+  Host<IndirectClass>::Nested1<int>* nested11;
+  // IWYU: IndirectClass is...*indirect.h
+  (void)sizeof(*nested11);
+
+  // IWYU: IndirectClass needs a declaration
+  // IWYU: IndirectClass is...*indirect.h
+  (void)sizeof(Host<int>::Nested2<IndirectClass>);
+  // IWYU: IndirectClass needs a declaration
+  Host<int>::Nested2<IndirectClass>* nested2;
+  // IWYU: IndirectClass is...*indirect.h
+  (void)sizeof(*nested2);
+
+  // IWYU: IndirectClass needs a declaration
+  Host<IndirectClass>::Intermediate1::Nested<int>* inner_nested;
+  // IWYU: IndirectClass is...*indirect.h
+  (void)sizeof(*inner_nested);
+
+  // IWYU: IndirectClass needs a declaration
+  Host<int>::Level1<IndirectClass>::Level2<int>* level2;
+  // IWYU: IndirectClass is...*indirect.h
+  (void)sizeof(*level2);
+
+  HostProvidingAlias::Nested1<int> hpan1;
+  // IWYU: IndirectClass is...*indirect.h
+  HostNonProvidingAlias::Nested1<int> hnpan1;
+
+  HostProvidingAliasTpl<int>::Nested1<int> hpatn1;
+  // IWYU: IndirectClass is...*indirect.h
+  HostNonProvidingAliasTpl<int>::Nested1<int> hnpatn1;
+
+  // IWYU: Class is...*-i1.h
+  (void)sizeof(NestedWithClass::Nested<int>);
+  NestedWithClass::Nested<int>* nested12;
+  // IWYU: Class is...*-i1.h
+  (void)sizeof(*nested12);
+
+  // IWYU: IndirectClass needs a declaration
+  // IWYU: Class is...*-i1.h
+  // IWYU: IndirectClass is...*indirect.h
+  Host<IndirectClass>::Level1NonProviding::Level2<int> inner_nested2;
+  // IWYU: IndirectClass needs a declaration
+  Host<IndirectClass>::Level1NonProviding::Level2<int>* p_inner_nested2;
+  // IWYU: Class is...*-i1.h
+  // IWYU: IndirectClass is...*indirect.h
+  (void)sizeof(*p_inner_nested2);
+  // IWYU: IndirectClass needs a declaration
+  // IWYU: Class is...*-i1.h
+  // IWYU: IndirectClass is...*indirect.h
+  (void)sizeof(Host<IndirectClass>::Level1NonProvidingAlTpl<int>::Level2<int>);
+
+  // IWYU: IndirectClass needs a declaration
+  // IWYU: Class is...*-i1.h
+  // IWYU: IndirectClass is...*indirect.h
+  (void)sizeof(AliasTplToTypedef<IndirectClass>::Level2<int>);
+}
+
+// ---------------------------------------------------------------
+
 /**** IWYU_SUMMARY
 
 tests/cxx/template_args.cc should add these lines:
@@ -399,12 +509,13 @@ tests/cxx/template_args.cc should add these lines:
 
 tests/cxx/template_args.cc should remove these lines:
 - #include "tests/cxx/direct.h"  // lines XX-XX
+- class Class;  // lines XX-XX
 
 The full include-list for tests/cxx/template_args.cc:
 #include "tests/cxx/indirect.h"  // for IndirectClass, IndirectTemplate
 #include "tests/cxx/template_args-d1.h"  // for ProvidingAlias
-#include "tests/cxx/template_args-d2.h"  // for NonProvidingAlias, NonProvidingFunctionAlias1, NonProvidingFunctionAlias2, NonProvidingPtrAlias
-#include "tests/cxx/template_args-i1.h"  // for TplHost, TplInI1
+#include "tests/cxx/template_args-d2.h"  // for HostNonProvidingAlias, HostNonProvidingAliasTpl, NonProvidingAlias, NonProvidingFunctionAlias1, NonProvidingFunctionAlias2, NonProvidingPtrAlias
+#include "tests/cxx/template_args-i1.h"  // for Class, TplHost, TplInI1
 template <typename F> struct FunctionStruct;  // lines XX-XX
 
 ***** IWYU_SUMMARY */


### PR DESCRIPTION
Prior to this, IWYU didn't report `Arg1` for instantiated member templates like `Host<Arg1>::Nested<Arg2>` when `Arg1` was fully used inside `Nested` template but not inside `Host` directly.

This improves only handling of (possibly indirect) member templates of other templates. Non-templated members of templates aren't still scanned correctly.