### PR TITLE
Ignore some fwd-decl uses

### DIFF
--- a/iwyu_output.cc
+++ b/iwyu_output.cc
@@ -1574,12 +1574,10 @@ void CalculateIwyuForForwardDeclareUse(
       if (ContainsKey(actual_includes, header))
         dfn_from_actual_includes = dfn;
     }
-    // We ourself are always a 'desired' and 'actual' include (though
-    // only if the definition is visible from the use location).
     if (IsBeforeInSameFile(dfn, use->use_loc())) {
-      dfn_from_desired_includes = dfn;
-      dfn_from_actual_includes = dfn;
-      break;
+      // TODO(bolshakov): this looks like a duplicate of A6 step. Deduplicate.
+      use->set_ignore_use();
+      return;
     }
   }
 
@@ -1598,8 +1596,8 @@ void CalculateIwyuForForwardDeclareUse(
   if (!same_file_decl) {
     for (const NamedDecl* redecl : redecls) {
       if (ContainsKey(associated_includes, GetFileEntry(redecl))) {
-        same_file_decl = redecl;
-        break;
+        use->set_ignore_use();
+        return;
       }
     }
   }
@@ -1620,10 +1618,6 @@ void CalculateIwyuForForwardDeclareUse(
     VERRS(6) << "Noting fwd-decl use of " << use->symbol_name()
              << " (" << use->PrintableUseLoc() << ") is declared at "
              << PrintableLoc(GetLocation(providing_decl)) << "\n";
-    // If same_file_decl is actually in an associated .h, mark our use
-    // of that.  No need to map-to-public for associated .h files.
-    if (GetFileEntry(same_file_decl) != GetFileEntry(use->use_loc()))
-      use->set_suggested_header(GetFilePath(same_file_decl));
   }
   if (providing_decl) {
     // Change decl_ to point to this "better" redecl.


### PR DESCRIPTION
If the file with a fwd-decl use contains the definition of the symbol, or if any of the associated headers contain a declaration, there is no need to forward-declare. For the case of a forward-declaration in an associated header, IWYU did not even print `(ptr only)` comment for that header, hence `set_suggested_header` call was useless.

This change simplifies `CalculateIwyuForForwardDeclareUse` a little.

No functional change is intended.