### PR TITLE
Add intermediate test header

### DIFF
--- a/tests/cxx/explicit_instantiation-spec-d1.h
+++ b/tests/cxx/explicit_instantiation-spec-d1.h
@@ -1,0 +1,10 @@
+//===--- explicit_instantiation-spec-d1.h - test input file for iwyu ------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/explicit_instantiation-spec-i1.h"

--- a/tests/cxx/explicit_instantiation-spec-i1.h
+++ b/tests/cxx/explicit_instantiation-spec-i1.h
@@ -1,4 +1,4 @@
-//===--- explicit_instantiation-spec.h - test input file for iwyu ---------===//
+//===--- explicit_instantiation-spec-i1.h - test input file for iwyu ------===//
 //
 //                     The LLVM Compiler Infrastructure
 //
@@ -17,12 +17,12 @@ class Template<T*> {};
 
 /**** IWYU_SUMMARY
 
-tests/cxx/explicit_instantiation-spec.h should add these lines:
+tests/cxx/explicit_instantiation-spec-i1.h should add these lines:
 
-tests/cxx/explicit_instantiation-spec.h should remove these lines:
+tests/cxx/explicit_instantiation-spec-i1.h should remove these lines:
 - #include "tests/cxx/explicit_instantiation-template_direct.h"  // lines XX-XX
 
-The full include-list for tests/cxx/explicit_instantiation-spec.h:
+The full include-list for tests/cxx/explicit_instantiation-spec-i1.h:
 template <typename T> class Template;  // lines XX-XX+1
 
 ***** IWYU_SUMMARY */

--- a/tests/cxx/explicit_instantiation.cc
+++ b/tests/cxx/explicit_instantiation.cc
@@ -7,11 +7,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-// IWYU_ARGS: -Xiwyu --check_also=tests/cxx/explicit_instantiation-spec.h \
+// IWYU_ARGS: -Xiwyu --check_also=tests/cxx/explicit_instantiation-spec-i1.h \
 //            -Xiwyu --check_also=tests/cxx/explicit_instantiation-template.h \
 //            -I .
 
-#include "tests/cxx/explicit_instantiation-spec.h"
+#include "tests/cxx/explicit_instantiation-spec-d1.h"
 #include "tests/cxx/explicit_instantiation-template_direct.h"
 #include "tests/cxx/explicit_instantiation-template2.h"
 
@@ -47,7 +47,9 @@ template<> class Template<char> {};
 extern template class Template<char>;
 
 // The partial specialization from 'explicit_instantiation-spec.h' is used here.
+// IWYU: Template<:0 *> is...*explicit_instantiation-spec-i1.h
 extern template class Template<int*>;
+// IWYU: Template<:0 *> is...*explicit_instantiation-spec-i1.h
 template class Template<int*>;
 
 // IWYU: Template is...*explicit_instantiation-template.h
@@ -140,14 +142,16 @@ void Fn() {
 /**** IWYU_SUMMARY
 
 tests/cxx/explicit_instantiation.cc should add these lines:
+#include "tests/cxx/explicit_instantiation-spec-i1.h"
 #include "tests/cxx/explicit_instantiation-template.h"
 #include "tests/cxx/indirect.h"
 
 tests/cxx/explicit_instantiation.cc should remove these lines:
+- #include "tests/cxx/explicit_instantiation-spec-d1.h"  // lines XX-XX
 - #include "tests/cxx/explicit_instantiation-template_direct.h"  // lines XX-XX
 
 The full include-list for tests/cxx/explicit_instantiation.cc:
-#include "tests/cxx/explicit_instantiation-spec.h"  // for Template
+#include "tests/cxx/explicit_instantiation-spec-i1.h"  // for Template
 #include "tests/cxx/explicit_instantiation-template.h"  // for ClassWithMethodUsingPtr, ClassWithUsingMethod, Template, TplWithDefArg, TplWithNotProvidedDefArg, getInt
 #include "tests/cxx/explicit_instantiation-template2.h"  // for ClassWithUsingMethod2, TplWithProvidedDefArg
 #include "tests/cxx/indirect.h"  // for IndirectClass, IndirectTemplate


### PR DESCRIPTION
This causes emitting explicit warnings in the partial specialization explicit instantiation test case thus making the test more informative.

`-i1` is appended to the file name because I'm going to add `-i2` header.

No functional change.