### PR TITLE
[clang compat] Update bug test for 958

### DIFF
--- a/tests/bugs/958/958.cc
+++ b/tests/bugs/958/958.cc
@@ -13,13 +13,14 @@
 #include "file1.h"
 
 template <typename T>
-int templFunc(T val) {
+int templFunc() {
+  T val;
   return val.x;
 }
 
 // Explicit function template instantiation:
 // https://en.cppreference.com/w/cpp/language/function_template#Explicit_instantiation
-template int templFunc<X>(X val);
+template int templFunc<X>();
 
 /**** IWYU_SUMMARY
 

--- a/tests/bugs/958/958.h
+++ b/tests/bugs/958/958.h
@@ -8,7 +8,7 @@
 //===----------------------------------------------------------------------===//
 
 template <typename T>
-int templFunc(T);
+int templFunc();
 
 /**** IWYU_SUMMARY
 


### PR DESCRIPTION
https://github.com/llvm/llvm-project/commit/fb024337497f4c158ea16bfb90 added a new ExplicitInstantiationDecl node in the AST, which is traversed by RecursiveASTVisitor in a way that it hits nodes we haven't seen before.

This fixed the bug demonstrated in the 958 bug test.

A small change to the bug test triggers the bug again (move the use of T from param list to the template body), so I've updated the issue and the test in concert to get back to a green mainline build.