### PR TITLE
Add forward-declaration mapping

### DIFF
--- a/docs/IWYUMappings.md
+++ b/docs/IWYUMappings.md
@@ -115,17 +115,30 @@ header.
 Data for this directive is a list of four strings containing:
 
 * The symbol name to map from
-* The visibility of the symbol
+* The use kind of the symbol (`full` or `fwd-decl`, where `full` corresponds
+  to uses that require the complete type info for tag types)
 * The include name to map to
 * The visibility of the include name to map to
 
 For example;
 
-    { "symbol": ["NULL", "private", "<cstddef>", "public"] }
+    { "symbol": ["NULL", "full", "<cstddef>", "public"] }
 
-The symbol visibility is largely redundant -- it must always be `private`. It
-isn't entirely clear why symbol visibility needs to be specified, and it might
-be removed moving forward.
+As another example, consider class `X` defined in `"bits/x.h"`. Here is what
+IWYU would suggest for different cases across mappings and uses:
+
+|                     |       No mapping      | `["X", "full", "<x.h>", ...` | `["X", "fwd-decl", "<xfwd.h>", ...` |
+| ------------------- | --------------------- | ---------------------------- | ----------------------------------- |
+| Full use of `X`     | `#include "bits/x.h"` | `#include <x.h>`             | `#include "bits/x.h"`               |
+| Fwd-decl use of `X` | `class X;`            | `class X;`                   | `#include <xfwd.h>`                 |
+
+If you want the mapping both for complete type info and fwd-decl uses, specify
+the both entries in the mapping file.
+
+If `fwd-decl` mapping is specified, IWYU suggests to replace already present
+forward-declarations with the corresponding headers. For backward compatibility
+with the old mapping file format, `private` is acceptable and is handled as
+`full` use kind.
 
 Unlike `include`, `symbol` directives do not support the `@`-prefixed regex
 syntax in the first entry. Track the [following

--- a/iwyu_include_picker.cc
+++ b/iwyu_include_picker.cc
@@ -16,6 +16,7 @@
 #include <map>                          // for map, map<>::mapped_type, etc
 #include <memory>
 #include <numeric>                      // for accumulate
+#include <optional>
 #include <string>                       // for string, basic_string, etc
 #include <system_error>                 // for error_code
 #include <utility>                      // for pair, make_pair
@@ -62,6 +63,7 @@ using llvm::yaml::document_iterator;
 using std::find;
 using std::make_pair;
 using std::map;
+using std::optional;
 using std::pair;
 using std::string;
 using std::unique_ptr;
@@ -1576,6 +1578,14 @@ void WriteMappings(StringRef directive,
   out << "]\n";
 }
 
+static optional<UseKind> ParseUseKind(StringRef use_kind) {
+  if (use_kind == "full" || use_kind == "private")
+    return UseKind::Full;
+  if (use_kind == "fwd-decl")
+    return UseKind::FwdDecl;
+  return {};
+}
+
 }  // anonymous namespace
 
 // Write out all internal mappings to files in dirpath.
@@ -1643,7 +1653,8 @@ void IncludePicker::AddInternalMappings(CStdLib cstdlib, CXXStdLib cxxstdlib) {
 
       // the canonical header is returned first
       for (const Header& header : sym.headers()) {
-        AddSymbolMapping(name, MappedInclude(header.name().str()), kPublic);
+        AddSymbolMapping(name, UseKind::Full,
+                         MappedInclude(header.name().str()), kPublic);
       }
     }
   }
@@ -1660,7 +1671,8 @@ void IncludePicker::AddInternalMappings(CStdLib cstdlib, CXXStdLib cxxstdlib) {
 
       // the canonical header is returned first
       for (const Header& header : sym.headers()) {
-        AddSymbolMapping(name, MappedInclude(header.name().str()), kPublic);
+        AddSymbolMapping(name, UseKind::Full,
+                         MappedInclude(header.name().str()), kPublic);
       }
     }
   }
@@ -1773,9 +1785,14 @@ void IncludePicker::AddIncludeMapping(const string& map_from,
 }
 
 void IncludePicker::AddSymbolMapping(const string& map_from,
+                                     UseKind use_kind,
                                      const MappedInclude& map_to,
                                      IncludeVisibility to_visibility) {
-  symbol_include_map_[map_from].push_back(map_to);
+  if (use_kind == UseKind::Full) {
+    symbol_include_map_[map_from].push_back(map_to);
+  } else {
+    fwd_decl_symbol_map_[map_from].push_back(map_to);
+  }
 
   MarkVisibility(&include_visibility_map_, map_to.quoted_include,
                  to_visibility);
@@ -1794,7 +1811,8 @@ void IncludePicker::AddSymbolMappings(const IncludeMapEntry* entries,
                                       size_t count) {
   for (size_t i = 0; i < count; ++i) {
     const IncludeMapEntry& e = entries[i];
-    AddSymbolMapping(e.map_from, MappedInclude(e.map_to), e.to_visibility);
+    AddSymbolMapping(e.map_from, UseKind::Full, MappedInclude(e.map_to),
+                     e.to_visibility);
   }
 }
 
@@ -1905,10 +1923,11 @@ void IncludePicker::FinalizeAddedIncludes() {
   // If a.h maps to b.h maps to c.h, we'd like an entry from a.h to c.h too.
   MakeMapTransitive(&filepath_include_map_);
   // Now that filepath_include_map_ is transitively closed, it's an
-  // easy task to get the values of symbol_include_map_ closed too.
-  for (IncludeMap::value_type& symbol_include : symbol_include_map_) {
+  // easy task to get the values of symbol maps closed too.
+  for (IncludeMap::value_type& symbol_include : symbol_include_map_)
     ExpandOnce(filepath_include_map_, &symbol_include.second);
-  }
+  for (IncludeMap::value_type& symbol_include : fwd_decl_symbol_map_)
+    ExpandOnce(filepath_include_map_, &symbol_include.second);
 
   has_called_finalize_added_include_lines_ = true;
 
@@ -1916,6 +1935,7 @@ void IncludePicker::FinalizeAddedIncludes() {
   if (ShouldPrint(9)) {
     PrintMappings(filepath_include_map_, "filepath_include_map_");
     PrintMappings(symbol_include_map_, "symbol_include_map_");
+    PrintMappings(fwd_decl_symbol_map_, "fwd_decl_symbol_map_");
   }
 }
 
@@ -1986,6 +2006,13 @@ vector<MappedInclude> IncludePicker::GetCandidateHeadersForSymbol(
     const string& symbol) const {
   CHECK_(has_called_finalize_added_include_lines_ && "Must finalize includes");
   return GetPublicValues(symbol_include_map_, symbol);
+}
+
+vector<string> IncludePicker::GetCandidateHeadersForSymbolFwdDecl(
+    const string& symbol, const string& including_filepath) const {
+  CHECK_(has_called_finalize_added_include_lines_ && "Must finalize includes");
+  return BestQuotedIncludesForIncluder(
+      GetPublicValues(fwd_decl_symbol_map_, symbol), including_filepath);
 }
 
 vector<string> IncludePicker::GetCandidateHeadersForSymbolUsedFrom(
@@ -2196,7 +2223,15 @@ void IncludePicker::AddMappingsFromFile(const string& filename,
           return;
         }
 
-        AddSymbolMapping(mapping[0], MappedInclude(mapping[2]), to_visibility);
+        optional<UseKind> use_kind = ParseUseKind(mapping[1]);
+        if (!use_kind) {
+          json_stream.printError(
+              current_node, "Unknown symbol use kind '" + mapping[1] + "'.");
+          return;
+        }
+
+        AddSymbolMapping(mapping[0], *use_kind, MappedInclude(mapping[2]),
+                         to_visibility);
       } else if (directive == "include") {
         // Include mapping.
         vector<string> mapping = GetSequenceValue(mapping_item_node.getValue());

--- a/iwyu_include_picker.h
+++ b/iwyu_include_picker.h
@@ -69,6 +69,8 @@ using std::vector;
 enum class RegexDialect;
 struct IncludeMapEntry;
 
+enum class UseKind { Full, FwdDecl };
+
 enum IncludeVisibility { kUnusedVisibility, kPublic, kPrivate };
 enum class CStdLib { None, ClangSymbols, Glibc };
 enum class CXXStdLib { None, ClangSymbols, Libstdcxx, Libcxx };
@@ -148,6 +150,8 @@ class IncludePicker {
   // most standard) header for the symbol.
   vector<MappedInclude> GetCandidateHeadersForSymbol(
       const string& symbol) const;
+  vector<string> GetCandidateHeadersForSymbolFwdDecl(
+      const string& symbol, const string& including_filepath) const;
 
   // As above, but given a specific including header it is possible to convert
   // mapped includes to quoted include strings (because we can for example know
@@ -219,9 +223,10 @@ class IncludePicker {
   // Adds a mapping from a a symbol to a quoted include. We use this to
   // maintain mappings of documented types, e.g.
   //  For std::map<>, include <map>.
-  void AddSymbolMapping(
-      const string& map_from, const MappedInclude& map_to,
-      IncludeVisibility to_visibility);
+  void AddSymbolMapping(const string& map_from,
+                        UseKind use_kind,
+                        const MappedInclude& map_to,
+                        IncludeVisibility to_visibility);
 
   // Adds mappings from sized arrays of IncludeMapEntry.
   void AddIncludeMappings(const IncludeMapEntry* entries, size_t count);
@@ -265,8 +270,10 @@ class IncludePicker {
   vector<string> BestQuotedIncludesForIncluder(
       const vector<MappedInclude>&, const string& including_filepath) const;
 
-  // From symbols to includes.
+  // From symbols to includes for full symbol uses.
   IncludeMap symbol_include_map_;
+  // From symbols to includes for uses that require only forward-declarations.
+  IncludeMap fwd_decl_symbol_map_;
 
   // From quoted filepath patterns to includes, where a pattern can be
   // either a quoted filepath (e.g. "foo/bar.h" or <a/b.h>) or @

--- a/iwyu_output.cc
+++ b/iwyu_output.cc
@@ -278,9 +278,12 @@ string GetShortNameAsString(const NamedDecl* named_decl) {
 }  // namespace internal
 
 // Holds information about a single full or fwd-decl use of a symbol.
-OneUse::OneUse(const NamedDecl* decl, SourceLocation use_loc,
-               SourceLocation decl_loc, OneUse::UseKind use_kind,
-               UseFlags flags, const char* comment)
+OneUse::OneUse(const NamedDecl* decl,
+               SourceLocation use_loc,
+               SourceLocation decl_loc,
+               UseKind use_kind,
+               UseFlags flags,
+               const char* comment)
     : symbol_name_(internal::GetQualifiedNameAsString(decl)),
       short_symbol_name_(internal::GetShortNameAsString(decl)),
       decl_(decl),
@@ -296,7 +299,8 @@ OneUse::OneUse(const NamedDecl* decl, SourceLocation use_loc,
 }
 
 // This constructor always creates a full use.
-OneUse::OneUse(const string& symbol_name, OptionalFileEntryRef dfn_file,
+OneUse::OneUse(const string& symbol_name,
+               OptionalFileEntryRef dfn_file,
                SourceLocation use_loc)
     : symbol_name_(symbol_name),
       short_symbol_name_(symbol_name),
@@ -304,7 +308,7 @@ OneUse::OneUse(const string& symbol_name, OptionalFileEntryRef dfn_file,
       decl_file_(dfn_file),
       decl_filepath_(GetFilePath(dfn_file)),
       use_loc_(use_loc),
-      use_kind_(kFullUse),
+      use_kind_(UseKind::Full),
       use_flags_(UF_None),
       ignore_use_(false),
       is_iwyu_violation_(false) {
@@ -324,7 +328,7 @@ OneUse::OneUse(OptionalFileEntryRef included_file,
       decl_file_(included_file),
       decl_filepath_(GetFilePath(included_file)),
       use_loc_(include_loc),
-      use_kind_(kFullUse),
+      use_kind_(UseKind::Full),
       use_flags_(UF_None),
       ignore_use_(false),
       is_iwyu_violation_(false) {
@@ -333,12 +337,24 @@ OneUse::OneUse(OptionalFileEntryRef included_file,
   suggested_header_ = quoted_include;
 }
 
+bool OneUse::is_full_use() const {
+  return use_kind_ == UseKind::Full;
+}
+
 void OneUse::reset_decl(const NamedDecl* decl) {
   CHECK_(decl_ && "Need existing decl to reset it");
   CHECK_(decl && "Need to reset decl with existing decl");
   decl_ = decl;
   decl_file_ = GetFileEntry(decl);
   decl_filepath_ = GetFilePath(decl);
+}
+
+void OneUse::set_full_use() {
+  use_kind_ = UseKind::Full;
+}
+
+void OneUse::set_forward_declare_use() {
+  use_kind_ = UseKind::FwdDecl;
 }
 
 int OneUse::UseLinenum() const {
@@ -353,6 +369,13 @@ void OneUse::SetPublicHeaders() {
   // We should never need to deal with public headers if we already know
   // who we map to.
   CHECK_(suggested_header_.empty() && "Should not need a public header here");
+
+  if (use_kind_ == UseKind::FwdDecl) {
+    public_headers_ = GlobalIncludePicker().GetCandidateHeadersForSymbolFwdDecl(
+        symbol_name_, GetFilePath(use_loc_));
+    return;
+  }
+
   if (decl_) {
     public_headers_ = GlobalIncludePicker().GetMappedPublicHeaders(
         decl_, GetFilePath(use_loc_), decl_filepath());
@@ -367,7 +390,8 @@ void OneUse::SetPublicHeaders() {
 const vector<string>& OneUse::public_headers() {
   if (public_headers_.empty()) {
     SetPublicHeaders();
-    CHECK_(!public_headers_.empty() && "Should always have at least one hdr");
+    CHECK_(use_kind_ == UseKind::FwdDecl || !public_headers_.empty())
+        << "Full uses should always have at least one hdr";
   }
   return public_headers_;
 }
@@ -377,8 +401,14 @@ bool OneUse::PublicHeadersContain(const string& elt) {
   return ContainsValue(public_headers(), elt);
 }
 
-bool OneUse::NeedsSuggestedHeader() const {
-  return (!ignore_use() && is_full_use() && suggested_header_.empty());;
+bool OneUse::NeedsSuggestedHeader() {
+  if (ignore_use() || !suggested_header_.empty())
+    return false;
+  if (is_full_use())
+    return true;
+  // If the forward-declarable type has no fwd-decl mappings, public_headers_ is
+  // empty, and no header should be picked for suggestion.
+  return !public_headers().empty();
 }
 
 namespace internal {
@@ -711,7 +741,7 @@ void IwyuFileInfo::ReportFullSymbolUse(SourceLocation use_loc,
     }
 
     symbol_uses_.push_back(OneUse(report_decl, use_loc, report_decl_loc,
-                                  OneUse::kFullUse, flags, comment));
+                                  UseKind::Full, flags, comment));
     LogSymbolUse("Marked full-info use of decl", symbol_uses_.back());
   }
 }
@@ -762,7 +792,7 @@ void IwyuFileInfo::ReportForwardDeclareUse(SourceLocation use_loc,
   // happened here, replace the friend with a real fwd decl.
   decl = GetNonfriendClassRedecl(decl);
   symbol_uses_.push_back(OneUse(decl, use_loc, GetLocation(decl),
-                                OneUse::kForwardDeclareUse, flags, comment));
+                                UseKind::FwdDecl, flags, comment));
   LogSymbolUse("Marked fwd-decl use of decl", symbol_uses_.back());
 }
 
@@ -882,14 +912,15 @@ set<string> CalculateMinimalIncludes(
   // those in private header files that only map to one public file.
   // For every other decl, we store the (decl, public-headers) pair.
   for (OneUse& use : *uses) {
-    // We don't need to add any #includes for non-full-use.
-    if (use.ignore_use() || !use.is_full_use())
+    if (use.ignore_use())
       continue;
     // Special case #1: Some uses come with a suggested header already picked.
     if (use.has_suggested_header()) {
       desired_headers.insert(use.suggested_header());
       continue;
     }
+    if (!use.NeedsSuggestedHeader())
+      continue;
     // Special case #2: if the dfn-file maps to the use-file, then
     // this is a file that the use-file is re-exporting symbols for,
     // and we should keep the #include as-is.

--- a/iwyu_output.h
+++ b/iwyu_output.h
@@ -46,12 +46,12 @@ using std::vector;
 
 class IwyuPreprocessorInfo;
 
+enum class UseKind;
+
 // This data structure holds information about a single use.  Not all
 // fields will be filled for all uses.
 class OneUse {
  public:
-  enum UseKind { kFullUse, kForwardDeclareUse };
-
   // This constructor is used to track nominal decl uses.
   OneUse(const clang::NamedDecl* decl,
          clang::SourceLocation use_loc,
@@ -92,9 +92,7 @@ class OneUse {
   clang::SourceLocation decl_loc() const {
     return decl_loc_;
   }
-  bool is_full_use() const {
-    return use_kind_ == kFullUse;
-  }
+  bool is_full_use() const;
   UseFlags flags() const {
     return use_flags_;
   }
@@ -118,8 +116,8 @@ class OneUse {
   }
 
   void reset_decl(const clang::NamedDecl* decl);
-  void set_full_use() { use_kind_ = kFullUse; }
-  void set_forward_declare_use() { use_kind_ = kForwardDeclareUse; }
+  void set_full_use();
+  void set_forward_declare_use();
   void set_ignore_use() { ignore_use_ = true; }
   void set_is_iwyu_violation() { is_iwyu_violation_ = true; }
   void set_suggested_header(const string& fh) { suggested_header_ = fh; }
@@ -127,7 +125,7 @@ class OneUse {
   string PrintableUseLoc() const;
   const vector<string>& public_headers();  // not const because we fill lazily
   bool PublicHeadersContain(const string& elt);
-  bool NeedsSuggestedHeader() const;    // not true for fwd-declare uses, e.g.
+  bool NeedsSuggestedHeader();
   int UseLinenum() const;
 
  private:
@@ -140,7 +138,7 @@ class OneUse {
   clang::OptionalFileEntryRef decl_file_;  // file entry where the symbol lives
   string decl_filepath_;           // filepath where the symbol lives
   clang::SourceLocation use_loc_;  // where the symbol is used from
-  UseKind use_kind_;               // kFullUse or kForwardDeclareUse
+  UseKind use_kind_;               // full use or forward-declare use
   UseFlags use_flags_;             // flags describing features of the use
   string comment_;                 // If not empty, append to clang warning msg
   vector<string> public_headers_;  // header to #include if dfn hdr is private

--- a/tests/cxx/fwd_decl_mapping-d1.h
+++ b/tests/cxx/fwd_decl_mapping-d1.h
@@ -1,0 +1,21 @@
+//===--- fwd_decl_mapping-d1.h - test input file for iwyu -----------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/fwd_decl_mapping-i1.h"
+
+// Test that IWYU doesn't suggest that this header should include itself.
+// TODO(bolshakov): wouldn't be better to suggest a forward-declaration here
+// despite of the mapping? Is this case related to real life at all?
+extern MappedToD1 mtd1;
+
+/**** IWYU_SUMMARY
+
+(tests/cxx/fwd_decl_mapping-d1.h has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/fwd_decl_mapping-i1.h
+++ b/tests/cxx/fwd_decl_mapping-i1.h
@@ -1,0 +1,28 @@
+//===--- fwd_decl_mapping-i1.h - test input file for iwyu -----------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+class OnlyFwdDeclUse {};
+
+class FwdDeclAndFullUse {};
+
+class FwdDeclInTwoHeaders1 {};
+
+class FwdDeclInI6 {};
+
+class HasIncludeMapping {};
+
+class HasMappingForFullUse {};
+
+class FwdDeclInTwoHeaders2 {};
+
+class MappedToD1 {};
+
+enum class EnumClass1 { A, B, C };
+
+enum class EnumClass2 { A, B, C };

--- a/tests/cxx/fwd_decl_mapping.cc
+++ b/tests/cxx/fwd_decl_mapping.cc
@@ -1,0 +1,73 @@
+//===--- fwd_decl_mapping.cc - test input file for iwyu -------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_ARGS: -I . -Xiwyu --mapping_file=tests/cxx/fwd_decl_mapping.imp \
+//            -Xiwyu --check_also=tests/cxx/fwd_decl_mapping-d1.h
+
+// Tests symbol mappings for forward-declarations.
+
+#include "tests/cxx/fwd_decl_mapping-d1.h"
+
+// IWYU: OnlyFwdDeclUse needs a declaration
+OnlyFwdDeclUse* pOnlyFwdDeclUse;
+
+// The forward-declaration header ('-i3.h') is not needed because the definition
+// should be available.
+// IWYU: FwdDeclAndFullUse needs a declaration
+FwdDeclAndFullUse* pFwdDeclAndFullUse;
+// IWYU: FwdDeclAndFullUse is...*-i4.h
+FwdDeclAndFullUse fwdDeclAndFullUse;
+
+// '-i5.h' should not be suggested because '-i6.h' should provide them both.
+// IWYU: FwdDeclInTwoHeaders1 needs a declaration
+FwdDeclInTwoHeaders1* fdth1;
+// IWYU: FwdDeclInI6 needs a declaration
+FwdDeclInI6* fdi6;
+
+// IWYU: HasIncludeMapping needs a declaration
+HasIncludeMapping* him;
+
+// IWYU: HasMappingForFullUse needs a declaration
+HasMappingForFullUse* hmffu;
+
+// Test that IWYU suggests the canonical (first mapped) header.
+// IWYU: FwdDeclInTwoHeaders2 needs a declaration
+FwdDeclInTwoHeaders2* fdth2;
+
+// IWYU: EnumClass1 needs a declaration
+EnumClass1 e1;
+
+// IWYU: EnumClass2 needs a declaration
+// IWYU: EnumClass2 is...*-i14.h
+EnumClass2 e2 = EnumClass2::A;
+
+/**** IWYU_SUMMARY
+
+tests/cxx/fwd_decl_mapping.cc should add these lines:
+#include "tests/cxx/fwd_decl_mapping-i10.h"
+#include "tests/cxx/fwd_decl_mapping-i12.h"
+#include "tests/cxx/fwd_decl_mapping-i14.h"
+#include "tests/cxx/fwd_decl_mapping-i2.h"
+#include "tests/cxx/fwd_decl_mapping-i4.h"
+#include "tests/cxx/fwd_decl_mapping-i6.h"
+#include "tests/cxx/fwd_decl_mapping-i9.h"
+
+tests/cxx/fwd_decl_mapping.cc should remove these lines:
+- #include "tests/cxx/fwd_decl_mapping-d1.h"  // lines XX-XX
+
+The full include-list for tests/cxx/fwd_decl_mapping.cc:
+#include "tests/cxx/fwd_decl_mapping-i10.h"  // for FwdDeclInTwoHeaders2 (ptr only)
+#include "tests/cxx/fwd_decl_mapping-i12.h"  // for EnumClass1 (ptr only)
+#include "tests/cxx/fwd_decl_mapping-i14.h"  // for EnumClass2
+#include "tests/cxx/fwd_decl_mapping-i2.h"  // for OnlyFwdDeclUse (ptr only)
+#include "tests/cxx/fwd_decl_mapping-i4.h"  // for FwdDeclAndFullUse
+#include "tests/cxx/fwd_decl_mapping-i6.h"  // for FwdDeclInI6 (ptr only), FwdDeclInTwoHeaders1 (ptr only), HasIncludeMapping (ptr only)
+#include "tests/cxx/fwd_decl_mapping-i9.h"  // for HasMappingForFullUse (ptr only)
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/fwd_decl_mapping.imp
+++ b/tests/cxx/fwd_decl_mapping.imp
@@ -1,0 +1,18 @@
+[
+  { "symbol": ["MappedToD1", "fwd-decl", "\"tests/cxx/fwd_decl_mapping-d1.h\"", "public"] },
+  { "symbol": ["OnlyFwdDeclUse", "fwd-decl", "\"tests/cxx/fwd_decl_mapping-i2.h\"", "public"] },
+  { "symbol": ["FwdDeclAndFullUse", "fwd-decl", "\"tests/cxx/fwd_decl_mapping-i3.h\"", "public"] },
+  { "symbol": ["FwdDeclAndFullUse", "full", "\"tests/cxx/fwd_decl_mapping-i4.h\"", "public"] },
+  { "symbol": ["FwdDeclInTwoHeaders1", "fwd-decl", "\"tests/cxx/fwd_decl_mapping-i5.h\"", "public"] },
+  { "symbol": ["FwdDeclInTwoHeaders1", "fwd-decl", "\"tests/cxx/fwd_decl_mapping-i6.h\"", "public"] },
+  { "symbol": ["FwdDeclInI6", "fwd-decl", "\"tests/cxx/fwd_decl_mapping-i6.h\"", "public"] },
+  { "symbol": ["HasIncludeMapping", "fwd-decl", "\"tests/cxx/fwd_decl_mapping-i7.h\"", "public"] },
+  { "include": ["\"tests/cxx/fwd_decl_mapping-i7.h\"", "public", "\"tests/cxx/fwd_decl_mapping-i6.h\"", "public"] },
+  { "symbol": ["HasMappingForFullUse", "full", "\"tests/cxx/fwd_decl_mapping-i8.h\"", "public"] },
+  { "symbol": ["HasMappingForFullUse", "fwd-decl", "\"tests/cxx/fwd_decl_mapping-i9.h\"", "public"] },
+  { "symbol": ["FwdDeclInTwoHeaders2", "fwd-decl", "\"tests/cxx/fwd_decl_mapping-i10.h\"", "public"] },
+  { "symbol": ["FwdDeclInTwoHeaders2", "fwd-decl", "\"tests/cxx/fwd_decl_mapping-i11.h\"", "public"] },
+  { "symbol": ["EnumClass1", "fwd-decl", "\"tests/cxx/fwd_decl_mapping-i12.h\"", "public"] },
+  { "symbol": ["EnumClass2", "fwd-decl", "\"tests/cxx/fwd_decl_mapping-i13.h\"", "public"] },
+  { "symbol": ["EnumClass2", "full", "\"tests/cxx/fwd_decl_mapping-i14.h\"", "public"] },
+]

--- a/tests/cxx/fwd_decl_mapping_path_local-d1.h
+++ b/tests/cxx/fwd_decl_mapping_path_local-d1.h
@@ -1,0 +1,12 @@
+//===--- fwd_decl_mapping_path_local-d1.h - test input file for iwyu ------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "fwd_decl_mapping_path_local-i1.h"
+
+class Class {};

--- a/tests/cxx/fwd_decl_mapping_path_local-i1.h
+++ b/tests/cxx/fwd_decl_mapping_path_local-i1.h
@@ -1,0 +1,12 @@
+//===--- fwd_decl_mapping_path_local-i1.h - test input file for iwyu ------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "fwd_decl_mapping_path_local-i2.h"  // IWYU pragma: export
+
+class ClassFromI1 {};

--- a/tests/cxx/fwd_decl_mapping_path_local-i2.h
+++ b/tests/cxx/fwd_decl_mapping_path_local-i2.h
@@ -1,0 +1,10 @@
+//===--- fwd_decl_mapping_path_local-i2.h - test input file for iwyu ------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+class Class;

--- a/tests/cxx/fwd_decl_mapping_path_local.cc
+++ b/tests/cxx/fwd_decl_mapping_path_local.cc
@@ -1,0 +1,36 @@
+//===--- fwd_decl_mapping_path_local.cc - test input file for iwyu --------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_ARGS: -Xiwyu --mapping_file=tests/cxx/fwd_decl_mapping_path_local.imp
+
+// Tests forward-declaration symbol mapping in the case of relative quoted
+// includes. '-I .' command line argument is left out intentionally.
+
+#include "fwd_decl_mapping_path_local-d1.h"
+
+// A forward-declaration of Class is mapped to '*-i2.h', which in turn is
+// exported by '*-i1.h', so including '*-i1.h' should be enough.
+Class* pClass;
+
+// Make sure '*-i1.h' is to be reported.
+// IWYU: ClassFromI1 is...*-i1.h
+ClassFromI1 cfi1;
+
+/**** IWYU_SUMMARY
+
+tests/cxx/fwd_decl_mapping_path_local.cc should add these lines:
+#include "fwd_decl_mapping_path_local-i1.h"
+
+tests/cxx/fwd_decl_mapping_path_local.cc should remove these lines:
+- #include "fwd_decl_mapping_path_local-d1.h"  // lines XX-XX
+
+The full include-list for tests/cxx/fwd_decl_mapping_path_local.cc:
+#include "fwd_decl_mapping_path_local-i1.h"  // for Class (ptr only), ClassFromI1
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/fwd_decl_mapping_path_local.imp
+++ b/tests/cxx/fwd_decl_mapping_path_local.imp
@@ -1,0 +1,3 @@
+[
+  { "symbol": ["Class", "fwd-decl", "\"fwd_decl_mapping_path_local-i2.h\"", "public"] },
+]

--- a/unittests/iwyu_output_test.cc
+++ b/unittests/iwyu_output_test.cc
@@ -16,6 +16,7 @@
 
 #include "iwyu_ast_util.h"
 #include "iwyu_globals.h"
+#include "iwyu_include_picker.h"
 #include "iwyu_verrs.h"
 #include "testing/base/public/gunit.h"
 
@@ -150,9 +151,9 @@ TEST(ProcessFullUseTest, B1) {
   FakeNamedDecl decl("class", "MyClass", "src/includes/myclass.h", 10);
   // Test the use being *before* the definition in the file (shouldn't matter)
   OneUse samefile_use(&decl, FakeSourceLocation("src/includes/myclass.h", 5),
-                      OneUse::kFullUse, false, NULL);
+                      UseKind::Full, false, NULL);
   OneUse difffile_use(&decl, FakeSourceLocation("src/myclass.cc", 10),
-                      OneUse::kFullUse, false, NULL);
+                      UseKind::Full, false, NULL);
   internal::ProcessFullUse(&samefile_use);
   internal::ProcessFullUse(&difffile_use);
   EXPECT_TRUE(samefile_use.ignore_use());
@@ -168,9 +169,9 @@ TEST(ProcessFullUseTest, B3) {
   FakeNamedDecl cc_decl("class", "MyClass", "src/myclass.cc", 10);
   // Test the use being *before* the definition in the file (shouldn't matter)
   OneUse h_use(&cc_decl, FakeSourceLocation("src/includes/myclass.h", 5),
-               OneUse::kFullUse, false, NULL);
-  OneUse cc_use(&cc_decl, FakeSourceLocation("src/main.cc", 10),
-                OneUse::kFullUse, false, NULL);
+               UseKind::Full, false, NULL);
+  OneUse cc_use(&cc_decl, FakeSourceLocation("src/main.cc", 10), UseKind::Full,
+                false, NULL);
   internal::ProcessFullUse(&h_use);
   internal::ProcessFullUse(&cc_use);
   EXPECT_TRUE(h_use.ignore_use());


### PR DESCRIPTION
This enables specifying headers in mapping files that should be used instead of forward-declarations of the corresponding tag types. The kind of a symbol mapping entry should be set in the second mapping data field and can be `full` or `fwd-decl`. `private` is also acceptable and is handled as `full` so that old symbol mappings are treated as full-use mappings.

If a source file under analysis contains a forward-declaration already, IWYU suggests replacing it with the mapped header, similar to the behavior with forward-declarations exported with pragmas.

This implements #988.