### PR TITLE
Look for host template arguments through sugar

### DIFF
--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -1891,7 +1891,7 @@ TemplateInstantiationData GetTplInstDataForClassNoComponentTypes(
   TemplateInstantiationData res;
   // Collect type template arguments from all the parts of a probably qualified
   // name (like Level1<Arg1>::Level2<Arg2>::Level3<Arg3>).
-  const Type* part = type;
+  const Type* part = Desugar(type);
   while (part) {
     if (const auto* typedef_type = part->getAs<TypedefType>()) {
       // Underlying types of aliases may in turn be qualified or unqualified
@@ -1919,8 +1919,9 @@ TemplateInstantiationData GetTplInstDataForClassNoComponentTypes(
     }
 
     NestedNameSpecifier nns = part->getPrefix();
-    part = nns.getKind() == NestedNameSpecifier::Kind::Type ? nns.getAsType()
-                                                            : nullptr;
+    part = nns.getKind() == NestedNameSpecifier::Kind::Type
+               ? Desugar(nns.getAsType())
+               : nullptr;
   }
   return res;
 }

--- a/tests/cxx/template_args.cc
+++ b/tests/cxx/template_args.cc
@@ -424,6 +424,13 @@ struct Host {
   typedef Level1<Class> Level1NonProviding;
   template <typename>
   using Level1NonProvidingAlTpl = Level1<Class>;
+
+  template <typename>
+  struct UsesInMethod {
+    static void Fn() {
+      T t;
+    }
+  };
 };
 
 // IWYU: IndirectClass is...*indirect.h
@@ -497,6 +504,17 @@ void TestMultiLevelArgs() {
   // IWYU: Class is...*-i1.h
   // IWYU: IndirectClass is...*indirect.h
   (void)sizeof(AliasTplToTypedef<IndirectClass>::Level2<int>);
+
+  Host<Class>::Intermediate1 intermediate1;
+  // IWYU: Class is...*-i1.h
+  decltype(intermediate1)::Nested<int> inner_nested3;
+  using Intermediate1AliasNonProviding = decltype(intermediate1);
+  // IWYU: Class is...*-i1.h
+  Intermediate1AliasNonProviding::Nested<int> inner_nested4;
+  // IWYU: IndirectClass needs a declaration
+  Host<IndirectClass>::UsesInMethod<int> uim;
+  // IWYU: IndirectClass is...*indirect.h
+  decltype(uim)::Fn();
 }
 
 // ---------------------------------------------------------------


### PR DESCRIPTION
In df466a6b07ea56781b8109858c4dcee3adffe1ae, I overlooked that `Desugar` should be called to be able to get a name prefix for sugar types other than type aliases (which are handled explicitly).