### PR TITLE
[clang compat] Use new getExplicitInstantiationInfo()

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -4035,6 +4035,10 @@ class InstantiatedTemplateVisitor
                           const Expr* calling_expr) {
     if (const Type* resugared_type = ResugarType(parent_type))
       parent_type = resugared_type;
+    if (callee) {
+      if (FunctionDecl* defn = callee->getDefinition())
+        callee = defn;
+    }
     if (!Base::HandleFunctionCall(callee, parent_type, calling_expr))
       return false;
     return TraverseFunctionIfInstantiatedTpl(callee, parent_type, calling_expr);

--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -98,6 +98,7 @@ using clang::EnumDecl;
 using clang::EnumType;
 using clang::ExplicitCastExpr;
 using clang::ExplicitInstantiationDecl;
+using clang::ExplicitInstantiationInfo;
 using clang::Expr;
 using clang::ExprResult;
 using clang::ExprValueKind;
@@ -1324,9 +1325,14 @@ bool IsExplicitInstantiationDefinitionAsWritten(
     const ClassTemplateSpecializationDecl* decl) {
   // When swithing instantiation declaration to definition, clang preserves
   // the 'extern' keyword location info.
-  return decl->getSpecializationKind() ==
-             clang::TSK_ExplicitInstantiationDefinition &&
-         decl->getExternKeywordLoc().isInvalid();
+  if (decl->getSpecializationKind() ==
+      clang::TSK_ExplicitInstantiationDefinition) {
+    if (const ExplicitInstantiationInfo* info =
+            decl->getExplicitInstantiationInfo()) {
+      return info->ExternKeywordLoc.isInvalid();
+    }
+  }
+  return false;
 }
 
 bool IsInInlineNamespace(const Decl* decl) {


### PR DESCRIPTION
https://github.com/llvm/llvm-project/commit/ff11bbce9e87ab4ef59a7
removed the getExternKeywordLoc wrapper, and instead added a
getExplicitInstantiationInfo function to get the whole instantiation
info.

The patch in question also changes the AST so that function call exprs
in template instantiations no longer always point to the definition of
the callee. Instead, it seems they point at the last seen
declaration. It seems we assumed the definition in
InstantiatedTemplateVisitor::HandleFunctionCall, so explicitly get the
definition before handling it.

Migrate our only use to the new API.

Note: the upstream patch is already reverted on LLVM mainline, and under
revision to be re-landed. But the packages at apt.llvm.org have not
caught up with that change yet, so I'll merge this now to get our builds
working again, and then revert it when the Ubuntu packages are up to
date again.
