### PR TITLE
Avoid reporting types without name

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -3606,6 +3606,10 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
     if (blocked_types.count(GetCanonicalType(type)))
       return;
     if (const NamedDecl* decl = TypeToDeclAsWritten(type)) {
+      if (!decl->getIdentifier()) {
+        VERRS(6) << "Ignoring unnamed type: " << PrintableType(type) << "\n";
+        return;
+      }
       decl = GetDefinitionAsWritten(decl);
       VERRS(6) << "(For type " << PrintableType(type) << "):\n";
       IwyuBaseAstVisitor<Derived>::ReportDeclUse(used_loc, decl);

--- a/tests/c/unnamed-direct.h
+++ b/tests/c/unnamed-direct.h
@@ -1,0 +1,10 @@
+//===--- unnamed-direct.h - iwyu test -------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/c/unnamed-i2.h"

--- a/tests/c/unnamed-i1.h
+++ b/tests/c/unnamed-i1.h
@@ -1,0 +1,12 @@
+//===--- unnamed-i1.h - iwyu test -----------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+extern struct {
+  int i;
+} var_of_unnamed_type;

--- a/tests/c/unnamed-i2.h
+++ b/tests/c/unnamed-i2.h
@@ -1,4 +1,4 @@
-//===--- 1789.c - iwyu test -----------------------------------------------===//
+//===--- unnamed-i2.h - iwyu test -----------------------------------------===//
 //
 //                     The LLVM Compiler Infrastructure
 //
@@ -7,16 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// IWYU_XFAIL
+#include "tests/c/unnamed-i1.h"
 
-#include "direct.h"
-
-int main() {
-    return var_direct.i;
-}
-
-/**** IWYU_SUMMARY
-
-(tests/bugs/1789/1789.c has correct #includes/fwd-decls)
-
-***** IWYU_SUMMARY */
+extern typeof(var_of_unnamed_type) deduced_var;

--- a/tests/c/unnamed.c
+++ b/tests/c/unnamed.c
@@ -1,0 +1,31 @@
+//===--- unnamed.c - iwyu test --------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/c/unnamed-direct.h"
+
+// IWYU_ARGS: -std=c23 -I .
+
+int main() {
+  // Notably, we do NOT want -i1.h because the type in there has no name.
+  // IWYU: deduced_var is...*unnamed-i2.h
+  return deduced_var.i;
+}
+
+/**** IWYU_SUMMARY
+
+tests/c/unnamed.c should add these lines:
+#include "tests/c/unnamed-i2.h"
+
+tests/c/unnamed.c should remove these lines:
+- #include "tests/c/unnamed-direct.h"  // lines XX-XX
+
+The full include-list for tests/c/unnamed.c:
+#include "tests/c/unnamed-i2.h"  // for deduced_var
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/unnamed-direct.h
+++ b/tests/cxx/unnamed-direct.h
@@ -1,0 +1,10 @@
+//===--- unnamed-direct.h - iwyu test -------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/unnamed-i2.h"

--- a/tests/cxx/unnamed-i1.h
+++ b/tests/cxx/unnamed-i1.h
@@ -1,4 +1,4 @@
-//===--- direct.h - iwyu test ---------------------------------------------===//
+//===--- unnamed-i1.h - iwyu test -----------------------------------------===//
 //
 //                     The LLVM Compiler Infrastructure
 //
@@ -7,6 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "indirect.h"
-
-extern typeof(var_indirect) var_direct;
+struct {
+  int i;
+} var_of_unnamed_type;

--- a/tests/cxx/unnamed-i2.h
+++ b/tests/cxx/unnamed-i2.h
@@ -1,4 +1,4 @@
-//===--- indirect.h - iwyu test -------------------------------------------===//
+//===--- unnamed-i2.h - iwyu test -----------------------------------------===//
 //
 //                     The LLVM Compiler Infrastructure
 //
@@ -7,4 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-extern struct { int i; } var_indirect;
+#include "tests/cxx/unnamed-i1.h"
+
+static decltype(var_of_unnamed_type) deduced_var;

--- a/tests/cxx/unnamed.cc
+++ b/tests/cxx/unnamed.cc
@@ -1,0 +1,31 @@
+//===--- unnamed.cc - iwyu test -------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/unnamed-direct.h"
+
+// IWYU_ARGS: -I .
+
+int main() {
+  // Notably, we do NOT want -i1.h because the type in there has no name.
+  // IWYU: deduced_var is...*unnamed-i2.h
+  return deduced_var.i;
+}
+
+/**** IWYU_SUMMARY
+
+tests/cxx/unnamed.cc should add these lines:
+#include "tests/cxx/unnamed-i2.h"
+
+tests/cxx/unnamed.cc should remove these lines:
+- #include "tests/cxx/unnamed-direct.h"  // lines XX-XX
+
+The full include-list for tests/cxx/unnamed.cc:
+#include "tests/cxx/unnamed-i2.h"  // for deduced_var
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
Add tests for deduced unnamed types using typeof() in C23 and decltype()
in C++.

Fixes #1789.