### PR TITLE
Handle user-defined literals in function-call traversal

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -218,6 +218,7 @@ using clang::FriendTemplateDecl;
 using clang::FunctionDecl;
 using clang::FunctionProtoType;
 using clang::FunctionTemplateDecl;
+using clang::UserDefinedLiteral;
 using clang::FunctionType;
 using clang::LateParsedTemplate;
 using clang::LinkageSpecDecl;
@@ -728,6 +729,17 @@ class BaseAstVisitor : public RecursiveASTVisitor<Derived> {
     }
     return this->getDerived().HandleFunctionCall(
         func, TypeOfParentIfMethod(expr), expr);
+  }
+
+  bool TraverseUserDefinedLiteral(UserDefinedLiteral* expr) {
+    if (!Base::TraverseUserDefinedLiteral(expr))
+      return false;
+    if (CanIgnoreCurrentASTNode())
+      return true;
+    FunctionDecl* func = expr->getDirectCallee();
+    if (!func)
+      return true;
+    return this->getDerived().HandleFunctionCall(func, nullptr, expr);
   }
 
   bool TraverseCXXMemberCallExpr(CXXMemberCallExpr* expr) {

--- a/tests/cxx/user_defined_literal-direct.h
+++ b/tests/cxx/user_defined_literal-direct.h
@@ -1,0 +1,18 @@
+//===--- user_defined_literal-direct.h - test input file for iwyu ---------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// This file is meant to be directly included by the test .cc file.  It only
+// re-exports the header that declares the literal operator.
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_USER_DEFINED_LITERAL_DIRECT_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_USER_DEFINED_LITERAL_DIRECT_H_
+
+#include "user_defined_literal-indirect.h"
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_USER_DEFINED_LITERAL_DIRECT_H_

--- a/tests/cxx/user_defined_literal-indirect.h
+++ b/tests/cxx/user_defined_literal-indirect.h
@@ -1,0 +1,19 @@
+//===--- user_defined_literal-indirect.h - test input file for iwyu -------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_USER_DEFINED_LITERAL_INDIRECT_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_USER_DEFINED_LITERAL_INDIRECT_H_
+
+constexpr unsigned long long operator""_x(unsigned long long value) {
+  return value;
+}
+
+class IndirectClass {};
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_USER_DEFINED_LITERAL_INDIRECT_H_

--- a/tests/cxx/user_defined_literal.cc
+++ b/tests/cxx/user_defined_literal.cc
@@ -1,0 +1,39 @@
+//===--- user_defined_literal.cc - test input file for iwyu ---------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_ARGS: -I .
+
+#include "user_defined_literal-direct.h"
+
+class IndirectClass;
+IndirectClass operator""_ic(unsigned long long);
+
+// IWYU: operator""_x(unsigned long long) is...*user_defined_literal-indirect.h
+constexpr unsigned long long kLiteralValue = 1_x;
+
+void Fn() {
+  // IWYU: IndirectClass is...*user_defined_literal-indirect.h
+  (void)1_ic;
+}
+
+int main() { return kLiteralValue; }
+
+/**** IWYU_SUMMARY
+
+tests/cxx/user_defined_literal.cc should add these lines:
+#include "tests/cxx/user_defined_literal-indirect.h"
+
+tests/cxx/user_defined_literal.cc should remove these lines:
+- #include "user_defined_literal-direct.h"  // lines XX-XX
+- class IndirectClass;  // lines XX-XX
+
+The full include-list for tests/cxx/user_defined_literal.cc:
+#include "tests/cxx/user_defined_literal-indirect.h"  // for IndirectClass, operator""_x
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
### Problem
IWYU could miss that a user-defined literal requires the header that declares its literal operator and could suggest removing a direct include even though that include was still needed for literal lookup.

This showed up in Bitcoin Core during review of [bitcoin/bitcoin#34435](https://github.com/bitcoin/bitcoin/pull/34435#discussion_r3115756052): headers using literals such as `16_MiB` could lose their direct `#include <util/byte_units.h>`.

### Fix
IWYU already has special traversal for ordinary function calls so it can record the callee declaration as a use and apply the usual call-site handling.
User-defined literals were missing that same treatment.
This change adds matching traversal for `UserDefinedLiteral` and routes it through the existing function-call handling path.

### Reproducers
A regression test has been added for a minimal direct/indirect include case:
a source file includes a wrapper header, uses a user-defined literal, and IWYU must replace the wrapper include with the header that directly declares the literal operator.

The test also covers a literal operator whose return type is only forward-declared at the call site, so IWYU must report the return type through the same function-call handling path.

The original Bitcoin Core failure is reproduced in https://github.com/l0rinc/bitcoin/pull/142.
The same Bitcoin Core state passes with this IWYU change applied in https://github.com/l0rinc/bitcoin/pull/141.