### PR TITLE
Report template static data member definitions

### DIFF
--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -166,8 +166,6 @@ using clang::UnresolvedLookupExpr;
 using clang::UsingDirectiveDecl;
 using clang::ValueDecl;
 using clang::VarDecl;
-using clang::VarTemplateDecl;
-using clang::VarTemplatePartialSpecializationDecl;
 using clang::VarTemplateSpecializationDecl;
 using clang::isTemplateInstantiation;
 using llvm::ArrayRef;
@@ -1238,21 +1236,9 @@ const NamedDecl* GetInstantiatedFromDecl(const NamedDecl* decl) {
             record_decl->getTemplateInstantiationPattern()) {
       return pattern;
     }
-  } else if (const auto* tpl_sp_decl =
-                 dyn_cast<VarTemplateSpecializationDecl>(decl)) {
-    // An instantiated variable template.
-    // TODO(bolshakov): getTemplateInstantiationPattern() instead of this code?
-    PointerUnion<VarTemplateDecl*, VarTemplatePartialSpecializationDecl*>
-        instantiated_from = tpl_sp_decl->getInstantiatedFrom();
-    if (const auto* tpl_decl = instantiated_from.dyn_cast<VarTemplateDecl*>()) {
-      // decl is instantiated from a non-specialized template.
-      return tpl_decl;
-    } else if (const auto* partial_spec_decl =
-                   instantiated_from
-                       .dyn_cast<VarTemplatePartialSpecializationDecl*>()) {
-      // decl is instantiated from a template partial specialization.
-      return partial_spec_decl;
-    }
+  } else if (const auto* var_decl = dyn_cast<VarDecl>(decl)) {
+    if (const VarDecl* pattern = var_decl->getTemplateInstantiationPattern())
+      return pattern;
   }
   // decl is not instantiated from a class or a variable template.
   return decl;

--- a/tests/cxx/static_data_member-d1.h
+++ b/tests/cxx/static_data_member-d1.h
@@ -1,0 +1,10 @@
+//===--- static_data_member-d1.h - test input file for iwyu ---------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/static_data_member-i1.h"

--- a/tests/cxx/static_data_member-i1.h
+++ b/tests/cxx/static_data_member-i1.h
@@ -1,0 +1,22 @@
+//===--- static_data_member-i1.h - test input file for iwyu ---------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/static_data_member-i2.h"
+
+template <typename T>
+int Tpl<T>::i;
+
+template <typename T>
+int PartiallySpecializedTpl<T*>::i;
+
+template <typename T>
+int TplWithMapping<T>::i;
+
+template <typename T>
+int PartiallySpecializedTplWithMapping<T*>::i;

--- a/tests/cxx/static_data_member-i2.h
+++ b/tests/cxx/static_data_member-i2.h
@@ -1,0 +1,34 @@
+//===--- static_data_member-i2.h - test input file for iwyu ---------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+template <typename>
+struct Tpl {
+  static int i;
+};
+
+template <typename>
+struct PartiallySpecializedTpl;
+
+template <typename T>
+struct PartiallySpecializedTpl<T*> {
+  static int i;
+};
+
+template <typename>
+struct TplWithMapping {
+  static int i;
+};
+
+template <typename>
+struct PartiallySpecializedTplWithMapping;
+
+template <typename T>
+struct PartiallySpecializedTplWithMapping<T*> {
+  static int i;
+};

--- a/tests/cxx/static_data_member.cc
+++ b/tests/cxx/static_data_member.cc
@@ -1,0 +1,48 @@
+//===--- static_data_member.cc - test input file for iwyu -----------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_ARGS: -I . -Xiwyu --mapping_file=tests/cxx/static_data_member.imp
+
+// Tests handling static data members, especially in templates.
+
+#include "tests/cxx/static_data_member-d1.h"
+
+void SetI() {
+  // IWYU: Tpl is...*-i2.h
+  // IWYU: Tpl::i is...*-i1.h
+  Tpl<int>::i = 1;
+  // IWYU: PartiallySpecializedTpl<:0 *> is...*-i2.h
+  // IWYU: PartiallySpecializedTpl<:0 *>::i is...*-i1.h
+  PartiallySpecializedTpl<int*>::i = 1;
+  // IWYU: TplWithMapping is...*-i2.h
+  // IWYU: TplWithMapping::i is...*-i3.h
+  TplWithMapping<int>::i = 1;
+  // IWYU: PartiallySpecializedTplWithMapping<:0 *> is...*-i2.h
+  // IWYU: PartiallySpecializedTplWithMapping<:0 *>::i is...*-i4.h
+  PartiallySpecializedTplWithMapping<int*>::i = 1;
+}
+
+/**** IWYU_SUMMARY
+
+tests/cxx/static_data_member.cc should add these lines:
+#include "tests/cxx/static_data_member-i1.h"
+#include "tests/cxx/static_data_member-i2.h"
+#include "tests/cxx/static_data_member-i3.h"
+#include "tests/cxx/static_data_member-i4.h"
+
+tests/cxx/static_data_member.cc should remove these lines:
+- #include "tests/cxx/static_data_member-d1.h"  // lines XX-XX
+
+The full include-list for tests/cxx/static_data_member.cc:
+#include "tests/cxx/static_data_member-i1.h"  // for PartiallySpecializedTpl<>::i, Tpl::i
+#include "tests/cxx/static_data_member-i2.h"  // for PartiallySpecializedTpl, PartiallySpecializedTplWithMapping, Tpl, TplWithMapping
+#include "tests/cxx/static_data_member-i3.h"  // for TplWithMapping::i
+#include "tests/cxx/static_data_member-i4.h"  // for PartiallySpecializedTplWithMapping<>::i
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/static_data_member.imp
+++ b/tests/cxx/static_data_member.imp
@@ -1,0 +1,4 @@
+[
+  { "symbol": ["TplWithMapping::i", "private", "\"tests/cxx/static_data_member-i3.h\"", "public"] },
+  { "symbol": ["PartiallySpecializedTplWithMapping<:0 *>::i", "private", "\"tests/cxx/static_data_member-i4.h\"", "public"] },
+]


### PR DESCRIPTION
Prior to this, instantiated static data members were attributed to their declarations inside the class template. Hence, their out-of-line definitions (which may reside in another header) were not suggested for inclusion in an instantiating file.