### PR TITLE
Report explicitly instantiated fn and var decls

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -210,6 +210,7 @@ using clang::ElaboratedTypeKeyword;
 using clang::EnumConstantDecl;
 using clang::EnumDecl;
 using clang::EnumType;
+using clang::ExplicitInstantiationDecl;
 using clang::Expr;
 using clang::ExprResult;
 using clang::FriendDecl;
@@ -5101,9 +5102,58 @@ class IwyuAstConsumer
       return true;
     if (decl->isExplicitSpecialization())
       ReportDeclUse(CurrentLoc(), decl->getSpecializedTemplate());
-    // TODO(bolshakov): handle explicit instantiations. Looks like clang doesn't
-    // store all of the explicit instantiation redeclarations in the AST.
     return Base::VisitVarTemplateSpecializationDecl(decl);
+  }
+
+  bool VisitExplicitInstantiationDecl(ExplicitInstantiationDecl* decl) {
+    if (CanIgnoreCurrentASTNode())
+      return true;
+    const NamedDecl* spec = decl->getSpecialization();
+    if (const auto* fn_spec = dyn_cast<FunctionDecl>(spec)) {
+      if (decl->isExternTemplate()) {
+        // Explicit instantiation declarations require only any function
+        // declaration. If it is a class method, a declaration should be already
+        // provided by that class.
+        if (!fn_spec->isCXXClassMember()) {
+          ReportDeclUse(CurrentLoc(),
+                        fn_spec->getPrimaryTemplate()->getTemplatedDecl());
+        }
+      } else {
+        if (fn_spec->getTemplateSpecializationKind() ==
+            clang::TSK_ExplicitSpecialization) {
+          // Explicit instantiation definition doesn't do anything if it refers
+          // to an explicit specialization, so any redeclaration of the latter
+          // goes.
+          ReportDeclUse(CurrentLoc(), fn_spec);
+        } else {
+          // Otherwise, report the instantiation pattern. Another template
+          // redeclaration in the instantiating file is not enough,
+          // so UF_InstantiationPattern is specified.
+          ReportDeclUse(CurrentLoc(), spec, nullptr, UF_InstantiationPattern);
+          // TODO(bolshakov): report required template arguments.
+        }
+      }
+    } else if (const auto* var_tpl_spec =
+                   dyn_cast<VarTemplateSpecializationDecl>(spec)) {
+      if (decl->isExternTemplate()) {
+        // An explicit specialization (if present) should be reported even
+        // in the case of a member variable template because it may alter
+        // the variable type.
+        ReportDeclUse(CurrentLoc(), var_tpl_spec);
+      } else {
+        ReportDeclUse(CurrentLoc(), spec, nullptr, UF_InstantiationPattern);
+        // TODO(bolshakov): report required template arguments.
+      }
+    } else if (const auto* var_spec = dyn_cast<VarDecl>(spec)) {
+      // Static data member of a template class. The type cannot be changed, and
+      // there should not be any redeclaration but the definition.
+      if (!decl->isExternTemplate()) {
+        ReportDeclUse(CurrentLoc(), var_spec);
+        // TODO(bolshakov): report required template arguments.
+      }
+    }
+    // TODO(bolshakov): handle class template and member class instantiations.
+    return Base::VisitExplicitInstantiationDecl(decl);
   }
 
   // Track use of namespace in using directive decl
@@ -5217,8 +5267,6 @@ class IwyuAstConsumer
         ReportDeclUse(CurrentLoc(), tpl_decl);
       }
     }
-    // TODO(bolshakov): handle explicit instantiations. Looks like clang doesn't
-    // store all of the explicit instantiation redeclarations in the AST.
     return Base::VisitFunctionDecl(decl);
   }
 

--- a/iwyu_output.cc
+++ b/iwyu_output.cc
@@ -1336,13 +1336,13 @@ void ProcessFullUse(OneUse* use, const IwyuPreprocessorInfo* preprocessor_info,
   // *any* declaration is in the same file, unless the symbol is a
   // class or enum.  (Every other kind of redeclarable symbol, such as
   // functions, have the property that a decl is the same as a
-  // definition from iwyu's point of view.)  We don't bother with
-  // RedeclarableTemplate<> types (FunctionTemplateDecl), since for
-  // those types, iwyu *does* care about the definition vs declaration.
-  // All this is moot for decl uses triggered by definitions, all their redecls
-  // are separately registered as uses so that a definition anchors all its
-  // declarations (UF_RedeclUse case).
-  if (!(use->flags() & UF_RedeclUse) && !is_builtin_function_with_mappings) {
+  // definition from iwyu's point of view.)  All this is moot for decl uses
+  // triggered by definitions, all their redecls are separately registered as
+  // uses so that a definition anchors all its declarations (UF_RedeclUse case).
+  // Also, definition uses triggered by explicit instantiation definitions
+  // should not be suppressed by any redecl (UF_InstantiationPattern case).
+  if (!(use->flags() & (UF_RedeclUse | UF_InstantiationPattern)) &&
+      !is_builtin_function_with_mappings) {
     set<const NamedDecl*> all_redecls;
     if (isa<TagDecl>(use->decl()) || isa<ClassTemplateDecl>(use->decl()))
       all_redecls.insert(use->decl());  // for classes, just consider the dfn

--- a/iwyu_use_flags.h
+++ b/iwyu_use_flags.h
@@ -23,6 +23,8 @@ const UseFlags UF_InCxxMethodBody = 1;
 const UseFlags UF_RedeclUse = 2;
 // Use targets an explicit instantiation.
 const UseFlags UF_ExplicitInstantiation = 4;
+// Primary template definition use by an instantiation.
+const UseFlags UF_InstantiationPattern = 8;
 }
 
 #endif

--- a/tests/cxx/explicit_instantiation-nested.h
+++ b/tests/cxx/explicit_instantiation-nested.h
@@ -1,0 +1,33 @@
+//===--- explicit_instantiation-nested.h - test input file for iwyu -------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_EXPLICIT_INSTANTIATION_NESTED_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_EXPLICIT_INSTANTIATION_NESTED_H_
+
+#include "tests/cxx/explicit_instantiation-template.h"
+
+template <typename T>
+void Host<T>::Fn() {
+}
+
+template <typename T>
+void Host<T>::StaticFn() {
+}
+
+template <typename T>
+int Host<T>::i;
+
+template <typename T>
+template <typename U>
+U Host<T>::var_tpl;
+
+template <typename T>
+template <typename U>
+char Host<T>::var_tpl<U*>;
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_EXPLICIT_INSTANTIATION_NESTED_H_

--- a/tests/cxx/explicit_instantiation-spec-i2.h
+++ b/tests/cxx/explicit_instantiation-spec-i2.h
@@ -1,4 +1,4 @@
-//===--- explicit_instantiation-spec-d1.h - test input file for iwyu ------===//
+//===--- explicit_instantiation-spec-i2.h - test input file for iwyu ------===//
 //
 //                     The LLVM Compiler Infrastructure
 //
@@ -7,5 +7,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "tests/cxx/explicit_instantiation-spec-i1.h"
-#include "tests/cxx/explicit_instantiation-spec-i2.h"
+#include "tests/cxx/explicit_instantiation-template.h"
+
+template <>
+void TplFn<char>();
+
+template <>
+inline char var_tpl<float>;
+
+template <typename T>
+double var_tpl<T*>;

--- a/tests/cxx/explicit_instantiation-template.h
+++ b/tests/cxx/explicit_instantiation-template.h
@@ -52,6 +52,36 @@ class TplWithNotProvidedDefArg {
   T t;
 };
 
+template <typename>
+void TplFn() {
+}
+
+template <typename>
+void TplFnWithRedecl() {
+}
+
+template <typename>
+void TplFnWithRedecl2() {
+}
+
+template <typename T>
+int var_tpl;
+
+template <typename T>
+int var_tpl_with_redecl;
+
+template <typename T>
+int var_tpl_with_redecl2;
+
+template <typename>
+struct Host {
+  void Fn();
+  static void StaticFn();
+  static int i;
+  template <typename U>
+  static U var_tpl;
+};
+
 #endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_EXPLICIT_INSTANTIATION_TEMPLATE_H_
 
 /**** IWYU_SUMMARY

--- a/tests/cxx/explicit_instantiation-template_direct.h
+++ b/tests/cxx/explicit_instantiation-template_direct.h
@@ -9,6 +9,7 @@
 #ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_EXPLICIT_INSTANTIATION_TEMPLATE_DIRECT_H_
 #define INCLUDE_WHAT_YOU_USE_TESTS_CXX_EXPLICIT_INSTANTIATION_TEMPLATE_DIRECT_H_
 
+#include "tests/cxx/explicit_instantiation-nested.h"
 #include "tests/cxx/explicit_instantiation-template.h"
 
 #endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_EXPLICIT_INSTANTIATION_TEMPLATE_DIRECT_H_

--- a/tests/cxx/explicit_instantiation.cc
+++ b/tests/cxx/explicit_instantiation.cc
@@ -9,7 +9,7 @@
 
 // IWYU_ARGS: -Xiwyu --check_also=tests/cxx/explicit_instantiation-spec-i1.h \
 //            -Xiwyu --check_also=tests/cxx/explicit_instantiation-template.h \
-//            -I .
+//            -I . -Wno-instantiation-after-specialization
 
 #include "tests/cxx/explicit_instantiation-spec-d1.h"
 #include "tests/cxx/explicit_instantiation-template_direct.h"
@@ -128,6 +128,122 @@ extern template class TplWithProvidedDefArg<>;
 // IWYU: IndirectTemplate needs a declaration
 extern template class ClassWithUsingMethod2<IndirectTemplate<int>>;
 
+// Test function template explicit instantiation.
+// IWYU: TplFn() is...*explicit_instantiation-template.h
+extern template void TplFn<int>();
+// One more explicit instantiation declaration.
+// IWYU: TplFn() is...*explicit_instantiation-template.h
+extern template void TplFn<int>();
+// IWYU: TplFn() is...*explicit_instantiation-template.h
+template void TplFn<int>();
+
+// IWYU: ClassWithUsingMethod is...*explicit_instantiation-template.h
+// IWYU: IndirectTemplate needs a declaration
+extern template void ClassWithUsingMethod<IndirectTemplate<float>>::Fn();
+// TODO: IWYU: IndirectTemplate is...*indirect.h
+// IWYU: IndirectTemplate needs a declaration
+// IWYU: ClassWithUsingMethod is...*explicit_instantiation-template.h
+template void ClassWithUsingMethod<IndirectTemplate<float>>::Fn();
+
+// The presence of the explicit specialization should not affect explicit
+// instantiation declarations: effect should be the same whether it is included
+// or not, AFAIU.
+// IWYU: TplFn() is...*explicit_instantiation-template.h
+extern template void TplFn<char>();
+// In the case of explicit instantiation definition, the explicit specialization
+// should be available to suppress instantiation, so as to avoid ODR-violation.
+// IWYU: TplFn() is...*explicit_instantiation-spec-i2.h
+template void TplFn<char>();
+
+template <typename>
+void TplFnWithRedecl();
+
+// An explicit instantiation declaration of a function template doesn't require
+// the template definition. The redeclaration above is sufficient.
+extern template void TplFnWithRedecl<int>();
+// In the case of an explicit instantiation definition, the template definition
+// is required.
+// IWYU: TplFnWithRedecl() is...*explicit_instantiation-template.h
+template void TplFnWithRedecl<int>();
+
+// IWYU: TplFnWithRedecl2() is...*explicit_instantiation-template.h
+extern template void TplFnWithRedecl2<int>();
+// IWYU: TplFnWithRedecl2() is...*explicit_instantiation-template.h
+template void TplFnWithRedecl2<int>();
+
+template <typename>
+void TplFnWithRedecl2();
+
+// Test variable templates.
+// IWYU: var_tpl is...*explicit_instantiation-template.h
+extern template int var_tpl<int>;
+// IWYU: var_tpl is...*explicit_instantiation-template.h
+extern template int var_tpl<int>;
+// IWYU: var_tpl is...*explicit_instantiation-template.h
+template int var_tpl<int>;
+
+// In the case of explicit specializations of variable templates, even explicit
+// instantiation declaration depends on the specialization because the latter
+// may change the variable type to some unrelated to the one of the primary
+// template.
+// IWYU: var_tpl<float> is...*explicit_instantiation-spec-i2.h
+extern template char var_tpl<float>;
+// IWYU: var_tpl<float> is...*explicit_instantiation-spec-i2.h
+template char var_tpl<float>;
+// IWYU: var_tpl<:0 *> is...*explicit_instantiation-spec-i2.h
+extern template double var_tpl<int*>;
+// IWYU: var_tpl<:0 *> is...*explicit_instantiation-spec-i2.h
+template double var_tpl<int*>;
+
+template <typename T>
+extern int var_tpl_with_redecl;
+
+extern template int var_tpl_with_redecl<int>;
+// IWYU: var_tpl_with_redecl is...*explicit_instantiation-template.h
+template int var_tpl_with_redecl<int>;
+
+// IWYU: var_tpl_with_redecl2 is...*explicit_instantiation-template.h
+extern template int var_tpl_with_redecl2<int>;
+// IWYU: var_tpl_with_redecl2 is...*explicit_instantiation-template.h
+template int var_tpl_with_redecl2<int>;
+
+template <typename T>
+extern int var_tpl_with_redecl2;
+
+// IWYU: Host is...*explicit_instantiation-template.h
+extern template void Host<int>::Fn();
+// IWYU: Host is...*explicit_instantiation-template.h
+// IWYU: Host::Fn() is...*explicit_instantiation-nested.h
+template void Host<int>::Fn();
+
+// IWYU: Host is...*explicit_instantiation-template.h
+extern template void Host<int>::StaticFn();
+// IWYU: Host is...*explicit_instantiation-template.h
+// IWYU: Host::StaticFn() is...*explicit_instantiation-nested.h
+template void Host<int>::StaticFn();
+
+// IWYU: Host is...*explicit_instantiation-template.h
+extern template int Host<int>::i;
+// IWYU: Host is...*explicit_instantiation-template.h
+// IWYU: Host::i is...*explicit_instantiation-nested.h
+template int Host<int>::i;
+
+// TODO: reporting '-nested.h' here is rather unwanted.
+// IWYU: Host is...*explicit_instantiation-template.h
+// IWYU: Host::var_tpl is...*explicit_instantiation-nested.h
+extern template int Host<int>::var_tpl<int>;
+// IWYU: Host is...*explicit_instantiation-template.h
+// IWYU: Host::var_tpl is...*explicit_instantiation-nested.h
+template int Host<int>::var_tpl<int>;
+// '-nested.h' is required here because the explicit specialization changes
+// the variable type.
+// IWYU: Host is...*explicit_instantiation-template.h
+// IWYU: Host::var_tpl<:0 *> is...*explicit_instantiation-nested.h
+extern template char Host<int>::var_tpl<int*>;
+// IWYU: Host is...*explicit_instantiation-template.h
+// IWYU: Host::var_tpl<:0 *> is...*explicit_instantiation-nested.h
+template char Host<int>::var_tpl<int*>;
+
 void Fn() {
   // Test that reporting for the out-of-line method is blocked due to
   // the presence of ClassWithUsingMethod2 explicit instantiation declaration
@@ -142,7 +258,9 @@ void Fn() {
 /**** IWYU_SUMMARY
 
 tests/cxx/explicit_instantiation.cc should add these lines:
+#include "tests/cxx/explicit_instantiation-nested.h"
 #include "tests/cxx/explicit_instantiation-spec-i1.h"
+#include "tests/cxx/explicit_instantiation-spec-i2.h"
 #include "tests/cxx/explicit_instantiation-template.h"
 #include "tests/cxx/indirect.h"
 
@@ -151,8 +269,10 @@ tests/cxx/explicit_instantiation.cc should remove these lines:
 - #include "tests/cxx/explicit_instantiation-template_direct.h"  // lines XX-XX
 
 The full include-list for tests/cxx/explicit_instantiation.cc:
+#include "tests/cxx/explicit_instantiation-nested.h"  // for Host::Fn, Host::StaticFn, Host::i, Host::var_tpl
 #include "tests/cxx/explicit_instantiation-spec-i1.h"  // for Template
-#include "tests/cxx/explicit_instantiation-template.h"  // for ClassWithMethodUsingPtr, ClassWithUsingMethod, Template, TplWithDefArg, TplWithNotProvidedDefArg, getInt
+#include "tests/cxx/explicit_instantiation-spec-i2.h"  // for TplFn, var_tpl
+#include "tests/cxx/explicit_instantiation-template.h"  // for ClassWithMethodUsingPtr, ClassWithUsingMethod, Host, Template, TplFn, TplFnWithRedecl, TplFnWithRedecl2, TplWithDefArg, TplWithNotProvidedDefArg, getInt, var_tpl, var_tpl_with_redecl, var_tpl_with_redecl2
 #include "tests/cxx/explicit_instantiation-template2.h"  // for ClassWithUsingMethod2, TplWithProvidedDefArg
 #include "tests/cxx/indirect.h"  // for IndirectClass, IndirectTemplate
 


### PR DESCRIPTION
This can be done now because after https://github.com/llvm/llvm-project/commit/fb024337497, there are distinct `ExplicitInstantiationDecl` nodes in the AST corresponding to every explicit instantiation declaration or definition.