### PR TITLE
Add libstdcxx-specific operator""s mapping

### DIFF
--- a/mapgen/iwyu-mapgen-std-symbol.py
+++ b/mapgen/iwyu-mapgen-std-symbol.py
@@ -161,6 +161,10 @@ HANDWRITTEN_MAPPING = (
       'ostream'),
     ('std::print', 'print'),
     ('std::println', 'print'),
+# libstdc++ defines a literal operator for seconds as a numeric literal operator
+# template despite the <chrono> header synopsis. This may be standardized later.
+# See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85821.
+    ('std::operator""s()', 'chrono'),
 )
 
 def contains_unspec_alias(inp):

--- a/std_symbol_map.inc
+++ b/std_symbol_map.inc
@@ -1851,6 +1851,7 @@
 { "std::operator\"\"ns(long double)", UseKind::Full, "<chrono>", kPublic },
 { "std::operator\"\"ns(unsigned long long)", UseKind::Full, "<chrono>", kPublic },
 { "std::operator\"\"s", UseKind::Full, "<string>", kPublic },
+{ "std::operator\"\"s()", UseKind::Full, "<chrono>", kPublic },
 { "std::operator\"\"s(long double)", UseKind::Full, "<chrono>", kPublic },
 { "std::operator\"\"s(unsigned long long)", UseKind::Full, "<chrono>", kPublic },
 { "std::operator\"\"sv", UseKind::Full, "<string_view>", kPublic },

--- a/tests/cxx/std_symbol_mapping-direct.h
+++ b/tests/cxx/std_symbol_mapping-direct.h
@@ -86,4 +86,24 @@ using wspanstream = basic_spanstream<wchar_t>;
 template <typename T, typename = char_traits<T>>
 class basic_fstream;
 using fstream = basic_fstream<char>;
+
+using intmax_t = long long;
+
+template <intmax_t, intmax_t = 1>
+class ratio;
+
+namespace chrono {
+template <typename, typename = ratio<1>>
+class duration {};
+
+using seconds = duration<long long>;
+}  // namespace chrono
+
+inline namespace literals {
+inline namespace chrono_literals {
+// This approximately resembles how operator""s is defined in libstdc++.
+template <char...>
+chrono::seconds operator""s();
+}  // namespace chrono_literals
+}  // namespace literals
 }

--- a/tests/cxx/std_symbol_mapping.cc
+++ b/tests/cxx/std_symbol_mapping.cc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// IWYU_ARGS: -I .
+// IWYU_ARGS: -I . -Wno-user-defined-literals
 
 // Tests the internal IWYU standard library symbol mapping. In particular, tests
 // that the mapping works with types in the fwd-decl context.
@@ -84,6 +84,12 @@ void Fn() {
   std::basic_spanstream<char>* ss;
   // IWYU: std::basic_spanstream is...*<spanstream>
   (void)sizeof(*ss);
+
+  {
+    using namespace std::chrono_literals;
+    // IWYU: operator""s({{.*}}) is...*<chrono>
+    (void)10s;
+  }
 }
 
 /**** IWYU_SUMMARY
@@ -91,6 +97,7 @@ void Fn() {
 tests/cxx/std_symbol_mapping.cc should add these lines:
 #include <algorithm>
 #include <array>
+#include <chrono>
 #include <cmath>
 #include <functional>
 #include <iosfwd>
@@ -104,6 +111,7 @@ tests/cxx/std_symbol_mapping.cc should remove these lines:
 The full include-list for tests/cxx/std_symbol_mapping.cc:
 #include <algorithm>  // for move
 #include <array>  // for array, get, operator==
+#include <chrono>  // for operator""s
 #include <cmath>  // for pow
 #include <functional>  // for function, swap
 #include <iosfwd>  // for basic_ostream (ptr only), char_traits (ptr only)

--- a/tests/cxx/std_symbol_mapping_canonical.cc
+++ b/tests/cxx/std_symbol_mapping_canonical.cc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// IWYU_ARGS: -I .
+// IWYU_ARGS: -I . -Wno-user-defined-literals
 
 // Tests that symbols from std are by default attributed to their canonical
 // headers (<iosfwd> for std::fstream in a forward-declarable context). For this

--- a/tests/cxx/std_typedefs.cc
+++ b/tests/cxx/std_typedefs.cc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// IWYU_ARGS: -I .
+// IWYU_ARGS: -I . -Wno-user-defined-literals
 
 // Tests handling typedefs provided by more than one standard library header.
 // Because wspanstream is used in the context requiring complete type info, it


### PR DESCRIPTION
`-Wno-user-defined-literals` has been added in tests because otherwise clang warns that literal suffixes not beginning with `_` are reserved.

This fixes #2057.