### PR TITLE
Suggest `<c*>` headers instead of `<*.h>` in C++ mode

### DIFF
--- a/include-what-you-use.1
+++ b/include-what-you-use.1
@@ -174,6 +174,10 @@ is already visible in the file's transitive includes.
 Print full include list with comments, even if there are no
 \(lqinclude-what-you-use\(rq violations.
 .TP
+.B \-\-use_c_headers
+In C++ mode, force use of C standard library headers \fB<\fIname\fP.h>\fR
+instead of their C++ counterparts \fB<c\fIname\fP>\fR.
+.TP
 .BI \-\-verbose= level
 Set verbosity. At the highest level, this will dump the AST of the source file
 and explain all decisions.

--- a/iwyu_globals.cc
+++ b/iwyu_globals.cc
@@ -132,6 +132,8 @@ static void PrintHelp(const char* extra_msg) {
          "   --experimental=flag[,flag...]: enable experimental features\n"
          "          clang_mappings: use Clang canonical standard library\n"
          "                          mappings instead of internal mappings\n"
+         "   --use_c_headers: suggest C standard library headers in C++ mode\n"
+         "        instead of their C++ counterparts\n"
          "\n"
          "In addition to IWYU-specific options you can specify the following\n"
          "options without -Xiwyu prefix:\n"
@@ -221,7 +223,8 @@ CommandlineFlags::CommandlineFlags()
       cxx17ns(false),
       exit_code_error(EXIT_SUCCESS),
       exit_code_always(EXIT_SUCCESS),
-      regex_dialect(RegexDialect::LLVM) {
+      regex_dialect(RegexDialect::LLVM),
+      use_c_headers(false) {
   // Always keep Qt .moc includes; its moc compiler does its own IWYU analysis.
   keep.emplace("*.moc");
 }
@@ -250,6 +253,7 @@ int CommandlineFlags::ParseArgv(int argc, char** argv) {
     {"regex", required_argument, nullptr, 'r'},
     {"experimental", required_argument, nullptr, 'p'},
     {"export_mappings", required_argument, nullptr, 'E'},
+    {"use_c_headers", no_argument, nullptr, 'U'},
     {nullptr, 0, nullptr, 0}
   };
   static const char shortopts[] = "v:c:m:d:nr";
@@ -352,6 +356,7 @@ int CommandlineFlags::ParseArgv(int argc, char** argv) {
         exit(EXIT_SUCCESS);
         break;
       }
+      case 'U': use_c_headers = true; break;
       case -1:
         return optind;  // means 'no more input'
       default:

--- a/iwyu_globals.h
+++ b/iwyu_globals.h
@@ -112,6 +112,7 @@ struct CommandlineFlags {
   set<string> dbg_flags; // Debug flags.
   set<string> exp_flags;       // Experimental flags.
   RegexDialect regex_dialect;  // Dialect for regular expression processing.
+  bool use_c_headers;  // Force use C standard library headers in C++ mode.
 };
 
 const CommandlineFlags& GlobalFlags();

--- a/iwyu_include_picker.cc
+++ b/iwyu_include_picker.cc
@@ -27,6 +27,7 @@
 #include "clang/Basic/LangOptions.h"
 #include "clang/Tooling/Inclusions/StandardLibrary.h"
 #include "iwyu_ast_util.h"
+#include "iwyu_globals.h"
 #include "iwyu_location_util.h"
 #include "iwyu_path_util.h"
 #include "iwyu_port.h"
@@ -1667,22 +1668,6 @@ void IncludePicker::AddInternalMappings(CStdLib cstdlib, CXXStdLib cxxstdlib) {
   using clang::tooling::stdlib::Lang;
   using clang::tooling::stdlib::Symbol;
 
-  if (cstdlib == CStdLib::Glibc) {
-    AddSymbolMappings(libc_symbol_map, IWYU_ARRAYSIZE(libc_symbol_map));
-    AddIncludeMappings(libc_include_map, IWYU_ARRAYSIZE(libc_include_map));
-  } else if (cstdlib == CStdLib::ClangSymbols) {
-    // Get canonical C standard library mappings from clang tooling
-    for (const Symbol& sym : Symbol::all(Lang::C)) {
-      string name = sym.name().str();
-
-      // the canonical header is returned first
-      for (const Header& header : sym.headers()) {
-        AddSymbolMapping(name, UseKind::Full,
-                         MappedInclude(header.name().str()), kPublic);
-      }
-    }
-  }
-
   if (cxxstdlib == CXXStdLib::Libstdcxx) {
     AddIncludeMappings(libstdcpp_include_map,
                        IWYU_ARRAYSIZE(libstdcpp_include_map));
@@ -1704,8 +1689,10 @@ void IncludePicker::AddInternalMappings(CStdLib cstdlib, CXXStdLib cxxstdlib) {
   if (cxxstdlib != CXXStdLib::None) {
     // Map C headers to associated C++ headers. The standard library
     // mappings shouldn't be mentioning the C headers.
-    AddIncludeMappings(stdlib_c_include_map,
-                       IWYU_ARRAYSIZE(stdlib_c_include_map));
+    if (!GlobalFlags().use_c_headers) {
+      AddIncludeMappings(stdlib_c_include_map,
+                         IWYU_ARRAYSIZE(stdlib_c_include_map));
+    }
     // C++ include mappings to allow different public headers that
     // generally include each other.
     AddIncludeMappings(stdlib_cpp_include_map,
@@ -1719,6 +1706,32 @@ void IncludePicker::AddInternalMappings(CStdLib cstdlib, CXXStdLib cxxstdlib) {
 
     AddPublicIncludes(stdlib_cpp_public_headers,
                       IWYU_ARRAYSIZE(stdlib_cpp_public_headers));
+  }
+
+  // C standard library include mapping should be added after
+  // stdlib_c_include_map so that IWYU prefers mapping <stdint.h> to <cstdint>
+  // rather than to <inttypes.h>/<cinttypes>.
+  if (cstdlib == CStdLib::Glibc) {
+    AddSymbolMappings(libc_symbol_map, IWYU_ARRAYSIZE(libc_symbol_map));
+    AddIncludeMappings(libc_include_map, IWYU_ARRAYSIZE(libc_include_map));
+  } else if (cstdlib == CStdLib::ClangSymbols) {
+    // Get canonical C standard library mappings from clang tooling
+    for (const Symbol& sym : Symbol::all(Lang::C)) {
+      string name = sym.name().str();
+
+      // the canonical header is returned first
+      for (const Header& header : sym.headers()) {
+        AddSymbolMapping(name, UseKind::Full,
+                         MappedInclude(header.name().str()), kPublic);
+      }
+    }
+  }
+
+  // HACK: Mark C standard library headers as private in C++ mode so that
+  // <cname> are suggested instead of <name.h>.
+  if (cxxstdlib != CXXStdLib::None && !GlobalFlags().use_c_headers) {
+    for (const IncludeMapEntry& entry : stdlib_c_include_map)
+      include_visibility_map_.at(entry.map_from) = IncludeVisibility::kPrivate;
   }
 }
 

--- a/iwyu_string_util.h
+++ b/iwyu_string_util.h
@@ -14,7 +14,6 @@
 #define INCLUDE_WHAT_YOU_USE_IWYU_STRING_UTIL_H_
 
 #include <cctype>
-#include <cstddef>
 #include <ctime>
 #include <string>
 #include <utility>

--- a/tests/cxx/associated_h_file_heuristic.cc
+++ b/tests/cxx/associated_h_file_heuristic.cc
@@ -16,17 +16,20 @@
 #include <stdio.h>
 #include <time.h>
 
+// IWYU: FILE is...*<cstdio>
 FILE* f = 0;
 
 /**** IWYU_SUMMARY
 
 tests/cxx/associated_h_file_heuristic.cc should add these lines:
+#include <cstdio>
 
 tests/cxx/associated_h_file_heuristic.cc should remove these lines:
+- #include <stdio.h>  // lines XX-XX
 - #include <time.h>  // lines XX-XX
 
 The full include-list for tests/cxx/associated_h_file_heuristic.cc:
 #include "tests/cxx/internal/associated_h_file_heuristic.h"
-#include <stdio.h>  // for FILE
+#include <cstdio>  // for FILE
 
 ***** IWYU_SUMMARY */

--- a/tests/cxx/badinc-inl.h
+++ b/tests/cxx/badinc-inl.h
@@ -16,7 +16,9 @@
 
 typedef int (*InlH_FunctionPtr)(int);
 
+// IWYU: NULL is...*<cstddef>
 InlH_FunctionPtr InlH_Function(class InlH_Class* c=NULL) {
+  // IWYU: NULL is...*<cstddef>
   return NULL;
 }
 
@@ -27,6 +29,15 @@ HPrivate_Enum InlH_PrivateFunction() { return HP1; }
 
 /**** IWYU_SUMMARY
 
-(tests/cxx/badinc-inl.h has correct #includes/fwd-decls)
+tests/cxx/badinc-inl.h should add these lines:
+#include <cstddef>
+
+tests/cxx/badinc-inl.h should remove these lines:
+- #include <locale.h>  // lines XX-XX
+
+The full include-list for tests/cxx/badinc-inl.h:
+#include <cstddef>  // for NULL
+#include "tests/cxx/badinc-private.h"  // for HPrivate_Enum
+#include "tests/cxx/badinc-private2.h"
 
 ***** IWYU_SUMMARY */

--- a/tests/cxx/badinc.cc
+++ b/tests/cxx/badinc.cc
@@ -172,6 +172,7 @@ Cc_OnlySpecializedStruct<int>* cc_onlyspecializedstruct_ptr;
 
 // Try a type that only needs a forward-declare because of the language linkage.
 extern "C" struct Cc_C_Struct;
+// IWYU: NULL is...*<cstddef>
 struct Cc_C_Struct* cc_c_struct_ptr = NULL;
 
 // The types.
@@ -438,6 +439,7 @@ int H_Class::f(I2_Enum i2_enum) { return 1; }
 /*static*/ int H_Class::static_out_of_line(I2_Enum i2_enum) {
   // IWYU: I1_Class needs a declaration
   I1_Class* i1_class;
+  // IWYU: NULL is...*<cstddef>
   i1_class = NULL;
   return 1;
 }
@@ -468,6 +470,7 @@ template<typename FOO>
 FOO H_TemplateClass<FOO>::static_out_of_line(I2_Enum i2_enum) {
   // IWYU: I1_Class needs a declaration
   I1_Class* i1_class;
+  // IWYU: NULL is...*<cstddef>
   i1_class = NULL;
   return FOO();
 }
@@ -476,6 +479,7 @@ template<typename FOO>
 int H_TemplateClass<FOO>::H_TplNestedStruct::tplnested(I2_Enum i2_enum) {
   // IWYU: I1_Class needs a declaration
   I1_Class* i1_class;
+  // IWYU: NULL is...*<cstddef>
   i1_class = NULL;
   return 1;
 }
@@ -484,6 +488,7 @@ template<typename FOO>
 FOO H_TemplateClass<FOO>::H_TplNestedStruct::static_tplnested(I2_Enum i2_enum) {
   // IWYU: I1_Class needs a declaration
   I1_Class* i1_class;
+  // IWYU: NULL is...*<cstddef>
   i1_class = NULL;
   return FOO();
 }
@@ -693,6 +698,7 @@ I1_TemplateClass<I1_Enum> i1_templateclass(I11);
 I1_TemplateClass<int> i1_templateclass2(10);
 // IWYU: I1_Class needs a declaration
 // IWYU: I1_TemplateClass is...*badinc-i1.h
+// IWYU: NULL is...*<cstddef>
 I1_TemplateClass<I1_Class*> i1_templateclass3(NULL);
 // We need full type info for i1_templateclass because we never
 // fwd-declare a class with default template parameters.
@@ -718,6 +724,7 @@ I1_TemplateClass<std::vector<I1_Class> >* i1_nested_templateclass_ptr;
 // IWYU: I1_TemplateClass is...*badinc-i1.h
 // IWYU: I1_Class needs a declaration
 // IWYU: std::vector is...*<vector>
+// IWYU: NULL is...*<cstddef>
 I1_TemplateClass<std::vector<I1_Class>*> i1_nested_templateclass_ptr2(NULL);
 // IWYU: I1_TemplateSubclass is...*badinc-i1.h
 // IWYU: I1_Class needs a declaration
@@ -742,11 +749,13 @@ I1_TemplateClass<std::vector<I1_Enum> >* i1_nested_templateclass_enum_ptr;
 // IWYU: I1_TemplateClass is...*badinc-i1.h
 // IWYU: I1_Enum is...*badinc-i1.h
 // IWYU: std::vector is...*<vector>
+// IWYU: NULL is...*<cstddef>
 I1_TemplateClass<std::vector<I1_Enum>*> i1_nested_templateclass_enum_ptr2(NULL);
 // Note: we have to avoid the most vexing parse, here!
 // IWYU: I1_TemplateClass is...*badinc-i1.h
 I1_TemplateClass<D1_I1_Typedef> i1_tplclass_with_typedef((D1_I1_Typedef()));
 // IWYU: I1_TemplateClass is...*badinc-i1.h
+// IWYU: NULL is...*<cstddef>
 I1_TemplateClass<D1_I1_Typedef*> i1_templateclass_with_typedef_ptr(NULL);
 // IWYU: I1_TemplateClass is...*badinc-i1.h
 I1_TemplateClass<D1_Enum> i1_templateclass_d(D11);
@@ -876,6 +885,7 @@ float SimpleFunction(I3_ForwardDeclareClass* a, I3_ForwardDeclareStruct* b)
     throw(I3_ForwardDeclareClass*, I1_Class*) {
   return 1.0;
 }
+// IWYU: NULL is...*<cstddef>
 float simple_function = SimpleFunction(NULL, NULL);
 
 // IWYU: I3_ForwardDeclareStruct needs a declaration
@@ -1018,7 +1028,7 @@ class CC_TemplateClass {
   typedef I1_TemplateClass<A> i1_typedef;
 
   // Let's throw in per-class operator new/delete.
-  // IWYU: size_t is...*{{<(stddef|stdio|string|time|wchar)\.h>}}
+  // IWYU: size_t is...*{{<c(stddef|stdio|string|time|wchar)>}}
   void* operator new(size_t size) {
     B b;
     (void)b;
@@ -1089,10 +1099,10 @@ int main() {
   x = cc_ns_alias::i1_subns::i1_int_global4sub;
 
   // Reference all the local variables, to avoid not-used errors.
-  // IWYU: fprintf({{.*}}) is...*<stdio.h>
-  // IWYU: stdout is...*<stdio.h>
+  // IWYU: fprintf({{.*}}) is...*<cstdio>
+  // IWYU: stdout is...*<cstdio>
   fprintf(stdout, "%d", local_cc_struct.a);  // test a global in stdio.h too
-  // IWYU: printf({{.*}}) is...*<stdio.h>
+  // IWYU: printf({{.*}}) is...*<cstdio>
   printf("%d", local_cc_struct.a);
   (void)Cc_typedef(4);
   // Not an iwyu violation, because Cc_typedef is responsible for its members.
@@ -1169,6 +1179,7 @@ int main() {
   i1_template_method_only_class.e(local_i2_class_ptr);
   // IWYU: std::vector is...*<vector>
   // IWYU: I2_Class needs a declaration
+  // IWYU: NULL is...*<cstddef>
   std::vector<I2_Class>* i2_class_vector = NULL;
   // IWYU: I2_Class is...*badinc-i2.h
   // IWYU: I1_TemplateMethodOnlyClass is...*badinc-i1.h
@@ -1414,7 +1425,7 @@ int main() {
   typeof(kI1ConstInt) another_const_int = 1;
   (void)(another_const_int);
   // This is a C standard macro, but is implemented via a gcc extension too.
-  // IWYU: offsetof is...*<stddef.h>
+  // IWYU: offsetof is...*<cstddef>
   // IWYU: I1_Struct is...*badinc-i1.h
   (void)(offsetof(I1_Struct, c));
   // IWYU: kI1ConstInt is...*badinc-i1.h
@@ -1429,6 +1440,7 @@ int main() {
   // IWYU: I1_Class needs a declaration
   // IWYU: I1_Class is...*badinc-i1.h
   // IWYU: I1_const_ptr is...*badinc-i1.h
+  // IWYU: NULL is...*<cstddef>
   I1_const_ptr<I1_Class> local_i1_const_ptr(NULL);
   // Needs I1_const_ptr because it calls its operator*().
   // IWYU: I1_const_ptr is...*badinc-i1.h
@@ -1453,6 +1465,7 @@ int main() {
   // IWYU: I1_Class needs a declaration
   // IWYU: I1_Class is...*badinc-i1.h
   // IWYU: I1_const_ptr is...*badinc-i1.h
+  // IWYU: NULL is...*<cstddef>
   I1_const_ptr<I1_Class> local_i1_const_ptr2(NULL);
   // IWYU: I1_const_ptr is...*badinc-i1.h
   local_i1_const_ptr2 = local_i1_const_ptr;
@@ -1461,9 +1474,11 @@ int main() {
   // IWYU: I1_Class needs a declaration
   // IWYU: I1_Class is...*badinc-i1.h
   // IWYU: I1_const_ptr is...*badinc-i1.h
+  // IWYU: NULL is...*<cstddef>
   (void)I1_const_ptr<I1_Class>(NULL);
   // IWYU: I1_Class needs a declaration
   // IWYU: I1_const_ptr is...*badinc-i1.h
+  // IWYU: NULL is...*<cstddef>
   I1_const_ptr<I1_Class*> local_i1_const_ptrptr(NULL);
   // TODO(csilvers): IWYU: I1_Class needs a declaration
   // IWYU: I1_const_ptr is...*badinc-i1.h
@@ -1596,6 +1611,7 @@ int main() {
   // IWYU: I1_TemplateClass is...*badinc-i1.h
   // IWYU: I1_Enum is...*badinc-i1.h
   // IWYU: I2_Class needs a declaration
+  // IWYU: NULL is...*<cstddef>
   I1_TemplateClass<I1_Enum, I2_Class>* local_i1_template_class_for_inl = NULL;
   // IWYU: I2_Class::~I2_Class() is...*badinc-i2-inl.h
   // IWYU: I1_TemplateClass is...*badinc-i1.h
@@ -1700,9 +1716,11 @@ int main() {
 
   // Also test while and if initializers.
   // IWYU: I1_Class needs a declaration
+  // IWYU: NULL is...*<cstddef>
   while (I1_Class* i = NULL) {
   }
   // IWYU: I1_Class needs a declaration
+  // IWYU: NULL is...*<cstddef>
   if (I1_Class* i = NULL) i = NULL;
 
   // Test some macros, including one we shouldn't mark as in-use.
@@ -1802,14 +1820,13 @@ int main() {
 // Some notes:
 // * We do not need to #include badinc-i2.h, badinc_i2-inl.h, set,
 //   stdio.h, or vector, because badinc.h is adding them for us.
-// * We *do* need to #include ctype.h, even though badinc.h #includes
+// * We *do* need to #include cctype, even though badinc.h #includes
 //   it, because badinc.h is removing that dependency.
 // * We're removing <algorithm> twice because it's in the file 3 times.
 /**** IWYU_SUMMARY
 
 tests/cxx/badinc.cc should add these lines:
-#include <ctype.h>
-#include <stddef.h>
+#include <cctype>
 #include <list>
 #include "tests/cxx/badinc-i1.h"
 class D2_Class;
@@ -1836,10 +1853,9 @@ tests/cxx/badinc.cc should remove these lines:
 The full include-list for tests/cxx/badinc.cc:
 #include "tests/cxx/badinc.h"
 #include "tests/cxx/badinc-inl.h"
-#include <ctype.h>  // for isascii
 #include <setjmp.h>
-#include <stddef.h>  // for offsetof
 #include <algorithm>  // for find
+#include <cctype>  // for isascii
 #include <fstream>  // for basic_fstream, fstream
 #include <list>  // for list
 #include <string>  // for basic_string, operator+, string

--- a/tests/cxx/badinc.h
+++ b/tests/cxx/badinc.h
@@ -11,8 +11,8 @@
 #ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_BADINC_H_
 #define INCLUDE_WHAT_YOU_USE_TESTS_CXX_BADINC_H_
 
-#include <ctype.h>  // used only in badinc.cc
-#include <errno.h>  // used both here and in badinc.cc
+#include <cctype>  // used only in badinc.cc
+#include <cerrno>  // used both here and in badinc.cc
 #include <math.h>
 #include <queue>    // used only in this .h file, not in any other file.
 #include <string>
@@ -158,7 +158,7 @@ class H_Class {
   void UsedInBadincH() { DefinedInBadincCc(); }
   H_NestedStruct h_nested_struct;
   ~H_Class() {
-    // IWYU: printf(const char *, ...) is...*<stdio.h>
+    // IWYU: printf(const char *, ...) is...*<cstdio>
     printf("%d/%d/%d/%d/%d\n", b(), c(), d(), e(), ee_);
   }
   // IWYU: I2_Enum is...*badinc-i2.h
@@ -331,7 +331,7 @@ template<typename A> int H_TemplateFunction(A a) {
   typedef I2_Class i2_type;
   // IWYU: I2_Class needs a declaration
   I2_Class* i2_class;
-  // IWYU: NULL is...*<stdio.h>
+  // IWYU: NULL is...*<cstdio>
   i2_class = NULL;
   return a == A() ? 1 : 0;
 }
@@ -378,22 +378,22 @@ H_TemplateTemplateClass<H_TemplateClass> h_i2_templatetemlpate_class;
 /**** IWYU_SUMMARY
 
 tests/cxx/badinc.h should add these lines:
-#include <stdio.h>
+#include <cstdio>
 #include <set>
 #include <vector>
 #include "tests/cxx/badinc-i2-inl.h"
 #include "tests/cxx/badinc-i2.h"
 
 tests/cxx/badinc.h should remove these lines:
-- #include <ctype.h>  // lines XX-XX
 - #include <math.h>  // lines XX-XX
+- #include <cctype>  // lines XX-XX
 - #include "tests/cxx/badinc-d2.h"  // lines XX-XX
 - class H_ForwardDeclareClass;  // lines XX-XX
 - template <typename T> class I2_TypedefOnly_Class;  // lines XX-XX
 
 The full include-list for tests/cxx/badinc.h:
-#include <errno.h>  // for errno
-#include <stdio.h>  // for NULL, printf
+#include <cerrno>  // for errno
+#include <cstdio>  // for NULL, printf
 #include <queue>  // for queue
 #include <set>  // for set
 #include <string>  // for basic_string, string

--- a/tests/cxx/catch.cc
+++ b/tests/cxx/catch.cc
@@ -48,7 +48,7 @@ int main() {
     // IWYU: Thrown is...*catch-thrown.h
     throw Thrown();
   } catch (...) {
-    // IWYU: puts(const char *) is...*stdio.h
+    // IWYU: puts(const char *) is...*cstdio
     puts("Unknown exception");
   }
 
@@ -66,7 +66,7 @@ int main() {
 /**** IWYU_SUMMARY
 
 tests/cxx/catch.cc should add these lines:
-#include <stdio.h>
+#include <cstdio>
 #include "tests/cxx/catch-byptr.h"
 #include "tests/cxx/catch-byref.h"
 #include "tests/cxx/catch-byvalue.h"
@@ -80,7 +80,7 @@ tests/cxx/catch.cc should remove these lines:
 - #include "tests/cxx/catch-exceptions.h"  // lines XX-XX
 
 The full include-list for tests/cxx/catch.cc:
-#include <stdio.h>  // for puts
+#include <cstdio>  // for puts
 #include "tests/cxx/catch-byptr.h"  // for CatchByPtr
 #include "tests/cxx/catch-byref.h"  // for CatchByRef
 #include "tests/cxx/catch-byvalue.h"  // for CatchByValue

--- a/tests/cxx/check_also-d1.h
+++ b/tests/cxx/check_also-d1.h
@@ -14,7 +14,7 @@
 
 #include "check_also-i1.h"
 
-// IWYU: NULL is...*<stddef.h>
+// IWYU: NULL is...*<cstddef>
 int* unused = NULL;   // NULL comes from check_also-i1.h
 
 #endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_CHECK_ALSO_D1_H_
@@ -22,12 +22,12 @@ int* unused = NULL;   // NULL comes from check_also-i1.h
 /**** IWYU_SUMMARY
 
 tests/cxx/check_also-d1.h should add these lines:
-#include <stddef.h>
+#include <cstddef>
 
 tests/cxx/check_also-d1.h should remove these lines:
 - #include "check_also-i1.h"  // lines XX-XX
 
 The full include-list for tests/cxx/check_also-d1.h:
-#include <stddef.h>  // for NULL
+#include <cstddef>  // for NULL
 
 ***** IWYU_SUMMARY */

--- a/tests/cxx/pch_in_code.cc
+++ b/tests/cxx/pch_in_code.cc
@@ -30,7 +30,7 @@
 // presence of a PCH.
 #include "tests/cxx/public/pch_in_code.h"
 #include <stdlib.h>  // unused
-#include <stdint.h>  // for int8_t
+#include <cstdint>   // for int8_t
 #include "tests/cxx/indirect.h"
 
 IndirectClass ic;
@@ -47,6 +47,6 @@ tests/cxx/pch_in_code.cc should remove these lines:
 The full include-list for tests/cxx/pch_in_code.cc:
 #include "tests/cxx/pch.h"
 #include "tests/cxx/public/pch_in_code.h"
-#include <stdint.h>  // for int8_t
+#include <cstdint>  // for int8_t
 
 ***** IWYU_SUMMARY */

--- a/tests/cxx/quoted_includes_first.cc
+++ b/tests/cxx/quoted_includes_first.cc
@@ -18,6 +18,7 @@
 #include "subdir/indirect_subdir.h" // User header
 #include "quoted_includes_first.h"  // Associated header
 
+// IWYU: EACCES is...*<cerrno>
 static int global_err = EACCES;
 std::exception global_exception;
 IndirectSubDirClass global_var;
@@ -27,13 +28,13 @@ IndirectSubDirClass global_var;
 tests/cxx/quoted_includes_first.cc should add these lines:
 
 tests/cxx/quoted_includes_first.cc should remove these lines:
+- #include <errno.h>  // lines XX-XX
 - #include <list>  // lines XX-XX
 
 The full include-list for tests/cxx/quoted_includes_first.cc:
 #include "tests/cxx/pch.h"
 #include "quoted_includes_first.h"
 #include "subdir/indirect_subdir.h"  // for IndirectSubDirClass
-#include <errno.h>  // for EACCES
 #include <exception>  // for exception
 
 ***** IWYU_SUMMARY */

--- a/tests/cxx/quoted_includes_first.h
+++ b/tests/cxx/quoted_includes_first.h
@@ -13,6 +13,7 @@
 #include "subdir/indirect_subdir.h" // User header
 
 inline int GetBaseError() {
+  // IWYU: ENOENT is...*<cerrno>
   return ENOENT;
 }
 
@@ -23,13 +24,15 @@ inline IndirectSubDirClass header_defined_var;
 /**** IWYU_SUMMARY
 
 tests/cxx/quoted_includes_first.h should add these lines:
+#include <cerrno>
 
 tests/cxx/quoted_includes_first.h should remove these lines:
+- #include <errno.h>  // lines XX-XX
 - #include <list>  // lines XX-XX
 
 The full include-list for tests/cxx/quoted_includes_first.h:
 #include "subdir/indirect_subdir.h"  // for IndirectSubDirClass
-#include <errno.h>  // for ENOENT
+#include <cerrno>  // for ENOENT
 #include <exception>  // for exception
 
 ***** IWYU_SUMMARY */

--- a/tests/cxx/replace_std_c_header.cc
+++ b/tests/cxx/replace_std_c_header.cc
@@ -1,0 +1,32 @@
+//===--- replace_std_c_header.cc - test input file for iwyu ---------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// Tests replacing C standard library headers with the C++ counterparts.
+// The behavior was proposed in
+// https://github.com/include-what-you-use/include-what-you-use/issues/1667.
+
+#include <stdlib.h>
+
+int main() {
+  // IWYU: EXIT_SUCCESS is...*<cstdlib>
+  return EXIT_SUCCESS;
+}
+
+/**** IWYU_SUMMARY
+
+tests/cxx/replace_std_c_header.cc should add these lines:
+#include <cstdlib>
+
+tests/cxx/replace_std_c_header.cc should remove these lines:
+- #include <stdlib.h>  // lines XX-XX
+
+The full include-list for tests/cxx/replace_std_c_header.cc:
+#include <cstdlib>  // for EXIT_SUCCESS
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/sizeof_reference.cc
+++ b/tests/cxx/sizeof_reference.cc
@@ -16,7 +16,7 @@
 //   When applied to a reference or a reference type,
 //   the result is the size of the referenced type.
 
-#include <stddef.h>
+#include <cstddef>
 #include "tests/cxx/direct.h"
 
 template <typename T> struct IndirectTemplateStruct {
@@ -129,7 +129,7 @@ tests/cxx/sizeof_reference.cc should remove these lines:
 - #include "tests/cxx/direct.h"  // lines XX-XX
 
 The full include-list for tests/cxx/sizeof_reference.cc:
-#include <stddef.h>  // for size_t
+#include <cstddef>  // for size_t
 #include "tests/cxx/indirect.h"  // for IndirectClass
 
 ***** IWYU_SUMMARY */

--- a/tests/cxx/std_symbol_mapping-direct.h
+++ b/tests/cxx/std_symbol_mapping-direct.h
@@ -107,3 +107,5 @@ chrono::seconds operator""s();
 }  // namespace chrono_literals
 }  // namespace literals
 }
+
+using int8_t = signed char;

--- a/tests/cxx/std_symbol_mapping.cc
+++ b/tests/cxx/std_symbol_mapping.cc
@@ -90,6 +90,12 @@ void Fn() {
     // IWYU: operator""s({{.*}}) is...*<chrono>
     (void)10s;
   }
+
+  // Test that using int8_t from the global namespace triggers <cstdint>
+  // suggestion, not <cinttypes> suggestion due to stdint.h -> inttypes.h ->
+  // cinttypes mapping.
+  // IWYU: int8_t is...*<cstdint>
+  int8_t int8_t_var;
 }
 
 /**** IWYU_SUMMARY
@@ -99,6 +105,7 @@ tests/cxx/std_symbol_mapping.cc should add these lines:
 #include <array>
 #include <chrono>
 #include <cmath>
+#include <cstdint>
 #include <functional>
 #include <iosfwd>
 #include <spanstream>
@@ -113,6 +120,7 @@ The full include-list for tests/cxx/std_symbol_mapping.cc:
 #include <array>  // for array, get, operator==
 #include <chrono>  // for operator""s
 #include <cmath>  // for pow
+#include <cstdint>  // for int8_t
 #include <functional>  // for function, swap
 #include <iosfwd>  // for basic_ostream (ptr only), char_traits (ptr only)
 #include <spanstream>  // for basic_spanstream

--- a/tests/cxx/stdint.cc
+++ b/tests/cxx/stdint.cc
@@ -11,9 +11,9 @@
 // header declaring the public API for the current source file, e.g. "foo.h" for
 // "foo.cc". Make sure it doesn't consider system headers associated.
 //
-// If it fails, this test will print unwanted IWYU diagnostics from stdint.h.
+// If it fails, this test will print unwanted IWYU diagnostics from cstdint.
 
-#include <stdint.h>
+#include <cstdint>
 
 int foo() {
   return (int32_t)100;

--- a/tests/cxx/use_c_headers.cc
+++ b/tests/cxx/use_c_headers.cc
@@ -1,0 +1,46 @@
+//===--- use_c_headers.cc - test input file for iwyu ----------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_ARGS: -I . -Wno-user-defined-literals -Xiwyu --use_c_headers
+
+// Tests --use_c_headers option which forces suggestions of C standard library
+// headers (<name.h>) instead of their C++ counterparts (<cname>).
+
+#include "tests/cxx/std_symbol_mapping-direct.h"
+#include <cassert>
+
+// IWYU: int8_t is...*<stdint.h>
+int8_t int8_t_var;
+// If std:: qualification is written explicitly, <cname> header should
+// nevertheless be suggested.
+// IWYU: std::size_t is...*<cstddef>
+std::size_t s;
+
+void Fn() {
+  // IWYU: assert is...*<assert.h>
+  assert(true);
+}
+
+/**** IWYU_SUMMARY
+
+tests/cxx/use_c_headers.cc should add these lines:
+#include <assert.h>
+#include <stdint.h>
+#include <cstddef>
+
+tests/cxx/use_c_headers.cc should remove these lines:
+- #include <cassert>  // lines XX-XX
+- #include "tests/cxx/std_symbol_mapping-direct.h"  // lines XX-XX
+
+The full include-list for tests/cxx/use_c_headers.cc:
+#include <assert.h>  // for assert
+#include <stdint.h>  // for int8_t
+#include <cstddef>  // for size_t
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/uses_printf.cc
+++ b/tests/cxx/uses_printf.cc
@@ -12,19 +12,19 @@
 #include "tests/cxx/uses_printf-d1.h"
 
 void hello() {
-  // IWYU: printf(const char *, ...) is...*<stdio.h>
+  // IWYU: printf(const char *, ...) is...*<cstdio>
   printf("Hello, world!\n");
 }
 
 /**** IWYU_SUMMARY
 
 tests/cxx/uses_printf.cc should add these lines:
-#include <stdio.h>
+#include <cstdio>
 
 tests/cxx/uses_printf.cc should remove these lines:
 - #include "tests/cxx/uses_printf-d1.h"  // lines XX-XX
 
 The full include-list for tests/cxx/uses_printf.cc:
-#include <stdio.h>  // for printf
+#include <cstdio>  // for printf
 
 ***** IWYU_SUMMARY */


### PR DESCRIPTION
This change makes `<cname>` headers the only acceptable option for the C standard library symbols in C++ mode. Strictly speaking, it is wrong for symbols from the global namespace, but the common implementations actually include `<name.h>` into `<cname>`. The new behavior is in line with the current C++ standard wording that discourages using `<name.h>` headers in source files not intended to be valid ISO C. If a file should be valid ISO C, IWYU should be launched on it in C mode (either implicitly based on the file extension, or explicitly with `-xc` or `-xc-header` flag).

For those who want to use `<name.h>` headers instead, a new command line flag `-Xiwyu --use_c_headers` has been introduced. It causes the opposite behavior: even if `<cname>` header is included directly, IWYU suggests replacing it with the corresponding `<name.h>` (except the case of explicitly spelled `std::` qualification). However, if a standard library implementation declares some tag type (like `timespec`) in `std` namespace first (which is unlikely to happen), it may not always work.

The order of adding the internal mappings has been changed so that `stdint.h` -> `cstdint` mapping path is preferred over `stdint.h` -> `inttypes.h` -> `cinttypes`.

The change in `iwyu_string_util.h` is because `<ctime>` now takes preference over `<cstddef>` for `size_t` because it is nailed down as the only candidate for `gmtime` and `strftime`.

This fixes #270, #890, #1093, #1126, and #1667.