### PR TITLE
Move UseFlag comments to their own lines

### DIFF
--- a/iwyu_use_flags.h
+++ b/iwyu_use_flags.h
@@ -15,10 +15,14 @@ namespace include_what_you_use {
 // Flags describing special features of a use that influence IWYU analysis.
 typedef unsigned UseFlags;
 
+// Normal use.
 const UseFlags UF_None = 0;
-const UseFlags UF_InCxxMethodBody = 1;       // use is inside a C++ method body
-const UseFlags UF_RedeclUse = 2;             // use is due to some redeclaration
-const UseFlags UF_ExplicitInstantiation = 4; // use targets an explicit instantiation
+// Use is inside a C++ method body.
+const UseFlags UF_InCxxMethodBody = 1;
+// Use is due to some redeclaration.
+const UseFlags UF_RedeclUse = 2;
+// Use targets an explicit instantiation.
+const UseFlags UF_ExplicitInstantiation = 4;
 }
 
 #endif


### PR DESCRIPTION
The trailing line comments make it hard to add a new flag, as doing so may cause a reformat of all existing flags when the aligned comments don't fit.