### PR TITLE
Deduplicate fwd-decls using the canonical decl

### DIFF
--- a/iwyu_output.h
+++ b/iwyu_output.h
@@ -196,7 +196,8 @@ class OneIncludeOrForwardDeclareLine {
   }
 
   bool matches(const clang::NamedDecl* decl) const {
-    return !IsIncludeLine() && (fwd_decl_ == decl);
+    return !IsIncludeLine() &&
+           (fwd_decl_->getCanonicalDecl() == decl->getCanonicalDecl());
   }
 
   void set_present() { is_present_ = true; }

--- a/tests/cxx/template_specialization-d3.h
+++ b/tests/cxx/template_specialization-d3.h
@@ -1,0 +1,11 @@
+//===--- template_specialization-d3.h - test input file for iwyu -*- C++ -*===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// Primary template forward-declaration.
+template <int> class DefinedBeforeSpec;

--- a/tests/cxx/template_specialization.cc
+++ b/tests/cxx/template_specialization.cc
@@ -14,6 +14,7 @@
 
 #include "tests/cxx/template_specialization-d1.h"
 #include "tests/cxx/template_specialization-d2.h"
+#include "tests/cxx/template_specialization-d3.h"
 #include "tests/cxx/direct.h"
 
 template<typename T> class Foo;
@@ -61,24 +62,32 @@ using FwdDeclaredTplSpecAlias = FwdDeclaredTpl<1>;
 // IWYU: FwdDeclaredTpl needs a declaration
 template <> class FwdDeclaredTpl<1> {};
 
+// IWYU: DefinedBeforeSpec needs a declaration
+using DefinedBeforeSpecAlias = DefinedBeforeSpec<1>;
+// Define the primary template; no diagnostic here.
+template <int> class DefinedBeforeSpec {};
+
 /**** IWYU_SUMMARY
 
 tests/cxx/template_specialization.cc should add these lines:
 #include "tests/cxx/indirect.h"
 #include "tests/cxx/template_specialization-i1.h"
 #include "tests/cxx/template_specialization-i2.h"
+template <int> class DefinedBeforeSpec;
 template <int> class FwdDeclaredTpl;
 
 tests/cxx/template_specialization.cc should remove these lines:
 - #include "tests/cxx/direct.h"  // lines XX-XX
 - #include "tests/cxx/template_specialization-d1.h"  // lines XX-XX
 - #include "tests/cxx/template_specialization-d2.h"  // lines XX-XX
+- #include "tests/cxx/template_specialization-d3.h"  // lines XX-XX
 - template <typename T> class Foo;  // lines XX-XX
 
 The full include-list for tests/cxx/template_specialization.cc:
 #include "tests/cxx/indirect.h"  // for IndirectClass
 #include "tests/cxx/template_specialization-i1.h"  // for Foo
 #include "tests/cxx/template_specialization-i2.h"  // for Foo
+template <int> class DefinedBeforeSpec;
 template <int> class FwdDeclaredTpl;
 template <typename T> struct Specialized;  // lines XX-XX+1
 


### PR DESCRIPTION
For forward-declarations inserted by IWYU, we try to deduplicate before
adding them. However, when there are multiple redeclarations, we would
sometimes end up with two different redecls in two different
uses (particularly when the target decl has been updated due to IWYU
policy).

The original repro case was:

    // tpl_fwd_decl.h
    template <int> class Tpl;

    // src.cpp
    #include "tpl_fwd_decl.h"

    using Alias = Tpl<1>;
    template <int> class Tpl {};

which would lead to:

    src.cpp should add these lines:
    template <int> class Tpl;
    template <int> class Tpl;

because the Alias produces both a fwd-decl and a full use of Tpl<1>. The
full use is first demoted to fwd-decl use, and then updated to point to
the described template (primary template in header), so there are now
two fwd-decl uses, each of their own individual decl.

Canonicalize both use-decls before comparing, so we match even if the
uses originally referred to different redecls.

Fixes #2064.