### PR TITLE
docs: fix http:// links and add License/Contributing sections to README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Coding and testing guidelines are available in the [IWYU Coding Style](docs/IWYU
 
 Use GitHub's [pull request system](https://github.com/include-what-you-use/include-what-you-use/pulls) to submit change requests to the `include-what-you-use/include-what-you-use` repo.
 
-It's usually a good idea to run ideas by the [IWYU mailing list](http://groups.google.com/group/include-what-you-use) to get general agreement on directions before you start hacking.
+It's usually a good idea to run ideas by the [IWYU mailing list](https://groups.google.com/g/include-what-you-use) to get general agreement on directions before you start hacking.
 
 ## Running the tests ##
 

--- a/README.md
+++ b/README.md
@@ -389,4 +389,4 @@ Ideas and directions can also be discussed on the
 
 ## License ##
 
-IWYU is distributed under the [LLVM Release License](LICENSE.TXT).
+IWYU is distributed under the [University of Illinois/NCSA Open Source License](LICENSE.TXT).

--- a/README.md
+++ b/README.md
@@ -380,13 +380,3 @@ Current IWYU pragmas are described in [IWYUPragmas](docs/IWYUPragmas.md).
 
 See our [FAQ](./docs/IWYUFAQ.md) for longer-form Q&A.
 
-
-## Contributing ##
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on submitting patches.
-Ideas and directions can also be discussed on the
-[IWYU mailing list](https://groups.google.com/g/include-what-you-use).
-
-## License ##
-
-IWYU is distributed under the [University of Illinois/NCSA Open Source License](LICENSE.TXT).

--- a/README.md
+++ b/README.md
@@ -379,3 +379,14 @@ Current IWYU pragmas are described in [IWYUPragmas](docs/IWYUPragmas.md).
 ## More questions? ##
 
 See our [FAQ](./docs/IWYUFAQ.md) for longer-form Q&A.
+
+
+## Contributing ##
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on submitting patches.
+Ideas and directions can also be discussed on the
+[IWYU mailing list](https://groups.google.com/g/include-what-you-use).
+
+## License ##
+
+IWYU is distributed under the [LLVM Release License](LICENSE.TXT).

--- a/docs/IWYUMappings.md
+++ b/docs/IWYUMappings.md
@@ -56,7 +56,7 @@ and data varies between the directives, see below.
 Note that you can mix directives of different kinds within the same mapping
 file.
 
-The `.imp` format looks like [JSON](http://json.org/), but IWYU actually uses
+The `.imp` format looks like [JSON](https://www.json.org/), but IWYU actually uses
 LLVM's [YAML](https://yaml.org/) parser to interpret the mapping files, which
 technically allows a richer syntax. We try to use a minimum of YAML features to
 get basic functionality (trailing comma syntax, `#` comments), but please be
@@ -198,9 +198,9 @@ For example;
 
 The rationale for the `ref` directive was to make it easier to compose
 project-specific mappings from a set of library-oriented mapping files. For
-example, IWYU might ship with mapping files for [Boost](http://www.boost.org),
+example, IWYU might ship with mapping files for [Boost](https://www.boost.org),
 the SCL, various C standard libraries, the Windows API, the [Poco
-Library](http://pocoproject.org), etc. Depending on what your specific project
+Library](https://pocoproject.org), etc. Depending on what your specific project
 uses, you could easily create an aggregate mapping file with refs to the
 relevant mappings.
 

--- a/docs/IWYUStyle.md
+++ b/docs/IWYUStyle.md
@@ -302,4 +302,4 @@ If any prerequisite fails the test will be skipped.
 [1]: https://google.github.io/styleguide/cppguide.html
 [2]: https://llvm.org/docs/CodingStandards.html
 [3]: https://google.github.io/styleguide/pyguide.html
-[4]: https://www.python.org/dev/peps/pep-0008
+[4]: https://peps.python.org/pep-0008/

--- a/docs/WhyIWYU.md
+++ b/docs/WhyIWYU.md
@@ -98,7 +98,7 @@ mentioned above, that come with `#include` lines.  (A future version of IWYU may
 mitigate this problem.)  And if a class changes -- for instance, it adds a new
 default template argument -- you need to change many callsites, not just one.
 It is also easier to accidentally violate the [One Definition
-Rule](http://en.wikipedia.org/wiki/One_Definition_Rule) when all you expose is
+Rule](https://en.wikipedia.org/wiki/One_Definition_Rule) when all you expose is
 the name of a class (via a forward declare) rather than the full definition (via
 an `#include`).
 


### PR DESCRIPTION
This PR fixes several documentation issues discovered during a codebase audit:

## Changes

### Fix insecure http:// links
- **CONTRIBUTING.md**: Update Google Groups mailing list URL from deprecated `http://groups.google.com/group/include-what-you-use` to canonical `https://groups.google.com/g/include-what-you-use`
- **docs/IWYUMappings.md**: Update Boost, Poco, and json.org links to https://
- **docs/WhyIWYU.md**: Update Wikipedia One Definition Rule link to https://
- **docs/IWYUStyle.md**: Update PEP 8 reference from deprecated `python.org/dev/peps/pep-0008` (currently unreachable) to canonical `https://peps.python.org/pep-0008/`

### Add missing README sections
- **README.md**: Add `## Contributing` and `## License` sections at the end — these are standard README conventions that help new users quickly find contribution guidelines and license information.

All changes are documentation-only with no functional impact.

Addresses #1997
Addresses #1998
Addresses #1999
Addresses #2001
Addresses #2002