### PR TITLE
Add unit tests for iwyu_regex, iwyu_verrs and iwyu_stl_util

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -297,8 +297,10 @@ endif(IWYU_USE_SYSTEM_GTEST)
 add_llvm_executable(iwyu-unittests
   unittests/iwyu_lexer_utils_test.cc
   unittests/iwyu_path_util_test.cc
+  unittests/iwyu_regex_test.cc
   unittests/iwyu_stl_util_test.cc
   unittests/iwyu_string_util_test.cc
+  unittests/iwyu_verrs_test.cc
   unittests/iwyu_unittest_main.cc
 )
 

--- a/unittests/iwyu_regex_test.cc
+++ b/unittests/iwyu_regex_test.cc
@@ -1,0 +1,118 @@
+//===--- iwyu_regex_test.cc - test iwyu_regex.h ---------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// Tests for the iwyu_regex module.
+
+#include "iwyu_regex.h"
+
+#include <string>
+
+#include "gtest/gtest.h"
+
+namespace include_what_you_use {
+
+namespace {
+
+// --- ParseRegexDialect tests ---
+
+TEST(IwyuRegexTest, ParseRegexDialectLLVM) {
+  RegexDialect dialect;
+  EXPECT_TRUE(ParseRegexDialect("llvm", &dialect));
+  EXPECT_EQ(RegexDialect::LLVM, dialect);
+}
+
+TEST(IwyuRegexTest, ParseRegexDialectECMAScript) {
+  RegexDialect dialect;
+  EXPECT_TRUE(ParseRegexDialect("ecmascript", &dialect));
+  EXPECT_EQ(RegexDialect::ECMAScript, dialect);
+}
+
+TEST(IwyuRegexTest, ParseRegexDialectInvalidOrEmpty) {
+  RegexDialect dialect = RegexDialect::LLVM;
+  EXPECT_FALSE(ParseRegexDialect("invalid", &dialect));
+  EXPECT_EQ(RegexDialect::LLVM, dialect);
+
+  EXPECT_FALSE(ParseRegexDialect("", &dialect));
+  EXPECT_EQ(RegexDialect::LLVM, dialect);
+}
+
+// --- Parameterized RegexMatch/RegexReplace tests ---
+// Tests that behave identically across both dialects.
+
+class RegexDialectTest : public ::testing::TestWithParam<RegexDialect> {};
+
+TEST_P(RegexDialectTest, MatchExact) {
+  EXPECT_TRUE(RegexMatch(GetParam(), "hello", "hello"));
+}
+
+TEST_P(RegexDialectTest, MatchNoMatch) {
+  EXPECT_FALSE(RegexMatch(GetParam(), "hello", "world"));
+}
+
+TEST_P(RegexDialectTest, MatchPartialDoesNotMatch) {
+  EXPECT_FALSE(RegexMatch(GetParam(), "hello world", "hello"));
+}
+
+TEST_P(RegexDialectTest, MatchWildcard) {
+  EXPECT_TRUE(RegexMatch(GetParam(), "hello world", "hello.*"));
+}
+
+TEST_P(RegexDialectTest, MatchEmptyPattern) {
+  EXPECT_TRUE(RegexMatch(GetParam(), "", ""));
+  EXPECT_FALSE(RegexMatch(GetParam(), "hello", ""));
+}
+
+TEST_P(RegexDialectTest, MatchDigits) {
+  EXPECT_TRUE(RegexMatch(GetParam(), "test123", "test[0-9]+"));
+  EXPECT_FALSE(RegexMatch(GetParam(), "test", "test[0-9]+"));
+}
+
+TEST_P(RegexDialectTest, ReplaceExact) {
+  std::string result =
+      RegexReplace(GetParam(), "hello", "hello", "world");
+  EXPECT_EQ("world", result);
+}
+
+TEST_P(RegexDialectTest, ReplaceNoMatch) {
+  std::string result =
+      RegexReplace(GetParam(), "hello", "xyz", "abc");
+  EXPECT_EQ("hello", result);
+}
+
+INSTANTIATE_TEST_SUITE_P(AllDialects, RegexDialectTest,
+                         ::testing::Values(RegexDialect::LLVM,
+                                           RegexDialect::ECMAScript));
+
+// --- Dialect-specific tests ---
+
+TEST(IwyuRegexTest, RegexReplaceLLVMWithCapture) {
+  std::string result = RegexReplace(RegexDialect::LLVM, "hello world",
+                                    "(hello) (world)", "\\2 \\1");
+  EXPECT_EQ("world hello", result);
+}
+
+TEST(IwyuRegexTest, RegexReplaceECMAScriptWithCapture) {
+  std::string result = RegexReplace(RegexDialect::ECMAScript, "hello world",
+                                    "(hello) (world)", "$2 $1");
+  EXPECT_EQ("world hello", result);
+}
+
+// ECMAScript supports negative lookahead; LLVM does not.
+// See issues #981, #935 and commits cf5388082266, a5d8408c5f2c.
+// Note: std::regex ECMAScript mode follows the ES5 spec which only supports
+// lookahead (?=...) and (?!...), not lookbehind (?<=...) and (?<!...).
+
+TEST(IwyuRegexTest, ECMAScriptNegativeLookahead) {
+  // Match "foo" not followed by "bar".
+  EXPECT_TRUE(RegexMatch(RegexDialect::ECMAScript, "foobaz", "foo(?!bar).*"));
+  EXPECT_FALSE(RegexMatch(RegexDialect::ECMAScript, "foobar", "foo(?!bar).*"));
+}
+
+}  // namespace
+}  // namespace include_what_you_use

--- a/unittests/iwyu_stl_util_test.cc
+++ b/unittests/iwyu_stl_util_test.cc
@@ -11,12 +11,18 @@
 
 #include "iwyu_stl_util.h"
 
+#include <map>
 #include <set>
+#include <string>
+#include <vector>
 
 #include "gtest/gtest.h"
 
 namespace include_what_you_use {
+using std::map;
 using std::set;
+using std::string;
+using std::vector;
 
 namespace {
 
@@ -51,6 +57,176 @@ TEST(IwyuSTLUtilTest, Union) {
 
   // Union of mixed lvalues and rvalues.
   EXPECT_EQ(set<int>({7, 8, 9, 10, 11, 12}), Union(std::move(s3), s4));
+}
+
+TEST(IwyuSTLUtilTest, ContainsKeyPresent) {
+  map<string, int> m{{"a", 1}, {"b", 2}};
+  EXPECT_TRUE(ContainsKey(m, string("a")));
+  EXPECT_TRUE(ContainsKey(m, string("b")));
+}
+
+TEST(IwyuSTLUtilTest, ContainsKeyAbsent) {
+  map<string, int> m{{"a", 1}};
+  EXPECT_FALSE(ContainsKey(m, string("z")));
+}
+
+TEST(IwyuSTLUtilTest, ContainsKeyEmptyContainer) {
+  map<int, int> m;
+  EXPECT_FALSE(ContainsKey(m, 1));
+}
+
+TEST(IwyuSTLUtilTest, ContainsKeyInSet) {
+  set<int> s{10, 20, 30};
+  EXPECT_TRUE(ContainsKey(s, 20));
+  EXPECT_FALSE(ContainsKey(s, 99));
+}
+
+TEST(IwyuSTLUtilTest, ContainsValuePresent) {
+  vector<int> v{1, 2, 3};
+  EXPECT_TRUE(ContainsValue(v, 2));
+}
+
+TEST(IwyuSTLUtilTest, ContainsValueAbsent) {
+  vector<int> v{1, 2, 3};
+  EXPECT_FALSE(ContainsValue(v, 4));
+}
+
+TEST(IwyuSTLUtilTest, ContainsValueEmpty) {
+  vector<string> v;
+  EXPECT_FALSE(ContainsValue(v, string("x")));
+}
+
+TEST(IwyuSTLUtilTest, ContainsKeyValuePresent) {
+  map<string, int> m{{"a", 1}, {"b", 2}};
+  EXPECT_TRUE(ContainsKeyValue(m, string("a"), 1));
+}
+
+TEST(IwyuSTLUtilTest, ContainsKeyValueWrongValue) {
+  map<string, int> m{{"a", 1}};
+  EXPECT_FALSE(ContainsKeyValue(m, string("a"), 99));
+}
+
+TEST(IwyuSTLUtilTest, ContainsKeyValueMissingKey) {
+  map<string, int> m{{"a", 1}};
+  EXPECT_FALSE(ContainsKeyValue(m, string("z"), 1));
+}
+
+TEST(IwyuSTLUtilTest, ContainsAnyKeyMatch) {
+  map<int, string> m{{1, "a"}, {2, "b"}, {3, "c"}};
+  set<int> keys{2, 5};
+  EXPECT_TRUE(ContainsAnyKey(m, keys));
+}
+
+TEST(IwyuSTLUtilTest, ContainsAnyKeyNoMatch) {
+  map<int, string> m{{1, "a"}, {2, "b"}};
+  set<int> keys{10, 20};
+  EXPECT_FALSE(ContainsAnyKey(m, keys));
+}
+
+TEST(IwyuSTLUtilTest, ContainsAnyKeyEmptyKeys) {
+  map<int, string> m{{1, "a"}};
+  set<int> keys;
+  EXPECT_FALSE(ContainsAnyKey(m, keys));
+}
+
+TEST(IwyuSTLUtilTest, GetOrDefaultHit) {
+  map<string, int> m{{"a", 42}};
+  EXPECT_EQ(42, GetOrDefault(m, string("a"), -1));
+}
+
+TEST(IwyuSTLUtilTest, GetOrDefaultMiss) {
+  map<string, int> m{{"a", 42}};
+  EXPECT_EQ(-1, GetOrDefault(m, string("z"), -1));
+}
+
+TEST(IwyuSTLUtilTest, GetOrDefaultEmpty) {
+  map<int, int> m;
+  EXPECT_EQ(0, GetOrDefault(m, 1, 0));
+}
+
+TEST(IwyuSTLUtilTest, FindInMapHit) {
+  map<string, int> m{{"a", 1}, {"b", 2}};
+  const int* val = FindInMap(&m, string("b"));
+  ASSERT_NE(nullptr, val);
+  EXPECT_EQ(2, *val);
+}
+
+TEST(IwyuSTLUtilTest, FindInMapMiss) {
+  map<string, int> m{{"a", 1}};
+  const int* val = FindInMap(&m, string("z"));
+  EXPECT_EQ(nullptr, val);
+}
+
+TEST(IwyuSTLUtilTest, FindInMapMutable) {
+  map<string, int> m{{"a", 1}};
+  int* val = FindInMap(&m, string("a"));
+  ASSERT_NE(nullptr, val);
+  *val = 99;
+  EXPECT_EQ(99, m["a"]);
+}
+
+TEST(IwyuSTLUtilTest, RemoveAllFromSet) {
+  set<int> target{1, 2, 3, 4, 5};
+  set<int> to_remove{2, 4};
+  RemoveAllFrom(to_remove, &target);
+  EXPECT_EQ(set<int>({1, 3, 5}), target);
+}
+
+TEST(IwyuSTLUtilTest, RemoveAllFromNoOverlap) {
+  set<int> target{1, 2, 3};
+  set<int> to_remove{10, 20};
+  RemoveAllFrom(to_remove, &target);
+  EXPECT_EQ(set<int>({1, 2, 3}), target);
+}
+
+TEST(IwyuSTLUtilTest, RemoveAllFromEmpty) {
+  set<int> target{1, 2, 3};
+  set<int> to_remove;
+  RemoveAllFrom(to_remove, &target);
+  EXPECT_EQ(set<int>({1, 2, 3}), target);
+}
+
+TEST(IwyuSTLUtilTest, InsertAllIntoSet) {
+  set<int> source{3, 4, 5};
+  set<int> target{1, 2, 3};
+  InsertAllInto(source, &target);
+  EXPECT_EQ(set<int>({1, 2, 3, 4, 5}), target);
+}
+
+TEST(IwyuSTLUtilTest, InsertAllIntoEmpty) {
+  set<int> source;
+  set<int> target{1, 2};
+  InsertAllInto(source, &target);
+  EXPECT_EQ(set<int>({1, 2}), target);
+}
+
+TEST(IwyuSTLUtilTest, ExtendVector) {
+  vector<int> target{1, 2};
+  vector<int> source{3, 4, 5};
+  Extend(&target, source);
+  EXPECT_EQ(vector<int>({1, 2, 3, 4, 5}), target);
+}
+
+TEST(IwyuSTLUtilTest, ExtendEmpty) {
+  vector<int> target{1, 2};
+  vector<int> source;
+  Extend(&target, source);
+  EXPECT_EQ(vector<int>({1, 2}), target);
+}
+
+TEST(IwyuSTLUtilTest, GetUniqueEntriesNoDuplicates) {
+  vector<int> v{1, 2, 3};
+  EXPECT_EQ(vector<int>({1, 2, 3}), GetUniqueEntries(v));
+}
+
+TEST(IwyuSTLUtilTest, GetUniqueEntriesWithDuplicates) {
+  vector<int> v{3, 1, 2, 1, 3, 4};
+  EXPECT_EQ(vector<int>({3, 1, 2, 4}), GetUniqueEntries(v));
+}
+
+TEST(IwyuSTLUtilTest, GetUniqueEntriesEmpty) {
+  vector<int> v;
+  EXPECT_EQ(vector<int>(), GetUniqueEntries(v));
 }
 
 }  // namespace

--- a/unittests/iwyu_verrs_test.cc
+++ b/unittests/iwyu_verrs_test.cc
@@ -1,0 +1,71 @@
+//===--- iwyu_verrs_test.cc - test iwyu_verrs.h ---------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// Tests for the iwyu_verrs module.
+// Only tests pure functions that do not require Clang infrastructure.
+
+#include "iwyu_verrs.h"
+
+#include "gtest/gtest.h"
+
+namespace include_what_you_use {
+
+namespace {
+
+// Fixture to save and restore verbose level between tests.
+class IwyuVerrsTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    saved_level_ = GetVerboseLevel();
+  }
+
+  void TearDown() override {
+    SetVerboseLevel(saved_level_);
+  }
+
+ private:
+  int saved_level_;
+};
+
+TEST_F(IwyuVerrsTest, SetGetVerboseLevelRoundtrip) {
+  SetVerboseLevel(5);
+  EXPECT_EQ(5, GetVerboseLevel());
+
+  SetVerboseLevel(0);
+  EXPECT_EQ(0, GetVerboseLevel());
+
+  SetVerboseLevel(10);
+  EXPECT_EQ(10, GetVerboseLevel());
+}
+
+TEST_F(IwyuVerrsTest, ShouldPrintAtExactLevel) {
+  SetVerboseLevel(3);
+  EXPECT_TRUE(ShouldPrint(3));
+}
+
+TEST_F(IwyuVerrsTest, ShouldPrintBelowLevel) {
+  SetVerboseLevel(3);
+  EXPECT_TRUE(ShouldPrint(1));
+  EXPECT_TRUE(ShouldPrint(2));
+}
+
+TEST_F(IwyuVerrsTest, ShouldPrintAboveLevelReturnsFalse) {
+  SetVerboseLevel(3);
+  EXPECT_FALSE(ShouldPrint(4));
+  EXPECT_FALSE(ShouldPrint(5));
+}
+
+TEST_F(IwyuVerrsTest, ShouldPrintAtZeroLevel) {
+  SetVerboseLevel(0);
+  EXPECT_TRUE(ShouldPrint(0));
+  EXPECT_FALSE(ShouldPrint(1));
+}
+
+}  // namespace
+}  // namespace include_what_you_use


### PR DESCRIPTION
This PR adds unit test coverage for three modules that previously had none or incomplete coverage.

## Changes

### New: `unittests/iwyu_regex_test.cc`
Closes #1994

Tests `ParseRegexDialect`, `RegexMatch`, and `RegexReplace` for both LLVM and ECMAScript dialects, including edge cases (empty patterns, no-match, anchored full-match semantics, capture group replacement).

### New: `unittests/iwyu_verrs_test.cc`
Closes #1996

Tests `SetVerboseLevel`/`GetVerboseLevel` roundtrip and `ShouldPrint` logic at various verbosity levels. Uses a test fixture to save and restore the verbose level between tests.

### Extended: `unittests/iwyu_stl_util_test.cc`
Closes #2000

Adds test cases for `ContainsKey`, `ContainsValue`, `ContainsKeyValue`, `ContainsAnyKey`, `GetOrDefault`, `FindInMap`, and `RemoveAllFrom` — all previously untested.

### CMakeLists.txt
Registers the two new test targets following the existing pattern.