### PR TITLE
Don't force exported fwd-decl when dfn is present

### DIFF
--- a/iwyu_output.cc
+++ b/iwyu_output.cc
@@ -1229,7 +1229,9 @@ void ProcessForwardDeclare(OneUse* use,
       const auto* decl = cast<NamedDecl>(redecl);
       if (preprocessor_info->ForwardDeclareIsExported(decl)) {
         use->reset_decl(decl);
-        use->set_full_use();
+        use->set_suggested_header(ConvertToQuotedInclude(
+            GetFilePath(decl->getLocation()),
+            MakeAbsolutePath(GetParentPath(GetFilePath(use->use_loc())))));
         break;
       }
     }
@@ -1862,13 +1864,12 @@ void CalculateDesiredIncludesAndForwardDeclares(
     if (use.ignore_use())
       continue;
 
-    if (use.is_full_use()) {
-      CHECK_(use.has_suggested_header() && "Full uses should have #includes");
+    if (use.has_suggested_header()) {
       if (!Contains(*lines, use.suggested_header())) { // must be added
         lines->push_back(OneIncludeOrForwardDeclareLine(
             use.decl_file(), use.suggested_header(), -1));
       }
-    } else if (!use.has_suggested_header()) {
+    } else {
       // Forward-declare uses that are already satisfied by an #include
       // have that as their suggested_header.  For the rest, we need to
       // make sure there's a forward-declare in the current file.
@@ -1934,13 +1935,14 @@ void CalculateDesiredIncludesAndForwardDeclares(
       for (auto it = range.first; it != range.second; ++it) {
         it->second->set_desired();
       }
-    } else if (ContainsKey(include_map, use.suggested_header())) {
-      // If we satisfy a forward-declare use from a file, let the file
-      // know (this is just for logging).
+    } else {
+      // If we satisfy a forward-declare use from a file, let the file know.
       const string symbol_name = use.short_symbol_name();
 
       auto range = include_map.equal_range(use.suggested_header());
+      CHECK_(range.first != range.second);
       for (auto it = range.first; it != range.second; ++it) {
+        it->second->set_desired();
         if (!it->second->HasSymbolUse(symbol_name))
           it->second->AddSymbolUse(symbol_name + " (ptr only)");
       }

--- a/tests/cxx/pragma_export_fwd-d1.h
+++ b/tests/cxx/pragma_export_fwd-d1.h
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "tests/cxx/pragma_export_fwd-i1.h"
+#include "tests/cxx/pragma_export_fwd-i2.h"
+
 class FwdDecl3;  // IWYU pragma: export
 
 // IWYU pragma: begin_exports

--- a/tests/cxx/pragma_export_fwd-i1.h
+++ b/tests/cxx/pragma_export_fwd-i1.h
@@ -1,0 +1,10 @@
+//===--- pragma_export_fwd-i1.h - test input file for iwyu ----------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+class FullAndFwdDeclUse {};

--- a/tests/cxx/pragma_export_fwd-i2.h
+++ b/tests/cxx/pragma_export_fwd-i2.h
@@ -1,0 +1,10 @@
+//===--- pragma_export_fwd-i2.h - test input file for iwyu ----------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+class FullAndFwdDeclUse;  // IWYU pragma: export

--- a/tests/cxx/pragma_export_fwd.cc
+++ b/tests/cxx/pragma_export_fwd.cc
@@ -14,18 +14,28 @@
 // Uses do not trigger warnings as they are already provided for.
 void a(const FwdDecl1&);
 void b(const FwdDecl2*);
+// IWYU: FwdDecl3 needs a declaration
 void c(const FwdDecl3&);
+// IWYU: FwdDecl4 needs a declaration
 void d(const FwdDecl4*);
+
+// IWYU should not suggest '-i2.h' for the forward-declaration because
+// the definition should be available.
+// IWYU: FullAndFwdDeclUse needs a declaration
+// IWYU: FullAndFwdDeclUse is...*-i1.h
+FullAndFwdDeclUse full_use, *fwd_decl_use;
 
 /**** IWYU_SUMMARY
 
 tests/cxx/pragma_export_fwd.cc should add these lines:
 #include "tests/cxx/pragma_export_fwd-d1.h"
+#include "tests/cxx/pragma_export_fwd-i1.h"
 
 tests/cxx/pragma_export_fwd.cc should remove these lines:
 
 The full include-list for tests/cxx/pragma_export_fwd.cc:
 #include "tests/cxx/pragma_export_fwd.h"
-#include "tests/cxx/pragma_export_fwd-d1.h"  // for FwdDecl3, FwdDecl4
+#include "tests/cxx/pragma_export_fwd-d1.h"  // for FwdDecl3 (ptr only), FwdDecl4 (ptr only)
+#include "tests/cxx/pragma_export_fwd-i1.h"  // for FullAndFwdDeclUse
 
 ***** IWYU_SUMMARY */

--- a/tests/cxx/pragma_export_fwd_path_local-d1.h
+++ b/tests/cxx/pragma_export_fwd_path_local-d1.h
@@ -1,0 +1,10 @@
+//===--- pragma_export_fwd_path_local-d1.h - test input file for iwyu -----===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "pragma_export_fwd_path_local-i1.h"

--- a/tests/cxx/pragma_export_fwd_path_local-i1.h
+++ b/tests/cxx/pragma_export_fwd_path_local-i1.h
@@ -1,0 +1,10 @@
+//===--- pragma_export_fwd_path_local-i1.h - test input file for iwyu -----===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+class FwdDecl;  // IWYU pragma: export

--- a/tests/cxx/pragma_export_fwd_path_local.cc
+++ b/tests/cxx/pragma_export_fwd_path_local.cc
@@ -1,0 +1,26 @@
+//===--- pragma_export_fwd_path_local.cc - test input file for iwyu -------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "pragma_export_fwd_path_local-d1.h"
+
+// IWYU: FwdDecl needs a declaration
+FwdDecl* pFwdDecl;
+
+/**** IWYU_SUMMARY
+
+tests/cxx/pragma_export_fwd_path_local.cc should add these lines:
+#include "pragma_export_fwd_path_local-i1.h"
+
+tests/cxx/pragma_export_fwd_path_local.cc should remove these lines:
+- #include "pragma_export_fwd_path_local-d1.h"  // lines XX-XX
+
+The full include-list for tests/cxx/pragma_export_fwd_path_local.cc:
+#include "pragma_export_fwd_path_local-i1.h"  // for FwdDecl (ptr only)
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
Recategorizing fwd-decl uses to full uses switched off the handling from the D1 step, so that if the definition should be already present, IWYU still suggested the header with the forward-declaration along the header with the definition.

This change fixes the bug by means of keeping the uses of exported forward-declarations as fwd-decl uses and setting a suggested header to them. `CalculateDesiredIncludesAndForwardDeclares` has been changed so that any use with a suggested header require an include line, not only full uses.