### PR TITLE
Fix manpage according to groff style guide

### DIFF
--- a/include-what-you-use.1
+++ b/include-what-you-use.1
@@ -175,8 +175,10 @@ Print full include list with comments, even if there are no
 \(lqinclude-what-you-use\(rq violations.
 .TP
 .B \-\-use_c_headers
-In C++ mode, force use of C standard library headers \fB<\fIname\fP.h>\fR
-instead of their C++ counterparts \fB<c\fIname\fP>\fR.
+In C++ mode, force use of C standard library headers
+.IR < name .h>
+instead of their C++ counterparts
+.IR <c name > .
 .TP
 .BI \-\-verbose= level
 Set verbosity. At the highest level, this will dump the AST of the source file


### PR DESCRIPTION
Filenames should be in italics with variant parts in roman.