### PR TITLE
Don't report non-aggregate classes in some cases

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -2956,6 +2956,12 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
       return true;
     ReportIfReferenceVararg(expr->getArgs(), expr->getNumArgs(),
                             expr->getConstructor());
+    // Implicitly-constructed classes inside aggregate initialization should be
+    // skipped because they should be provided by the aggregate.
+    if (current_ast_node()->template ParentIsA<InitListExpr>() &&
+        expr->getBeginLoc() == expr->getEndLoc()) {
+      return true;
+    }
 
     if (IsAutocastExpr(current_ast_node()))
       HandleAutocastOnCallSite(expr);

--- a/tests/cxx/implicit_ctor-i2.h
+++ b/tests/cxx/implicit_ctor-i2.h
@@ -55,3 +55,11 @@ struct OuterAggregate2 {
 struct OuterAggregateWithRef {
   const InnerAggregate1& inner_ref;
 };
+
+struct I2NonAggregate {
+  I2NonAggregate(int = 0);
+};
+
+struct AggregateWithNonAggregate {
+  I2NonAggregate na;
+};

--- a/tests/cxx/implicit_ctor.cc
+++ b/tests/cxx/implicit_ctor.cc
@@ -139,6 +139,8 @@ void TakeOuterAggregate2(OuterAggregate2);
 void TakeOuterAggregateWithRef(OuterAggregateWithRef);
 void TakeNonProvidingOuterAggregate1(NonProvidingOuterAggregate1);
 void TakeProvidingOuterAggregate1(ProvidingOuterAggregate1);
+// IWYU: AggregateWithNonAggregate needs a declaration
+void TakeAggregateWithNonAggregate(AggregateWithNonAggregate);
 
 template <typename T, typename>
 void TestAggregateInitTplFn() {
@@ -188,6 +190,26 @@ void TestAggregateInit(const OuterAggregate1& par) {
   // IWYU: OuterAggregate1 is...*implicit_ctor-i2.h
   TakeNonProvidingOuterAggregate1({});
   TakeProvidingOuterAggregate1({});
+
+  // There is no point in reporting I2NonAggregate here.
+  // IWYU: AggregateWithNonAggregate needs a declaration
+  // IWYU: AggregateWithNonAggregate is...*implicit_ctor-i2.h
+  const AggregateWithNonAggregate& awna = {};
+  // IWYU: AggregateWithNonAggregate is...*implicit_ctor-i2.h
+  TakeAggregateWithNonAggregate({});
+  // In these cases, I2NonAggregate should be reported because
+  // AggregateWithNonAggregate::na could be 'const I2NonAggregate&'.
+  // IWYU: I2NonAggregate is...*implicit_ctor-i2.h
+  // IWYU: AggregateWithNonAggregate is...*implicit_ctor-i2.h
+  TakeAggregateWithNonAggregate({{}});
+  // IWYU: I2NonAggregate is...*implicit_ctor-i2.h
+  // IWYU: AggregateWithNonAggregate is...*implicit_ctor-i2.h
+  TakeAggregateWithNonAggregate({{1}});
+  // In contrast to subaggregates, AggregateWithNonAggregate::na could be
+  // a reference even in this case.
+  // IWYU: I2NonAggregate is...*implicit_ctor-i2.h
+  // IWYU: AggregateWithNonAggregate is...*implicit_ctor-i2.h
+  TakeAggregateWithNonAggregate({1});
 }
 
 /**** IWYU_SUMMARY
@@ -200,6 +222,6 @@ tests/cxx/implicit_ctor.cc should remove these lines:
 The full include-list for tests/cxx/implicit_ctor.cc:
 #include "tests/cxx/implicit_ctor-d1.h"  // for ImplicitCtorFn, ImplicitCtorInPartialFn, ImplicitCtorRefFn, InlineImplicitCtorRefFn, ProvidingOuterAggregate1, TakeMultipleRedeclStruct
 #include "tests/cxx/implicit_ctor-d2.h"  // for NoTrivialCtorDtorNonProvidingAlias, NonProviding, NonProvidingOuterAggregate1
-#include "tests/cxx/implicit_ctor-i2.h"  // for IndirectWithImplicitCtor, InnerAggregate1, InnerAggregate2, NoAutocastCtor, NoTrivialCtorDtor, OuterAggregate1, OuterAggregate2, OuterAggregateWithRef
+#include "tests/cxx/implicit_ctor-i2.h"  // for AggregateWithNonAggregate, I2NonAggregate, IndirectWithImplicitCtor, InnerAggregate1, InnerAggregate2, NoAutocastCtor, NoTrivialCtorDtor, OuterAggregate1, OuterAggregate2, OuterAggregateWithRef
 
 ***** IWYU_SUMMARY */

--- a/tests/cxx/typedef_in_template.cc
+++ b/tests/cxx/typedef_in_template.cc
@@ -187,9 +187,6 @@ void ArgumentTypeProvision() {
   (void)sizeof(decltype_not_provided);
   // IWYU: IndirectClass is...*indirect.h
   ConstructionFromIndirectClass cficnp{decltype_not_provided};
-  // TODO: probably, IndirectClass should not be reported here because it is
-  // provided by AggregateContainingIndirectClass definition.
-  // IWYU: IndirectClass is...*indirect.h
   AggregateContainingIndirectClass acicnp{decltype_not_provided};
 
   Identity<Providing>::Inner::Type p3;


### PR DESCRIPTION
Reporting default-initialized non-aggregate parts of an aggregate is redundant when the initialization is not reflected in the source. In such cases, the type should already be complete.