### PR TITLE
Don't scan instantiated specialization arguments

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -3815,11 +3815,11 @@ class InstantiatedTemplateVisitor
     }
 
     if (const auto* tpl_spec_type = type->getAs<TemplateSpecializationType>()) {
-      TraverseTemplateSpecializationType(
-          const_cast<TemplateSpecializationType*>(tpl_spec_type), false);
+      TraverseTemplateSpecializationTypeHelper(tpl_spec_type);
     } else if (const auto* record_type = type->getAs<RecordType>()) {
       TraverseRecordTypeHelper(record_type);
     }
+    ReportExplicitInstantiations(type);
   }
 
   void ScanInstantiatedClass(ClassTemplateSpecializationDecl* decl,
@@ -4027,6 +4027,7 @@ class InstantiatedTemplateVisitor
     const Decl* decl = TypeToDeclAsWritten(type);
     ASTNode new_node{decl};
     CurrentASTNodeUpdater canu{&current_ast_node_, &new_node};
+    current_ast_node_->set_in_forward_declare_context(true);
     if (ShouldPrintSymbolFromCurrentFile()) {
       errs() << AnnotatedName(GetKindName(decl)) << PrintablePtr(decl)
              << PrintableDecl(decl) << "\n";

--- a/tests/cxx/template_args-i1.h
+++ b/tests/cxx/template_args-i1.h
@@ -18,3 +18,7 @@ struct TplHost {
 };
 
 class Class {};
+
+constexpr int GetInt() {
+  return 1;
+}

--- a/tests/cxx/template_args.cc
+++ b/tests/cxx/template_args.cc
@@ -602,6 +602,22 @@ void TestNonTemplatesInsideTemplate() {
 
 // ---------------------------------------------------------------
 
+template <int>
+class IntArgTpl {};
+
+// IWYU: GetInt() is...*-i1.h
+extern IntArgTpl<GetInt()> iat1;
+
+// IWYU: GetInt() is...*-i1.h
+IntArgTpl<GetInt()> GetIntArgTpl();
+
+// No need to report GetInt here: it should be reported where the template
+// arguments are specified.
+auto iat_size = sizeof(iat1);
+auto iat2 = GetIntArgTpl();
+
+// ---------------------------------------------------------------
+
 /**** IWYU_SUMMARY
 
 tests/cxx/template_args.cc should add these lines:
@@ -616,7 +632,7 @@ The full include-list for tests/cxx/template_args.cc:
 #include "tests/cxx/indirect.h"  // for IndirectClass, IndirectTemplate
 #include "tests/cxx/template_args-d1.h"  // for ProvidingAlias
 #include "tests/cxx/template_args-d2.h"  // for HostNonProvidingAlias, HostNonProvidingAliasTpl, IndirectClassNonProviding, NonProvidingAlias, NonProvidingFunctionAlias1, NonProvidingFunctionAlias2, NonProvidingPtrAlias, TplWithMethodWithoutDefNonProviding
-#include "tests/cxx/template_args-i1.h"  // for Class, TplHost, TplInI1
+#include "tests/cxx/template_args-i1.h"  // for Class, GetInt, TplHost, TplInI1
 template <typename F> struct FunctionStruct;  // lines XX-XX
 
 ***** IWYU_SUMMARY */


### PR DESCRIPTION
They should be handled only where specified, otherwise it may cause unwanted reports about entities used to specify them. For example, if a variable
```cpp
extern IntArgTpl<GetInt()> iat;
```
is declared in a header, then `GetInt` function should be reported for that header and not for any other source file that fully uses the variable and hence instantiates the template.

`TraverseTemplateSpecializationType` function causes template specialization argument traversing, whereas
`TraverseTemplateSpecializationTypeHelper` does not.

The call of `ReportExplicitInstantiations` has been inserted because this function is called from `VisitTemplateSpecializationType` which in turn is called from `TraverseTemplateSpecializationType` but not from `TraverseTemplateSpecializationTypeHelper`.

Besides, `set_in_forward_declare_context` is called from `VisitTemplateSpecializationType` and hence should now be called explicitly for alias templates. An instantiated alias template can always be scanned as if its top-level type is in a fwd-decl context because even if it is not it is anyway reported from `VisitTemplateSpecializationType` (perhaps in `IwyuAstConsumer`), and doing it from `TraverseInstantiatedAliasTemplateHelper` was just a redundant double-reporting.