### PR TITLE
Fix header spelling in fwd-decl uses

### DIFF
--- a/iwyu_output.cc
+++ b/iwyu_output.cc
@@ -1565,12 +1565,15 @@ void CalculateIwyuForForwardDeclareUse(
   // fact.  Also if it's defined in one of the actual_includes.
   const NamedDecl* dfn_from_desired_includes = nullptr;
   const NamedDecl* dfn_from_actual_includes = nullptr;
+  string desired_hdr_with_dfn;
   for (const NamedDecl* dfn : dfns) {
     vector<string> headers = GlobalIncludePicker().GetMappedPublicHeaders(
         dfn, GetFilePath(use->use_loc()), GetFilePath(dfn));
     for (const string& header : headers) {
-      if (ContainsKey(desired_includes, header))
+      if (ContainsKey(desired_includes, header)) {
         dfn_from_desired_includes = dfn;
+        desired_hdr_with_dfn = header;
+      }
       if (ContainsKey(actual_includes, header))
         dfn_from_actual_includes = dfn;
     }
@@ -1610,9 +1613,8 @@ void CalculateIwyuForForwardDeclareUse(
              << " (" << use->PrintableUseLoc() << ") is satisfied by dfn in "
              << PrintableLoc(GetLocation(providing_decl)) << "\n";
     // Mark that this use is another reason we want this header.
-    const string file = GetFilePath(providing_decl);
-    const string quoted_hdr = ConvertToQuotedInclude(file);
-    use->set_suggested_header(quoted_hdr);
+    CHECK_(!desired_hdr_with_dfn.empty());
+    use->set_suggested_header(desired_hdr_with_dfn);
   } else if (same_file_decl) {
     providing_decl = same_file_decl;
     VERRS(6) << "Noting fwd-decl use of " << use->symbol_name()

--- a/tests/cxx/new_header_path_local.cc
+++ b/tests/cxx/new_header_path_local.cc
@@ -15,6 +15,9 @@
 void foo() {
   // IWYU: IndirectClass is...*indirect.h
   IndirectClass ic;
+  // Test that 'IndirectTemplate (ptr only)' is printed in the comment.
+  // IWYU: IndirectTemplate needs a declaration
+  IndirectTemplate<int>* pit;
 }
 
 /**** IWYU_SUMMARY
@@ -26,6 +29,6 @@ tests/cxx/new_header_path_local.cc should remove these lines:
 - #include "direct_near.h"  // lines XX-XX
 
 The full include-list for tests/cxx/new_header_path_local.cc:
-#include "indirect.h"  // for IndirectClass
+#include "indirect.h"  // for IndirectClass, IndirectTemplate (ptr only)
 
 ***** IWYU_SUMMARY */


### PR DESCRIPTION
For the case of quoted includes with the path relative to the includer, `ConvertToQuotedInclude` with the defaulted second parameter returned the absolute file path which did not match any of the include lines inside `CalculateDesiredIncludesAndForwardDeclares`. Due to that, `(ptr only)` comment did not appear for the corresponding `#include` line. This fixes such behavior.

As an alternative fix, the correct 2nd argument could probably be passed to `ConvertToQuotedInclude`.