### PR TITLE
Fix crash on dependent function return type

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -3467,7 +3467,8 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
       if (const auto* tpl_spec_type =
               dyn_cast<TemplateSpecializationType>(component)) {
         const NamedDecl* decl = TypeToDeclAsWritten(tpl_spec_type);
-        if (const auto* al_tpl_decl = dyn_cast<TypeAliasTemplateDecl>(decl)) {
+        if (const auto* al_tpl_decl =
+                dyn_cast_or_null<TypeAliasTemplateDecl>(decl)) {
           InsertAllInto(
               GetAliasTemplateProvidedTypes(tpl_spec_type, al_tpl_decl),
               &retval);

--- a/tests/cxx/dependent_tpl_crash.cc
+++ b/tests/cxx/dependent_tpl_crash.cc
@@ -49,6 +49,15 @@ void TplFn() {
   (void)sizeof(n);
 }
 
+struct DependentFnReturn {
+  template <typename T>
+  static typename T::template NestedTpl<T> GetNestedTpl() {
+    return {};
+  }
+
+  using ThisType = DependentFnReturn;
+};
+
 int main() {
   test<0>();
   Tpl<int> t;


### PR DESCRIPTION
The crash occurred on handling the static member function template inside `HandleAliasedClassMethods`.

This fixes #2054.