### PR TITLE
fix(iwyu_tool): reduce CPU usage in job polling loop

### DIFF
--- a/iwyu_tool.py
+++ b/iwyu_tool.py
@@ -438,8 +438,8 @@ def execute(invocations, verbose, formatter, jobs, max_load_average=0):
         pending.extend(i.start(verbose) for i in invocations[:capacity])
         invocations = invocations[capacity:]
 
-        # Yield CPU.
-        time.sleep(0.0001)
+        # Yield CPU between job polls.
+        time.sleep(0.1)
     return exit_code
 
 


### PR DESCRIPTION
Fixes #1995

The job scheduling loop in `iwyu_tool.py` used `time.sleep(0.0001)` (100us), causing 10,000 wakeups per second while waiting for IWYU analysis jobs that typically run for seconds.

This PR changes the sleep interval to `0.1` seconds (10 polls/sec), which is more than sufficient granularity for long-running jobs and significantly reduces CPU and battery usage during analysis runs.