### PR TITLE
Add mapping generator and mappings for Clang builtin headers

### DIFF
--- a/clang_builtin_include_map.inc
+++ b/clang_builtin_include_map.inc
@@ -1,0 +1,24 @@
+// Clang builtin mappings, generated with:
+// mapgen/iwyu-mapgen-clang-builtins.py --lang=c++ /usr/lib/llvm-23/lib/clang/23/include/
+// Do not edit!
+// Private-to-public #include mappings.
+{ "<__float_float.h>", kPrivate, "<float.h>", kPublic },
+{ "<__float_header_macro.h>", kPrivate, "<float.h>", kPublic },
+{ "<__float_infinity_nan.h>", kPrivate, "<float.h>", kPublic },
+{ "<__stdarg___gnuc_va_list.h>", kPrivate, "<stdarg.h>", kPublic },
+{ "<__stdarg___va_copy.h>", kPrivate, "<stdarg.h>", kPublic },
+{ "<__stdarg_header_macro.h>", kPrivate, "<stdarg.h>", kPublic },
+{ "<__stdarg_va_arg.h>", kPrivate, "<stdarg.h>", kPublic },
+{ "<__stdarg_va_copy.h>", kPrivate, "<stdarg.h>", kPublic },
+{ "<__stdarg_va_list.h>", kPrivate, "<stdarg.h>", kPublic },
+{ "<__stddef_header_macro.h>", kPrivate, "<stddef.h>", kPublic },
+{ "<__stddef_max_align_t.h>", kPrivate, "<stddef.h>", kPublic },
+{ "<__stddef_null.h>", kPrivate, "<stddef.h>", kPublic },
+{ "<__stddef_nullptr_t.h>", kPrivate, "<stddef.h>", kPublic },
+{ "<__stddef_offsetof.h>", kPrivate, "<stddef.h>", kPublic },
+{ "<__stddef_ptrdiff_t.h>", kPrivate, "<stddef.h>", kPublic },
+{ "<__stddef_rsize_t.h>", kPrivate, "<stddef.h>", kPublic },
+{ "<__stddef_size_t.h>", kPrivate, "<stddef.h>", kPublic },
+{ "<__stddef_unreachable.h>", kPrivate, "<stddef.h>", kPublic },
+{ "<__stddef_wchar_t.h>", kPrivate, "<stddef.h>", kPublic },
+{ "<__stddef_wint_t.h>", kPrivate, "<stddef.h>", kPublic },

--- a/iwyu_include_picker.cc
+++ b/iwyu_include_picker.cc
@@ -1331,6 +1331,11 @@ const IncludeMapEntry libcxx_include_map[] = {
     {"<__fwd/set.h>", kPrivate, "<set>", kPublic},
 };
 
+// The compiler-provided C headers have some private/public factoring.
+const IncludeMapEntry clang_builtin_include_map[] = {
+#include "clang_builtin_include_map.inc"  // IWYU pragma: keep
+};
+
 // Returns true if str is a valid quoted filepath pattern (i.e. either
 // a quoted filepath or "@" followed by a regex for matching a quoted
 // filepath).
@@ -1631,6 +1636,7 @@ void ExportInternalMappings(const string& dirpath) {
   WRITE_MAPPINGS_ARRAY("include", stdlib_cpp_include_map);
   WRITE_MAPPINGS_ARRAY("include", libstdcpp_include_map);
   WRITE_MAPPINGS_ARRAY("include", libcxx_include_map);
+  WRITE_MAPPINGS_ARRAY("include", clang_builtin_include_map);
 
   WRITE_MAPPINGS_ARRAY("symbol", libc_symbol_map);
   WRITE_MAPPINGS_ARRAY("symbol", stdlib_cxx_symbol_map);
@@ -1726,6 +1732,11 @@ void IncludePicker::AddInternalMappings(CStdLib cstdlib, CXXStdLib cxxstdlib) {
       }
     }
   }
+
+  // Always add the clang builtin header mappings; they are always used by IWYU,
+  // via Clang.
+  AddIncludeMappings(clang_builtin_include_map,
+                     IWYU_ARRAYSIZE(clang_builtin_include_map));
 
   // HACK: Mark C standard library headers as private in C++ mode so that
   // <cname> are suggested instead of <name.h>.

--- a/mapgen/iwyu-mapgen-clang-builtins.py
+++ b/mapgen/iwyu-mapgen-clang-builtins.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+
+##===--- iwyu-mapgen-clang-builtins.py ------------------------------------===##
+#
+#                     The LLVM Compiler Infrastructure
+#
+# This file is distributed under the University of Illinois Open Source
+# License. See LICENSE.TXT for details.
+#
+##===----------------------------------------------------------------------===##
+
+"""Generates mappings for Clang builtin headers.
+
+The builtin headers serve as an interface between the compiler and libc. For
+Clang, only a few of the builtin headers have private components and they are
+related only by filename so that '__$public_$purpose.h' maps to '$public.h'.
+
+Generate private-to-public mappings for double-underscore-prefixed names based
+on this naming convention.
+"""
+import sys
+import os
+import re
+import glob
+import argparse
+import json
+
+
+IGNORED_DUNDER_PREFIXES = [
+    # __clang prefix used for various proprietary and intrinsic support headers.
+    "__clang_",
+    # __wmmintrin prefix used for intrinsics.
+    "__wmmintrin_"
+]
+
+OUTPUT_HEADER = f"""
+Clang builtin mappings, generated with:
+{" ".join(sys.argv)}
+Do not edit!
+""".strip()
+
+# The capturing group pulls 'float' from '__float_header_macro.h', and similar.
+HEADERNAME_RE = re.compile(r"^__([^_]+).*\.h$")
+
+
+def print_output_header(comment_style):
+    """ Print a "generated-by" header. """
+    def prefix_lines(text, prefix):
+        return prefix + ("\n" + prefix).join(text.splitlines())
+    # Expand placeholders
+    output_hdr = OUTPUT_HEADER.format()
+    comment_prefix = comment_style + " "
+    print(prefix_lines(output_hdr, comment_prefix))
+
+
+def write_cxx_mappings(private_mappings):
+    """ Write out mappings as C++ for IncludeMapEntry initialization. """
+    print_output_header("//")
+    print("// Private-to-public #include mappings.")
+    for map_from, mapping_list in sorted(private_mappings.items()):
+        for map_to in sorted(mapping_list):
+            print("{ \"%s\", kPrivate, \"%s\", kPublic }," %
+                  (map_from, map_to))
+
+
+def write_imp_mappings(private_mappings):
+    """ Write out mappings as YAML for .imp mappings. """
+    def quoted(name):
+        return json.dumps(name)
+
+    print_output_header("#")
+    print("[")
+    print("  # Private-to-public #include mappings.")
+    for map_from, mapping_list in sorted(private_mappings.items()):
+        for map_to in sorted(mapping_list):
+            print('  { "include": [%s, "private", %s, "public"] },' %
+                  (quoted(map_from), quoted(map_to)))
+    print("]")
+
+
+def is_ignored(header_path):
+    """ Check if the header is ignored by prefix. """
+    headername = os.path.basename(header_path)
+    for ignore in IGNORED_DUNDER_PREFIXES:
+        if headername.startswith(ignore):
+            return True
+    return False
+
+
+def create_mapping(header_path):
+    """ Split header_path into a private and public include-name. """
+    headername = os.path.basename(header_path)
+    m = HEADERNAME_RE.match(headername)
+    if not m:
+        print("warning: unexpected headername format: %s" % headername,
+              file=sys.stderr)
+        return None, None
+    private = m.group(0)
+    public = m.group(1)
+    return f"<{private}>", f"<{public}.h>"
+
+
+def main(rootdir, lang):
+    """ Entry point. """
+    mappings = {}
+
+    # Enumerate all dunder headers
+    header_paths = glob.glob(os.path.join(rootdir, '__*.h'))
+    for header_path in header_paths:
+        if os.path.isdir(header_path):
+            continue
+
+        if is_ignored(header_path):
+            continue
+
+        private, public = create_mapping(header_path)
+        if not private and not public:
+            continue
+        mappings.setdefault(private, set()).add(public)
+
+    if lang == "c++":
+        write_cxx_mappings(mappings)
+    elif lang == "imp":
+        write_imp_mappings(mappings)
+    else:
+        print("error: unsupported language: %s" % lang, file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--lang", choices=["c++", "imp"], default="imp",
+                        help="output language")
+    parser.add_argument("rootdir",
+                        help=("Clang builtin header include root"))
+    args = parser.parse_args()
+    sys.exit(main(args.rootdir, args.lang))

--- a/tests/c/builtin_float-d1.h
+++ b/tests/c/builtin_float-d1.h
@@ -1,0 +1,10 @@
+//===--- builtin_float-d1.h - test input file for iwyu --------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include <float.h>

--- a/tests/c/builtin_float.c
+++ b/tests/c/builtin_float.c
@@ -1,0 +1,45 @@
+//===--- builtin_float.c - test input file for iwyu -----------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// The float macros live in the compiler builtin header <float.h>. This test
+// case proves we have internal mappings to sort out any private/public
+// challenges. Uses C23, since NAN is defined to live in <float.h> from that
+// point (<math.h>, not a compiler built-in, before that).
+//
+// Note that <float.h> lives in the compiler resource dir, but may delegate to a
+// system <float.h> using #include_next, so this test could fail on more exotic
+// platforms. If it does, let's remove it. We typically don't test include
+// mappings exactly because they aren't very portable.
+
+#include "tests/c/builtin_float-d1.h"
+
+// IWYU_ARGS: -std=c23 -I .
+
+static double epsilon(void) {
+  // IWYU: DBL_EPSILON is...*float.h
+  return DBL_EPSILON;
+}
+
+static int nonumber(void) {
+  // IWYU: NAN is...*float.h
+  return NAN;
+}
+
+/**** IWYU_SUMMARY
+
+tests/c/builtin_float.c should add these lines:
+#include <float.h>
+
+tests/c/builtin_float.c should remove these lines:
+- #include "tests/c/builtin_float-d1.h"  // lines XX-XX
+
+The full include-list for tests/c/builtin_float.c:
+#include <float.h>  // for DBL_EPSILON, NAN
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
Some of the compiler builtin headers have gradually been split into
private underscore-prefixed header names on the form
'__$public_$purpose.h', which maps to '$public.h'.

Add a mapping generator which does simple name translation to produce
mappings, both for C++ and .imp.

Add a new internal mapping set for the Clang compiler builtins, based on
the output from the mapping generator.

Add a testcase for C23 and float.h. This should be reasonably portable
since float.h is part of the compiler builtin headers, which have to be
available in the resource dir for Clang and IWYU to work (but note that
it #include_next's into the system float.h for some platforms, so we
could see an entirely different include tree outside of the mainstream).

Fixes #2073.