### PR TITLE
Make public_headers() const

### DIFF
--- a/iwyu_output.cc
+++ b/iwyu_output.cc
@@ -349,26 +349,22 @@ string OneUse::PrintableUseLoc() const {
   return PrintableLoc(use_loc());
 }
 
-void OneUse::SetPublicHeaders() {
-  // We should never need to deal with public headers if we already know
-  // who we map to.
-  CHECK_(suggested_header_.empty() && "Should not need a public header here");
-  if (decl_) {
-    public_headers_ = GlobalIncludePicker().GetMappedPublicHeaders(
-        decl_, GetFilePath(use_loc_), decl_filepath());
-  } else {
-    public_headers_ = GlobalIncludePicker().GetMappedPublicHeaders(
-        symbol_name_, GetFilePath(use_loc_), decl_filepath());
-  }
-  if (public_headers_.empty())
-    public_headers_.push_back(ConvertToQuotedInclude(decl_filepath()));
-}
-
-const vector<string>& OneUse::public_headers() {
+const vector<string>& OneUse::public_headers() const {
   if (public_headers_.empty()) {
-    SetPublicHeaders();
-    CHECK_(!public_headers_.empty() && "Should always have at least one hdr");
+    // We should never need to deal with public headers if we already know
+    // who we map to.
+    CHECK_(suggested_header_.empty() && "Should not need a public header here");
+    if (decl_) {
+      public_headers_ = GlobalIncludePicker().GetMappedPublicHeaders(
+          decl_, GetFilePath(use_loc_), decl_filepath());
+    } else {
+      public_headers_ = GlobalIncludePicker().GetMappedPublicHeaders(
+          symbol_name_, GetFilePath(use_loc_), decl_filepath());
+    }
+    if (public_headers_.empty())
+      public_headers_.push_back(ConvertToQuotedInclude(decl_filepath()));
   }
+  CHECK_(!public_headers_.empty() && "Should always have at least one hdr");
   return public_headers_;
 }
 

--- a/iwyu_output.h
+++ b/iwyu_output.h
@@ -125,14 +125,12 @@ class OneUse {
   void set_suggested_header(const string& fh) { suggested_header_ = fh; }
 
   string PrintableUseLoc() const;
-  const vector<string>& public_headers();  // not const because we fill lazily
+  const vector<string>& public_headers() const;
   bool PublicHeadersContain(const string& elt);
   bool NeedsSuggestedHeader() const;    // not true for fwd-declare uses, e.g.
   int UseLinenum() const;
 
  private:
-  void SetPublicHeaders();         // sets based on decl_filepath_
-
   string symbol_name_;             // the symbol being used
   string short_symbol_name_;       // 'short' form of the symbol being used
   const clang::NamedDecl* decl_;   // decl of the symbol, if we know it
@@ -143,7 +141,8 @@ class OneUse {
   UseKind use_kind_;               // kFullUse or kForwardDeclareUse
   UseFlags use_flags_;             // flags describing features of the use
   string comment_;                 // If not empty, append to clang warning msg
-  vector<string> public_headers_;  // header to #include if dfn hdr is private
+  mutable vector<string> public_headers_;  // header to #include if dfn hdr is
+                                           // private (lazily computed).
   string suggested_header_;        // header that allows us to satisfy use
   bool ignore_use_;                // set to true if use is discarded
   bool is_iwyu_violation_;         // set to false when we figure out it's not


### PR DESCRIPTION
Inline SetPublicHeaders (only used from public_headers()), and mark public_headers() const.

Mark the public_headers_ member mutable to allow lazy-loading.

No functional change.