### PR TITLE
fix: add parentheses to IWYU_ARRAYSIZE macro expression

### DIFF
--- a/iwyu_port.h
+++ b/iwyu_port.h
@@ -17,7 +17,7 @@
 #include "llvm/Support/raw_ostream.h"
 
 // Count of statically allocated array.
-#define IWYU_ARRAYSIZE(arr) sizeof(arr) / sizeof(*arr)
+#define IWYU_ARRAYSIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
 
 namespace include_what_you_use {
 


### PR DESCRIPTION
Fixes #1993

The `IWYU_ARRAYSIZE` macro in `iwyu_port.h` was missing outer parentheses around the division expression, making it unsafe when used in multiplication or addition contexts (e.g. `2 * IWYU_ARRAYSIZE(arr)` would evaluate as `(2 * sizeof(arr)) / sizeof(*arr)`).

This PR adds the missing parentheses and uses the more conventional `(arr)[0]` instead of `*arr`.

No call sites need to change since all current usages pass the result as a direct function argument.