### PR TITLE
Add reduced bug test for #1250

### DIFF
--- a/tests/bugs/1250/1250b-direct.h
+++ b/tests/bugs/1250/1250b-direct.h
@@ -1,0 +1,11 @@
+//===--- 1250b-direct.h - iwyu test ---------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "1250b-i1.h"
+#include "1250b-i2.h"

--- a/tests/bugs/1250/1250b-i1.h
+++ b/tests/bugs/1250/1250b-i1.h
@@ -1,0 +1,21 @@
+//===--- 1250b-i1.h - iwyu test ------* c++ *------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// A template with methods and an iterator type.
+// Inspired by Clang's AST type Redeclarable, which shows this problem in
+// iwyu_ast_util.cc.
+
+template<class T>
+class Template {
+public:
+  using iterator = T*;
+
+  Template<T>::iterator begin();
+  Template<T>::iterator end();
+};

--- a/tests/bugs/1250/1250b-i2.h
+++ b/tests/bugs/1250/1250b-i2.h
@@ -1,0 +1,12 @@
+//===--- 1250b-i2.h - iwyu test ------* c++ *------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// A template that takes an iterator range.
+template<class IteratorType>
+void consume(IteratorType begin, IteratorType end);

--- a/tests/bugs/1250/1250b.cc
+++ b/tests/bugs/1250/1250b.cc
@@ -1,0 +1,55 @@
+//===--- 1250b.cc - iwyu test ---------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_XFAIL
+
+#include "1250b-direct.h"
+
+template<class T>
+// IWYU: Template...*needs a declaration
+void func_template(Template<T>* v) {
+  // IWYU: consume is...*1250b-i2.h
+  consume(
+    // IWYU: Template is...*1250b-i1.h
+    v->begin(),
+    // IWYU: Template is...*1250b-i1.h
+    v->end());
+}
+
+// IWYU seems to miss the two calls to begin() and end() in the function
+// template above, so Template is only reported for forward-decl use.
+
+// For contrast, a plain function with instantiated template reports everything
+// as expected. You can uncomment below to verify.
+
+// // IWYU: Template...*needs a declaration
+// void function(Template<int>* v) {
+//   // Curiosity: this reports as consume(:0, :0), not just consume.
+//   // IWYU: consume(:0, :0) is...*1250b-i2.h
+//   consume(
+//     // IWYU: Template is...*1250b-i1.h
+//     v->begin(),
+//     // IWYU: Template is...*1250b-i1.h
+//     v->end());
+// }
+
+/**** IWYU_SUMMARY
+
+tests/bugs/1250/1250b.cc should add these lines:
+#include "1250b-i1.h"
+#include "1250b-i2.h"
+
+tests/bugs/1250/1250b.cc should remove these lines:
+- #include "1250b-direct.h"  // lines XX-XX
+
+The full include-list for tests/bugs/1250/1250b.cc:
+#include "1250b-i1.h"  // for Template
+#include "1250b-i2.h"  // for consume
+
+***** IWYU_SUMMARY */

--- a/tests/bugs/1250/1250b.cc
+++ b/tests/bugs/1250/1250b.cc
@@ -22,6 +22,13 @@ void func_template(Template<T>* v) {
     v->end());
 }
 
+void instantiate() {
+  // IWYU: Template is...*1250b-i1.h
+  Template<int> v;
+  // BUG: consume() is reported here.
+  func_template(&v);
+}
+
 // IWYU seems to miss the two calls to begin() and end() in the function
 // template above, so Template is only reported for forward-decl use.
 


### PR DESCRIPTION
I ran into this while debugging #1759, which cover hidden friend decls. When trying the suggested change, uses of Redeclarable were missed.

It turns out it's because operator!= was the only seen use of Redeclarable.h, all other uses were hidden behind UnresolvedLookupExpr due to being inside an uninstantiated template.

The testcase laid out here carries some echoes of the Redeclarable problem, but I think it's closer related to the "not-seen-in-template" problem described in #1250.