### PR TITLE
[clang compat] Handle new HLSL builtin trait

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -2235,6 +2235,7 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
         if (!lhs_type->isIncompleteArrayType())
           ReportTypeUse(CurrentLoc(), lhs_type, DerefKind::None);
         return true;
+      case TypeTrait::UTT_IsConstantBufferElementCompatible:
       case TypeTrait::UTT_IsIntangibleType:
       case TypeTrait::UTT_IsTypedResourceElementCompatible:
       case TypeTrait::BTT_IsScalarizedLayoutCompatible:


### PR DESCRIPTION
A new HLSL unary type trait, IsConstantBufferElementCompatible, was added in https://github.com/llvm/llvm-project/commit/90a2a8e6d042780423.

Sema::CheckUnaryTypeTraitTypeCompleteness does not require complete types for this trait, and we generally don't handle HLSL yet. Ignore it together with the other HLSL builtin traits.

This is the first breaking change vs. llvm-22.