### PR TITLE
Print "ptr only" uses according to comment_style

### DIFF
--- a/iwyu_output.cc
+++ b/iwyu_output.cc
@@ -1968,7 +1968,9 @@ void CalculateDesiredIncludesAndForwardDeclares(
       }
     } else {
       // If we satisfy a forward-declare use from a file, let the file know.
-      const string symbol_name = use.short_symbol_name();
+      const string symbol_name = GlobalFlags().comments_with_namespace
+                                     ? use.symbol_name()
+                                     : use.short_symbol_name();
 
       auto range = include_map.equal_range(use.suggested_header());
       CHECK_(range.first != range.second);

--- a/tests/cxx/comment_style-i2.h
+++ b/tests/cxx/comment_style-i2.h
@@ -11,4 +11,7 @@ namespace Bar {
   int foo(int x) {
     return x;
   }
+
+  class FullAndFwdDeclUse {};
+  class FwdDeclUse {};
 };

--- a/tests/cxx/comment_style_long.cc
+++ b/tests/cxx/comment_style_long.cc
@@ -13,6 +13,13 @@
 
 #include "tests/cxx/comment_style-d1.h" // for bar
 
+// IWYU: Bar::FullAndFwdDeclUse is...*comment_style-i2.h
+Bar::FullAndFwdDeclUse full_use;
+// IWYU: Bar::FullAndFwdDeclUse needs a declaration
+Bar::FullAndFwdDeclUse* fwd_decl_use1;
+// IWYU: Bar::FwdDeclUse needs a declaration
+Bar::FwdDeclUse* fwd_decl_use2;
+
 int main() {
   Foo::bar(1);
   // IWYU: Bar::foo(int) is...*"tests/cxx/comment_style-i2.h"
@@ -28,5 +35,5 @@ tests/cxx/comment_style_long.cc should remove these lines:
 
 The full include-list for tests/cxx/comment_style_long.cc:
 #include "tests/cxx/comment_style-d1.h"  // for Foo::bar(int)
-#include "tests/cxx/comment_style-i2.h"  // for Bar::foo(int)
+#include "tests/cxx/comment_style-i2.h"  // for Bar::FullAndFwdDeclUse, Bar::FwdDeclUse (ptr only), Bar::foo(int)
 ***** IWYU_SUMMARY */


### PR DESCRIPTION
Prior to this, printing comments for "ptr only" uses did not take into account `--comment_style` option, so they were printed without namespace qualification on `--comment_style=long`. Even worse, IWYU failed to detect if a header is already required for the full use, so the both comments appeared, like this:
```cpp
#include "class.h"  // for ns::Class, Class (ptr only)
```