### PR TITLE
Recompute symbol names when use decls are reassigned

### DIFF
--- a/iwyu_output.cc
+++ b/iwyu_output.cc
@@ -347,6 +347,8 @@ void OneUse::reset_decl(const NamedDecl* decl) {
   decl_ = decl;
   decl_file_ = GetFileEntry(decl);
   decl_filepath_ = GetFilePath(decl);
+  symbol_name_ = internal::GetQualifiedNameAsString(decl);
+  short_symbol_name_ = internal::GetShortNameAsString(decl);
 }
 
 void OneUse::set_full_use() {

--- a/tests/cxx/explicit_instantiation2.cc
+++ b/tests/cxx/explicit_instantiation2.cc
@@ -79,7 +79,6 @@ TemplateTemplateArgShortFwd<
 Template<int> t9; // 9
 
 // IWYU: Template needs a declaration
-// IWYU: Template<char> needs a declaration
 template <> class Template<char> {};
 
 TemplateAsDefaultFull<char> t10; // 10

--- a/tests/cxx/template_specialization.cc
+++ b/tests/cxx/template_specialization.cc
@@ -57,7 +57,6 @@ struct Specialized<int> : IndirectClass {};
 // forward-declaration in the alias-defining file. That full use is then
 // recategorized to fwd-decl use because the defn is actually after the alias.
 // IWYU: FwdDeclaredTpl needs a declaration
-// IWYU: FwdDeclaredTpl<1> needs a declaration
 using FwdDeclaredTplSpecAlias = FwdDeclaredTpl<1>;
 // IWYU: FwdDeclaredTpl needs a declaration
 template <> class FwdDeclaredTpl<1> {};


### PR DESCRIPTION
The IWYU analysis occasionally discovers a better decl to target for a use, and calls OneUse::reset_decl to update it.

Sometimes the decl that triggered the use is materially different from the new reported decl, e.g. template specializations redirect to their primary template.

In reset_decl, also update the symbol spellings of the decl, to make sure we match the new decl.

This triggers a few changes in the test suite, but for the better. Before we would see reports of the specialization being declared as well as its primary template. After this change, we only see the primary template report.