### PR TITLE
Report unresolved function template args

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -3044,8 +3044,10 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
     // end up being the built-in form of the operator.  (Even if the
     // only operator==() we see is in foo.h, we don't need to #include
     // foo.h if the only call to operator== we see is on two integers.)
-    if (!arbitrary_fn_decl || !arbitrary_fn_decl->isOverloadedOperator())
-      ReportDeclUse(CurrentLoc(), first_decl);
+    if (!arbitrary_fn_decl || !arbitrary_fn_decl->isOverloadedOperator()) {
+      ReportDeclUse(CurrentLoc(),
+                    arbitrary_fn_decl ? arbitrary_fn_decl : first_decl);
+    }
     return true;
   }
 

--- a/iwyu.cc
+++ b/iwyu.cc
@@ -3015,24 +3015,28 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
           ReportDeclUse(CurrentLoc(), decl);
         // No AddProcessedOverloadLoc here: PublicHeaderIntendsToProvide should
         // already work well at the instantiation site.
-      } else if (!expr->requiresADL()) {
-        // Report any of the decls so as to keep the code compilable. If ADL is
-        // to be applied (i.e. the function name is unqualified), it is allowed
-        // to have no declaration.
-        ReportDeclUse(CurrentLoc(), first_decl);
-        // No AddProcessedOverloadLoc here: even first_decl may be different
-        // when scanning different translation units. It's better to
-        // double-report it on template-defn and instantiation sites than not
-        // to report an actually used decl at all.
+        return true;
+      } else if (expr->requiresADL()) {
+        // If ADL is to be applied (i.e. the function name is unqualified), it
+        // is allowed to have no declaration.
+        return true;
       }
-      return true;
     }
 
+    // Report any of the decls so as to keep the code compilable.
+    // No AddProcessedOverloadLoc here: the expr decls may be different when
+    // scanning different translation units. It's better to double-report on
+    // template-defn and instantiation sites than not to report an actually used
+    // decl at all.
     const FunctionDecl* arbitrary_fn_decl = nullptr;
     for (const NamedDecl* decl : expr->decls()) {
-      // Sometimes a UsingShadowDecl comes between us and the 'real' decl.
-      if (const UsingShadowDecl* using_shadow_decl = DynCastFrom(decl))
+      // Sometimes a UsingShadowDecl comes between us and the 'real' decl. Make
+      // sure we report it before resolving.
+      if (const UsingShadowDecl* using_shadow_decl = DynCastFrom(decl)) {
+        ReportDeclUse(CurrentLoc(), decl, nullptr, UF_None,
+                      /*report_using_decl_only = */ true);
         decl = using_shadow_decl->getTargetDecl();
+      }
       if (const FunctionDecl* fn_decl = DynCastFrom(decl)) {
         arbitrary_fn_decl = fn_decl;
         break;
@@ -3047,8 +3051,10 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
     // end up being the built-in form of the operator.  (Even if the
     // only operator==() we see is in foo.h, we don't need to #include
     // foo.h if the only call to operator== we see is on two integers.)
-    if (!arbitrary_fn_decl || !arbitrary_fn_decl->isOverloadedOperator())
-      ReportDeclUse(CurrentLoc(), first_decl);
+    if (!arbitrary_fn_decl || !arbitrary_fn_decl->isOverloadedOperator()) {
+      ReportDeclUse(CurrentLoc(),
+                    arbitrary_fn_decl ? arbitrary_fn_decl : first_decl);
+    }
     return true;
   }
 

--- a/tests/cxx/badinc.cc
+++ b/tests/cxx/badinc.cc
@@ -137,6 +137,7 @@ using namespace i1_ns2;
 using i1_ns3::i1_int_global3;
 namespace cc_ns_alias = i1_ns4;
 using i1_ns::I1_NamespaceStruct;
+// IWYU: i1_ns::I1_NamespaceTemplateFn is...*tests/cxx/badinc-i1.h
 using i1_ns::I1_NamespaceTemplateFn;
 // TODO(csilvers): mark this using declaration as redundant and remove it?
 // IWYU: i1_ns::I1_UnusedNamespaceStruct needs a declaration

--- a/tests/cxx/badinc.cc
+++ b/tests/cxx/badinc.cc
@@ -346,7 +346,7 @@ template<class T,int> class Cc_TemplateSubclass : public H_TemplateTypedef { };
 // Let's test that we detect overloaded functions correctly when all
 // overloads are in the same file, and then when they're in different files.
 template<typename T> void CallOverloadedFunctionSameFile(T t) {
-  // IWYU: I1_OverloadedFunction is...*badinc-i1.h
+  // IWYU: I1_OverloadedFunction(const :0 &) is...*badinc-i1.h
   I1_OverloadedFunction(t);
 }
 
@@ -360,7 +360,7 @@ template<typename T> void CallOverloadWithUsingShadowDecl(T t) {
   // This is only defined in one place, but because we get to it via
   // a using expression, it generates a UsingShadowExpr.  Make sure we
   // "see through" that properly.
-  // IWYU: i1_ns::I1_NamespaceTemplateFn is...*badinc-i1.h
+  // IWYU: i1_ns::I1_NamespaceTemplateFn(:0) is...*badinc-i1.h
   I1_NamespaceTemplateFn(t);
 }
 

--- a/tests/cxx/badinc.cc
+++ b/tests/cxx/badinc.cc
@@ -347,7 +347,7 @@ template<class T,int> class Cc_TemplateSubclass : public H_TemplateTypedef { };
 // Let's test that we detect overloaded functions correctly when all
 // overloads are in the same file, and then when they're in different files.
 template<typename T> void CallOverloadedFunctionSameFile(T t) {
-  // IWYU: I1_OverloadedFunction is...*badinc-i1.h
+  // IWYU: I1_OverloadedFunction(const :0 &) is...*badinc-i1.h
   I1_OverloadedFunction(t);
 }
 
@@ -361,7 +361,7 @@ template<typename T> void CallOverloadWithUsingShadowDecl(T t) {
   // This is only defined in one place, but because we get to it via
   // a using expression, it generates a UsingShadowExpr.  Make sure we
   // "see through" that properly.
-  // IWYU: i1_ns::I1_NamespaceTemplateFn is...*badinc-i1.h
+  // IWYU: i1_ns::I1_NamespaceTemplateFn(:0) is...*badinc-i1.h
   I1_NamespaceTemplateFn(t);
 }
 

--- a/tests/cxx/overload_fn_mapping.cc
+++ b/tests/cxx/overload_fn_mapping.cc
@@ -122,6 +122,21 @@ void User() {
   TplFn(arr2);
 }
 
+// Do all template examples again inside an uninstantiated template.
+template<typename T>
+void UserTemplate(T v) {
+  // IWYU: TplFn(:0, :1) is...*-i2.h
+  TplFn(v, v);
+  // IWYU: TplFn(:1, :0 *) is...*-i3.h
+  TplFn(v, &v);
+  // IWYU: Tpl is...*-i1.h
+  // IWYU: TplFn(Tpl<:0>) is...*-i4.h
+  TplFn(Tpl<T>{});
+  T arr2[7];
+  // IWYU: TplFn(:0 (&)[:1]) is...*-i5.h
+  TplFn(arr2);
+}
+
 /**** IWYU_SUMMARY
 
 tests/cxx/overload_fn_mapping.cc should add these lines:

--- a/tests/cxx/overload_fn_mapping.cc
+++ b/tests/cxx/overload_fn_mapping.cc
@@ -123,17 +123,20 @@ void User() {
 }
 
 // Do all template examples again inside an uninstantiated template.
-template<typename T>
+// TODO: note that all uses are reported, but IWYU doesn't know how to
+// distinguish between overloads in uninstantiated contexts, so we fuzzy-match
+// overload and definition filename.
+template <typename T>
 void UserTemplate(T v) {
-  // IWYU: TplFn(:0, :1) is...*-i2.h
+  // IWYU: TplFn(...*) is...*-i{{[0-9]}}.h
   TplFn(v, v);
-  // IWYU: TplFn(:1, :0 *) is...*-i3.h
+  // IWYU: TplFn(...*) is...*-i{{[0-9]}}.h
   TplFn(v, &v);
   // IWYU: Tpl is...*-i1.h
-  // IWYU: TplFn(Tpl<:0>) is...*-i4.h
+  // IWYU: TplFn(...*) is...*-i{{[0-9]}}.h
   TplFn(Tpl<T>{});
   T arr2[7];
-  // IWYU: TplFn(:0 (&)[:1]) is...*-i5.h
+  // IWYU: TplFn(...*) is...*-i{{[0-9]}}.h
   TplFn(arr2);
 }
 

--- a/tests/cxx/overload_fn_tpl-d1.h
+++ b/tests/cxx/overload_fn_tpl-d1.h
@@ -1,0 +1,12 @@
+//===--- overload_fn_tpl-d1.h - test input file for iwyu ------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/overload_fn_tpl-i1.h"
+#include "tests/cxx/overload_fn_tpl-i2.h"
+#include "tests/cxx/overload_fn_tpl-i3.h"

--- a/tests/cxx/overload_fn_tpl-d2.h
+++ b/tests/cxx/overload_fn_tpl-d2.h
@@ -1,0 +1,15 @@
+//===--- overload_fn_tpl-d2.h - test input file for iwyu ------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+namespace ns {
+
+template <typename T>
+int TplFnDirect(T, int);
+
+}  // namespace ns

--- a/tests/cxx/overload_fn_tpl-d3.h
+++ b/tests/cxx/overload_fn_tpl-d3.h
@@ -1,0 +1,15 @@
+//===--- overload_fn_tpl-d3.h - test input file for iwyu ------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+namespace ns {
+
+template <typename T, typename U>
+int TplFnDirect(T, U);
+
+}  // namespace ns

--- a/tests/cxx/overload_fn_tpl-i1.h
+++ b/tests/cxx/overload_fn_tpl-i1.h
@@ -1,0 +1,15 @@
+//===--- overload_fn_tpl-i1.h - test input file for iwyu ------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+namespace ns {
+
+template <typename T, typename U>
+int TplFn(T, U);
+
+}  // namespace ns

--- a/tests/cxx/overload_fn_tpl-i2.h
+++ b/tests/cxx/overload_fn_tpl-i2.h
@@ -1,0 +1,15 @@
+//===--- overload_fn_tpl-i2.h - test input file for iwyu ------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+namespace ns {
+
+template <typename T, typename U>
+int TplFn(T*, U*);
+
+}  // namespace ns

--- a/tests/cxx/overload_fn_tpl-i3.h
+++ b/tests/cxx/overload_fn_tpl-i3.h
@@ -1,0 +1,18 @@
+//===--- overload_fn_tpl-i3.h - test input file for iwyu ------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+namespace ns {
+
+// Two overloads in the same file.
+template <typename T>
+T TplFnSameFile(T);
+
+int TplFnSameFile(int);
+
+}  // namespace ns

--- a/tests/cxx/overload_fn_tpl.cc
+++ b/tests/cxx/overload_fn_tpl.cc
@@ -1,0 +1,61 @@
+//===--- overload_fn_tpl.cc - test input file for iwyu --------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_ARGS: -I .
+
+#include "tests/cxx/overload_fn_tpl-d1.h"
+#include "tests/cxx/overload_fn_tpl-d2.h"
+#include "tests/cxx/overload_fn_tpl-d3.h"
+
+// Test function template use with dependent types inside an uninstantiated
+// template.
+template <typename T>
+void UserTemplate(T v) {
+  // There are multiple overloads available from different files -i1.h and
+  // -i2.h. An arbitrary decl is reported.
+  // IWYU: ns::TplFn(:0, :1) is...*-i1.h
+  ns::TplFn(v, bool{});
+
+  // There's technically a better overload in -i2.h, but an arbitrary decl is
+  // reported. User can include -i2.h directly to state a preference, see
+  // TplFnDirect below.
+  int i = 0;
+  // IWYU: ns::TplFn(:0, :1) is...*-i1.h
+  ns::TplFn(&v, &i);
+
+  // When all overloads are in the same file, an arbitrary decl from that file
+  // is reported to keep the file included.
+  // IWYU: ns::TplFnSameFile(:0) is...*-i3.h
+  ns::TplFnSameFile(v);
+
+  // No diagnostic here. When decls are directly included, we assume the user
+  // made an active choice for which overloads to make available. Both -d2.h and
+  // -d3.h are preserved in the summary below.
+  ns::TplFnDirect(v, i);
+
+  // Trigger ADL. No diagnostic or tracking expected.
+  Undefined(v);
+}
+
+/**** IWYU_SUMMARY
+
+tests/cxx/overload_fn_tpl.cc should add these lines:
+#include "tests/cxx/overload_fn_tpl-i1.h"
+#include "tests/cxx/overload_fn_tpl-i3.h"
+
+tests/cxx/overload_fn_tpl.cc should remove these lines:
+- #include "tests/cxx/overload_fn_tpl-d1.h"  // lines XX-XX
+
+The full include-list for tests/cxx/overload_fn_tpl.cc:
+#include "tests/cxx/overload_fn_tpl-d2.h"  // for TplFnDirect
+#include "tests/cxx/overload_fn_tpl-d3.h"  // for TplFnDirect
+#include "tests/cxx/overload_fn_tpl-i1.h"  // for TplFn
+#include "tests/cxx/overload_fn_tpl-i3.h"  // for TplFnSameFile
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/placement_new.cc
+++ b/tests/cxx/placement_new.cc
@@ -153,7 +153,7 @@ void TaggedNewInTemplate() {
 template <typename T>
 void Reconstruct(T& ref) {
   // IWYU: operator new is...*<new>
-  // IWYU: AddressOf is...*placement_new-i2.h
+  // IWYU: AddressOf(:0 &) is...*placement_new-i2.h
   new (AddressOf(ref)) T();
 }
 


### PR DESCRIPTION
This showed up in an unrelated context:
https://github.com/include-what-you-use/include-what-you-use/pull/2016/changes#r3143816232

When a template was called from an uninstantiated template, e.g.

    template<typename T, typename U>
    void Tpl(T, U);

    template<typename T>
    void CallTpl(T v) {
      Tpl(v, int{});
    }

the IWYU diagnostics only included the function name, and not the :N
parameter types, i.e. we got:

    Tpl is defined in "blah.h" ...

instead of the expected:

    Tpl(:0, :1) is defined in "blah.h" ...

Improve the logic in VisitUnresolvedLookupExpr to report an actual
function decl rather than the first decl in the lookup set (which might
be a using-decl).

Now that we report a resolved function decl, we also have to explicitly
report any using-decl; that information is lost when arbitrary_fn_decl
is reported.

Add test coverage for both multiple-directly-included files, ADL
lookup (no use tracking) and arbitrary fn decl resolution.

Update existing test diagnostics to have parameters where necessary.