### PR TITLE
Adjust to new Clang

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -3424,6 +3424,9 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
         // AST node) -- then we're forward-declarable by definition.
         if (IsForwardDecl(parent_decl))
           return true;
+      } else if (const auto* expl_inst =
+                     ast_node->GetParentAs<ExplicitInstantiationDecl>()) {
+        return expl_inst->isExternTemplate();
       }
     }
 

--- a/iwyu.cc
+++ b/iwyu.cc
@@ -4485,6 +4485,8 @@ class InstantiatedTemplateVisitor
       }
     }
     if (decl_as_written) {
+      if (const FunctionDecl* dfn = decl_as_written->getDefinition())
+        decl_as_written = dfn;
       FunctionDecl* const daw = const_cast<FunctionDecl*>(decl_as_written);
       nodes_to_ignore_.AddAll(nodeset_getter.GetNodesBelow(daw));
     }
@@ -4505,7 +4507,8 @@ class InstantiatedTemplateVisitor
     VarDecl* decl_as_written = decl->getTemplateInstantiationPattern();
     if (!decl_as_written)  // TODO(bolshakov): could it be null?
       return true;
-    nodes_to_ignore_.AddAll(nodeset_getter.GetNodesBelow(decl_as_written));
+    nodes_to_ignore_.AddAll(
+        nodeset_getter.GetNodesBelow(decl_as_written->getDefinition()));
 
     // This is not TraverseDecl because clang otherwise skips
     // VarTemplateSpecializationDecl as an implicit instantiation

--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -1263,8 +1263,10 @@ const NamedDecl* GetInstantiatedFromDecl(const NamedDecl* decl) {
       return pattern;
     }
   } else if (const auto* var_decl = dyn_cast<VarDecl>(decl)) {
-    if (const VarDecl* pattern = var_decl->getTemplateInstantiationPattern())
-      return pattern;
+    if (const VarDecl* pattern = var_decl->getTemplateInstantiationPattern()) {
+      if (const VarDecl* defn = pattern->getDefinition())
+        return defn;
+    }
   }
   // decl is not instantiated from a class or a variable template.
   return decl;

--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -1011,7 +1011,7 @@ static map<const Type*, const Type*> GetTplTypeResugarMapForExplicitTplArgs(
 static map<const Type*, const Type*> GetTplTypeResugarMapForExplicitTplArgs(
     const ExplicitInstantiationDecl* decl) {
   map<const Type*, const Type*> retval;
-  for (unsigned i = 0, ie = decl->getNumTemplateArgs(); i < ie; ++i) {
+  for (unsigned i = 0; i < decl->getNumTemplateArgs().value_or(0); ++i) {
     TemplateArgumentLoc loc = decl->getTemplateArg(i);
     if (const Type* arg_type = GetTemplateArgAsType(loc.getArgument())) {
       retval[GetCanonicalType(arg_type)] = arg_type;
@@ -1955,7 +1955,7 @@ TemplateInstantiationData GetTplExplicitInstData(
   if (const auto* fn_spec = dyn_cast<FunctionDecl>(spec)) {
     map<const Type*, const Type*> implicit_tpl_arg_map =
         GetTplTypeResugarMapForFunctionNoCallExpr(
-            fn_spec, /*start_arg=*/decl->getNumTemplateArgs());
+            fn_spec, /*start_arg=*/decl->getNumTemplateArgs().value_or(0));
 
     set<const Type*> fn_param_types;
     const auto* fn_type =

--- a/tests/cxx/expl_inst_args.cc
+++ b/tests/cxx/expl_inst_args.cc
@@ -94,7 +94,8 @@ extern template void S2<Struct1>::method();              // (j)
 // IWYU: Struct1 needs a declaration
 // IWYU: Struct1 is...*expl_inst_args-i1.h
 template void foo<Struct1>(Struct1);              // (a)
-// TODO: Language wants complete Struct1 here for bar dfn.
+// IWYU: Struct1 needs a declaration
+// IWYU: Struct1 is...*expl_inst_args-i1.h
 template Struct1 bar<Struct1>;                    // (b)
 // IWYU: Struct1 needs a declaration
 // IWYU: Struct1 is...*expl_inst_args-i1.h
@@ -102,8 +103,8 @@ template struct S<Struct1>;                       // (c)
 // IWYU: Struct2 needs a declaration
 // IWYU: Struct2 is...*expl_inst_args-i1.h
 template void S<Struct2>::method(Struct2);        // (d)
-// TODO: Language wants complete Struct2 here for sval static member dfn.
 // IWYU: Struct2 needs a declaration
+// IWYU: Struct2 is...*expl_inst_args-i1.h
 template Struct2 S<Struct2>::sval;                // (e) & (i)
 // IWYU: Struct1 needs a declaration
 // IWYU: Struct2 needs a declaration

--- a/tests/cxx/variable_template.cc
+++ b/tests/cxx/variable_template.cc
@@ -58,8 +58,14 @@ int both_args_used_def_non_provided = [] {
 }();
 
 template <typename>
+extern int refers_to_fn_in_init;
+
+template <typename>
 // IWYU: GetInt() is...*-i1.h
 int refers_to_fn_in_init = GetInt();
+
+template <typename>
+extern int refers_to_fn_in_init;
 
 template <typename T>
 T typed_as_param_expl_spec;

--- a/tests/cxx/variable_template.cc
+++ b/tests/cxx/variable_template.cc
@@ -76,7 +76,7 @@ extern template IndirectClass typed_as_param_expl_inst_decl<IndirectClass>;
 template <typename T>
 T typed_as_param_expl_inst_def;
 
-// TODO: IWYU: IndirectClass is...*indirect.h
+// IWYU: IndirectClass is...*indirect.h
 template IndirectClass typed_as_param_expl_inst_def<IndirectClass>;
 
 template <typename>


### PR DESCRIPTION
https://github.com/llvm/llvm-project/commit/6768170423542b772f9dfbfd21b06eefd983e188 changes `ExplicitInstantiationDecl::getNumTemplateArgs()` return type to optional. Moreover, it fixes traversing type of variable template explicit instantiation, but some handling was needed in `CanForwardDeclareType` method because only explicit instantiation definitions require the complete type.

https://github.com/llvm/llvm-project/commit/3a25f7b645fa68343d548eb116d884fd1ebb3edb removes obtaining definitions from `getTemplateInstantiationPattern` methods, so it should be done at the call sites now.