### PR TITLE
Consider symbol mappings for definition headers

### DIFF
--- a/iwyu_output.cc
+++ b/iwyu_output.cc
@@ -1566,9 +1566,8 @@ void CalculateIwyuForForwardDeclareUse(
   const NamedDecl* dfn_from_desired_includes = nullptr;
   const NamedDecl* dfn_from_actual_includes = nullptr;
   for (const NamedDecl* dfn : dfns) {
-    vector<string> headers =
-        GlobalIncludePicker().GetCandidateHeadersForFilepathIncludedFrom(
-            GetFilePath(dfn), GetFilePath(use->use_loc()));
+    vector<string> headers = GlobalIncludePicker().GetMappedPublicHeaders(
+        dfn, GetFilePath(use->use_loc()), GetFilePath(dfn));
     for (const string& header : headers) {
       if (ContainsKey(desired_includes, header))
         dfn_from_desired_includes = dfn;

--- a/tests/cxx/remove_fwd_decl_when_including-d1.h
+++ b/tests/cxx/remove_fwd_decl_when_including-d1.h
@@ -1,0 +1,10 @@
+//===--- remove_fwd_decl_when_including-d1.h - test input file for iwyu ---===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+class HasSymbolMapping {};

--- a/tests/cxx/remove_fwd_decl_when_including.cc
+++ b/tests/cxx/remove_fwd_decl_when_including.cc
@@ -7,7 +7,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// IWYU_ARGS: -I .
+// IWYU_ARGS: -I . \
+//            -Xiwyu --mapping_file=tests/cxx/remove_fwd_decl_when_including.imp
 
 // This tests the following behavior: when we need to #include a
 // file to get the full type of Foo (here, Foo == IndirectClass),
@@ -19,25 +20,35 @@
 // #include a class, and forward-declare the same class, in a file.
 
 #include "tests/cxx/direct.h"
+#include "tests/cxx/remove_fwd_decl_when_including-d1.h"
 
 class IndirectClass;
+class HasSymbolMapping;
 
 int main() {
   IndirectClass* p;
   // IWYU: IndirectClass is...*indirect.h
   IndirectClass i;
+
+  HasSymbolMapping* phsm;
+  // IWYU: HasSymbolMapping is...*-i1.h
+  HasSymbolMapping hsm;
 }
 
 /**** IWYU_SUMMARY
 
 tests/cxx/remove_fwd_decl_when_including.cc should add these lines:
 #include "tests/cxx/indirect.h"
+#include "tests/cxx/remove_fwd_decl_when_including-i1.h"
 
 tests/cxx/remove_fwd_decl_when_including.cc should remove these lines:
 - #include "tests/cxx/direct.h"  // lines XX-XX
+- #include "tests/cxx/remove_fwd_decl_when_including-d1.h"  // lines XX-XX
+- class HasSymbolMapping;  // lines XX-XX
 - class IndirectClass;  // lines XX-XX
 
 The full include-list for tests/cxx/remove_fwd_decl_when_including.cc:
 #include "tests/cxx/indirect.h"  // for IndirectClass
+#include "tests/cxx/remove_fwd_decl_when_including-i1.h"  // for HasSymbolMapping
 
 ***** IWYU_SUMMARY */

--- a/tests/cxx/remove_fwd_decl_when_including.imp
+++ b/tests/cxx/remove_fwd_decl_when_including.imp
@@ -1,0 +1,3 @@
+[
+  { "symbol": ["HasSymbolMapping", "private", "\"tests/cxx/remove_fwd_decl_when_including-i1.h\"", "public"] },
+]


### PR DESCRIPTION
Prior to this, only include-mapped headers (if any) were taken into account to determine if a fwd-decl use is satisfied by a definition from any header that should be included.

This should fix #224.