### PR TITLE
Search for autocast constructors in definitions

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -90,7 +90,6 @@
 
 #include <cstdio>
 #include <cstdlib>                      // for atoi, exit
-#include <functional>
 #include <map>                          // for map, swap, etc
 #include <memory>                       // for unique_ptr
 #include <set>                          // for set, set<>::iterator, swap

--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -839,19 +839,6 @@ bool IsImplicitInstantiation(const VarDecl* decl) {
 }
 
 bool HasImplicitConversionCtor(const CXXRecordDecl* cxx_class) {
-  // Clang leaves ClassTemplateSpecializationDecl empty for uninstantiated
-  // specializations. Hence, replace cxx_class with template definition so that
-  // IWYU can find constructors.
-  if (const auto* tpl_spec =
-          dyn_cast<ClassTemplateSpecializationDecl>(cxx_class)) {
-    if (!tpl_spec->isExplicitSpecialization()) {
-      cxx_class = tpl_spec->getSpecializedTemplate()
-                      ->getCanonicalDecl()
-                      ->getTemplatedDecl();
-    }
-    // TODO(bolshakov): handle partial specializations.
-  }
-
   for (CXXRecordDecl::ctor_iterator ctor = cxx_class->ctor_begin();
        ctor != cxx_class->ctor_end(); ++ctor) {
     if (!IsImplicitConversionCtor(*ctor))
@@ -1799,7 +1786,7 @@ bool HasImplicitConversionConstructor(const Type* type) {
     return false;  // can't implicitly convert to a non-const reference
 
   type = RemoveReferenceAsWritten(type);
-  const NamedDecl* decl = TypeToDeclAsWritten(type);
+  const NamedDecl* decl = GetTagDefinition(TypeToDeclAsWritten(type));
   if (!decl)  // not the kind of type that has a decl (e.g. built-in)
     return false;
 

--- a/iwyu_cache.cc
+++ b/iwyu_cache.cc
@@ -9,7 +9,6 @@
 
 #include "iwyu_cache.h"
 
-#include <functional>
 #include <set>
 #include <string>
 

--- a/tests/cxx/implicit_ctor-d1.h
+++ b/tests/cxx/implicit_ctor-d1.h
@@ -27,6 +27,10 @@ inline int InlineImplicitCtorRefFn(const IndirectWithImplicitCtor&) {
   return 1;
 }
 
+// IWYU: ImplicitCtorInPartial needs a declaration
+// IWYU: ImplicitCtorInPartial<:0 *> is...*implicit_ctor-i2.h...*for autocast
+int ImplicitCtorInPartialFn(ImplicitCtorInPartial<char*>);
+
 // Test parameter type uses that do not require special handling for "autocast".
 int NoAutocastFn(
     // A subtle c++ point: forward-declaring is ok for nonconst, because
@@ -60,7 +64,7 @@ tests/cxx/implicit_ctor-d1.h should remove these lines:
 - #include "tests/cxx/implicit_ctor-i1.h"  // lines XX-XX
 
 The full include-list for tests/cxx/implicit_ctor-d1.h:
-#include "tests/cxx/implicit_ctor-i2.h"  // for IndirectWithImplicitCtor, MultipleRedeclStruct
+#include "tests/cxx/implicit_ctor-i2.h"  // for ImplicitCtorInPartial, IndirectWithImplicitCtor, MultipleRedeclStruct
 class IndirectClass;
 
 ***** IWYU_SUMMARY */

--- a/tests/cxx/implicit_ctor-i2.h
+++ b/tests/cxx/implicit_ctor-i2.h
@@ -25,3 +25,12 @@ struct NoTrivialCtorDtor {
 struct MultipleRedeclStruct {
   MultipleRedeclStruct(int);
 };
+
+template <typename T>
+struct ImplicitCtorInPartial;
+
+template <typename T>
+struct ImplicitCtorInPartial<T*> {
+  ImplicitCtorInPartial(int) {
+  }
+};

--- a/tests/cxx/implicit_ctor.cc
+++ b/tests/cxx/implicit_ctor.cc
@@ -55,6 +55,8 @@ int e = LocalFn(5);
 // hence no reporting.
 int f = InlineImplicitCtorRefFn(6);
 
+int g = ImplicitCtorInPartialFn(7);
+
 // Make sure we are responsible for the conversion when it's not for a
 // function call.
 // IWYU: IndirectWithImplicitCtor is...*implicit_ctor-i2.h
@@ -137,7 +139,7 @@ tests/cxx/implicit_ctor.cc should add these lines:
 tests/cxx/implicit_ctor.cc should remove these lines:
 
 The full include-list for tests/cxx/implicit_ctor.cc:
-#include "tests/cxx/implicit_ctor-d1.h"  // for ImplicitCtorFn, ImplicitCtorRefFn, InlineImplicitCtorRefFn, TakeMultipleRedeclStruct
+#include "tests/cxx/implicit_ctor-d1.h"  // for ImplicitCtorFn, ImplicitCtorInPartialFn, ImplicitCtorRefFn, InlineImplicitCtorRefFn, TakeMultipleRedeclStruct
 #include "tests/cxx/implicit_ctor-d2.h"  // for NoTrivialCtorDtorNonProvidingAlias, NonProviding
 #include "tests/cxx/implicit_ctor-i2.h"  // for IndirectWithImplicitCtor, NoAutocastCtor, NoTrivialCtorDtor
 

--- a/tests/cxx/iwyu_stricter_than_cpp-i5.h
+++ b/tests/cxx/iwyu_stricter_than_cpp-i5.h
@@ -19,3 +19,6 @@ struct TplIndirectStruct3 {
   static constexpr auto s = sizeof(T1);
   T2* t2;
 };
+
+template <typename, typename>
+struct TplDirectStruct7;


### PR DESCRIPTION
Prior to this, a forward-declaration of a template appeared prior to the definition spoiled IWYU analysis of "autocast" constructors because the canonical template declaration is the first (empty in such cases) declaration. Thus, the "autocast" constructors were not found.

`GetTagDefinition` does the right thing even with uninstantiated template specializations, so the self-written code has been replaced with it.

Moreover, IWYU finds now "autocast" constructors inside partial specializations, including the one of `std::function`.