### PR TITLE
Preserve includes for function template default arguments

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -718,19 +718,8 @@ class BaseAstVisitor : public RecursiveASTVisitor<Derived> {
       return false;
     if (CanIgnoreCurrentASTNode())
       return true;
-    FunctionDecl* func = expr->getDirectCallee();
-    if (!func)
-      return true;
-    // If the call makes use of default arguments, select exactly that
-    // redeclaration which specifies the first default argument used.
-    for (unsigned i = 0, ie = expr->getNumArgs(); i < ie; ++i) {
-      if (isa<CXXDefaultArgExpr>(expr->getArg(i))) {
-        func = GetRedeclSpecifyingDefArg(i, func);
-        break;
-      }
-    }
     return this->getDerived().HandleFunctionCall(
-        func, TypeOfParentIfMethod(expr), expr);
+        expr->getDirectCallee(), TypeOfParentIfMethod(expr), expr);
   }
 
   bool TraverseUserDefinedLiteral(UserDefinedLiteral* expr) {
@@ -827,18 +816,6 @@ class BaseAstVisitor : public RecursiveASTVisitor<Derived> {
     const Type* parent_type = expr->getAllocatedType().getTypePtrOrNull();
     // 'new' calls operator new in addition to the ctor of the new-ed type.
     if (FunctionDecl* operator_new = expr->getOperatorNew()) {
-      // If the placement-new call makes use of default arguments, select
-      // exactly that redecl which specifies the first default argument used.
-      for (unsigned i = 0, ie = expr->getNumPlacementArgs(); i < ie; ++i) {
-        if (isa<CXXDefaultArgExpr>(expr->getPlacementArg(i))) {
-          // The 1st parameter is the size of the allocated type, there is not
-          // any corresponding argument.
-          CHECK_(i + 1 < operator_new->getNumParams());
-          operator_new = GetRedeclSpecifyingDefArg(i + 1, operator_new);
-          break;
-        }
-      }
-
       // If operator new is a method, it must (by the semantics of
       // per-class operator new) be a method on the class we're newing.
       const Type* op_parent = nullptr;
@@ -3172,14 +3149,27 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
     if (!callee || CanIgnoreCurrentASTNode() || CanIgnoreDecl(callee))
       return true;
 
-    HandleFnReturnOnCallSite(callee, parent_type, calling_expr);
+    FunctionDecl* default_arg_provider =
+        GetUsedDefaultArgumentProvider(callee, calling_expr);
+    const bool is_template_specialization =
+        callee->isFunctionTemplateSpecialization();
+    FunctionDecl* callee_for_use =
+        default_arg_provider && !is_template_specialization
+            ? default_arg_provider
+            : callee;
+
+    HandleFnReturnOnCallSite(callee_for_use, parent_type, calling_expr);
+    if (default_arg_provider && is_template_specialization) {
+      ReportDeclUse(CurrentLoc(), default_arg_provider, nullptr,
+                    UF_DefaultArgument);
+    }
 
     // We may have already been checked in a previous
     // VisitUnresolvedLookupExpr() call.  Don't check again in that case.
     if (IsProcessedOverloadLoc(CurrentLoc()))
       return true;
 
-    ReportDeclUse(CurrentLoc(), callee);
+    ReportDeclUse(CurrentLoc(), callee_for_use);
 
     return true;
   }
@@ -3513,6 +3503,57 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
 
  private:
   template <typename T> friend class IwyuBaseAstVisitor;
+
+  FunctionDecl* GetUsedDefaultArgumentProvider(FunctionDecl* callee,
+                                               const Expr* calling_expr) {
+    unsigned param_index = callee->getNumParams();
+    // Argument positions do not always match parameter indexes. For example,
+    // member operator calls include the implicit object argument, while a
+    // placement-new argument list omits the implicit allocation-size parameter.
+    // Use the ParmVarDecl as the source of truth.
+    if (const auto* call_expr = dyn_cast_or_null<CallExpr>(calling_expr)) {
+      for (const Expr* arg : call_expr->arguments()) {
+        const auto* default_arg = dyn_cast<CXXDefaultArgExpr>(arg);
+        if (!default_arg)
+          continue;
+
+        param_index = default_arg->getParam()->getFunctionScopeIndex();
+        break;
+      }
+    } else if (const auto* new_expr =
+                   dyn_cast_or_null<CXXNewExpr>(calling_expr)) {
+      for (const Expr* arg : new_expr->placement_arguments()) {
+        const auto* default_arg = dyn_cast<CXXDefaultArgExpr>(arg);
+        if (!default_arg)
+          continue;
+
+        param_index = default_arg->getParam()->getFunctionScopeIndex();
+        break;
+      }
+    }
+
+    if (param_index >= callee->getNumParams())
+      return nullptr;
+
+    if (callee->isFunctionTemplateSpecialization()) {
+      FunctionDecl* pattern = callee->getTemplateInstantiationPattern();
+      if (!pattern)
+        return nullptr;
+
+      // Header patterns already retain their inherited-default providers in
+      // VisitFunctionTemplateDecl. Only source patterns need the call site to
+      // report the provider.
+      if (IsInHeader(pattern))
+        return nullptr;
+
+      CHECK_(param_index < pattern->getNumParams());
+      if (!pattern->getParamDecl(param_index)->hasInheritedDefaultArg())
+        return nullptr;
+      callee = pattern;
+    }
+
+    return GetRedeclSpecifyingDefArg(param_index, callee);
+  }
 
   bool IsProcessedOverloadLoc(SourceLocation loc) const {
     return ContainsKey(visitor_state_->processed_overload_locs, loc);
@@ -5322,6 +5363,30 @@ class IwyuAstConsumer
       }
     }
     return Base::VisitFunctionDecl(decl);
+  }
+
+  bool VisitFunctionTemplateDecl(FunctionTemplateDecl* decl) {
+    if (CanIgnoreCurrentASTNode())
+      return true;
+
+    // Default function arguments for function templates can only be specified
+    // in the initial declaration. A header redeclaration with inherited
+    // defaults therefore requires the declaration that provides them.
+    FunctionDecl* function = decl->getTemplatedDecl();
+    if (!IsInHeader(function))
+      return Base::VisitFunctionTemplateDecl(decl);
+
+    for (const ParmVarDecl* param : function->parameters()) {
+      if (!param->hasInheritedDefaultArg())
+        continue;
+
+      const unsigned param_index = param->getFunctionScopeIndex();
+      ReportDeclUse(CurrentLoc(),
+                    GetRedeclSpecifyingDefArg(param_index, function), nullptr,
+                    UF_RedeclUse);
+      break;
+    }
+    return Base::VisitFunctionTemplateDecl(decl);
   }
 
   // Avoid forward-declaration warnings for types which _should_ be already

--- a/iwyu_output.cc
+++ b/iwyu_output.cc
@@ -729,15 +729,16 @@ void IwyuFileInfo::ReportFullSymbolUse(SourceLocation use_loc,
     const NamedDecl* report_decl;
     SourceLocation report_decl_loc;
 
-    if ((flags & (UF_RedeclUse | UF_ExplicitInstantiation)) == 0) {
+    if ((flags &
+         (UF_RedeclUse | UF_ExplicitInstantiation | UF_DefaultArgument)) == 0) {
       // Since we need the full symbol, we need the decl's definition-site too.
       // Also, by default we canonicalize the location, using GetLocation.
       report_decl = GetDefinitionAsWritten(decl);
       report_decl_loc = GetLocation(report_decl);
     } else {
-      // However, if a declaration is used by its own definition or we are
-      // targeting an explicit instantiation, we want to use them as-is and not
-      // try to canonicalize at all.
+      // However, if a declaration is used by its own definition, targets an
+      // explicit instantiation, or provides a used default argument, we want
+      // to use it as-is and not try to canonicalize at all.
       report_decl = decl;
       report_decl_loc = decl->getLocation();
     }
@@ -1388,6 +1389,7 @@ void ProcessFullUse(OneUse* use, const IwyuPreprocessorInfo* preprocessor_info,
   // uses so that a definition anchors all its declarations (UF_RedeclUse case).
   // Also, definition uses triggered by explicit instantiation definitions
   // should not be suppressed by any redecl (UF_InstantiationPattern case).
+  // Default-argument provider uses intentionally remain subject to this filter.
   if (!(use->flags() & (UF_RedeclUse | UF_InstantiationPattern)) &&
       !is_builtin_function_with_mappings) {
     set<const NamedDecl*> all_redecls;

--- a/iwyu_use_flags.h
+++ b/iwyu_use_flags.h
@@ -25,6 +25,9 @@ const UseFlags UF_RedeclUse = 2;
 const UseFlags UF_ExplicitInstantiation = 4;
 // Primary template definition use by an instantiation.
 const UseFlags UF_InstantiationPattern = 8;
+// Preserve the exact default-argument provider without bypassing same-file
+// suppression.
+const UseFlags UF_DefaultArgument = 16;
 }
 
 #endif

--- a/tests/cxx/fn_def_args-i1.h
+++ b/tests/cxx/fn_def_args-i1.h
@@ -20,6 +20,10 @@ void FnTplWithDefArg<float>(int) {
 }
 
 template <typename T>
+void FnTplDefinedInHeader(int) {
+}
+
+template <typename T>
 void* operator new(std::size_t, T, int) noexcept {
   return nullptr;
 }

--- a/tests/cxx/fn_def_args-i2.h
+++ b/tests/cxx/fn_def_args-i2.h
@@ -27,6 +27,21 @@ template <typename T>
 void FnTplWithDefArg(int = 0);
 
 template <typename T>
+void FnTplSourceDefault(int = 0);
+
+template <typename T>
+void FnTplSourceExplicit(int = 0);
+
+template <typename T>
+void FnTplSourceUnused(int = 0);
+
+template <typename T>
+void FnTplDefinedInHeader(int = 0);
+
+template <typename T>
 void* operator new(std::size_t, T, int = 0) noexcept;
+
+template <typename T>
+void* operator new(std::size_t, T, short, long = 0) noexcept;
 
 #endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_FN_DEF_ARGS_I2_H_

--- a/tests/cxx/fn_def_args.cc
+++ b/tests/cxx/fn_def_args.cc
@@ -9,14 +9,35 @@
 
 // IWYU_ARGS: -Xiwyu --check_also="tests/cxx/fn_def_args-d1.h" -I .
 
-// Tests handling function default arguments. In particular, tests that IWYU
-// doesn't report them when analyzing call site.
+// Tests include requirements introduced by function default arguments.
 
 #include "tests/cxx/fn_def_args-d1.h"
 
 // IWYU: FnWithSmearedDefArgs3(int, int, int) is...*-i1.h
 void FnWithSmearedDefArgs3(int = 0, int, int);
 void FnWithDefArg(int);
+
+// Source-file redeclarations do not require their inherited default arguments
+// until a call actually uses one.
+template <typename T>
+void FnTplSourceDefault(int);
+
+template <typename T>
+void FnTplSourceExplicit(int);
+
+template <typename T>
+void FnTplSourceUnused(int);
+
+template <typename T>
+void* operator new(decltype(sizeof(0)), T, short, long) noexcept;
+
+template <typename T>
+void FnTplDefinedInHeader(int);
+
+template <typename T>
+void CallFnTplDefinedInHeader() {
+  FnTplDefinedInHeader<T>();
+}
 
 template <typename T>
 void TplFn() {
@@ -68,10 +89,26 @@ void Fn() {
   FnTplWithDefArg<float>();
   // IWYU: FnTplWithDefArg(int) is...*-i1.h
   FnTplWithDefArg<float>(1);
+
+  // IWYU: FnTplSourceDefault(int) is...*fn_def_args-i2.h
+  FnTplSourceDefault<int>();
+  FnTplSourceExplicit<int>(0);
+  // IWYU: FnTplDefinedInHeader(int) is...*fn_def_args-i2.h
+  FnTplDefinedInHeader<int>();
+  // The dependent call in CallFnTplDefinedInHeader is resolved only when the
+  // wrapper is instantiated, revealing the actual definition and its provider.
+  // IWYU: FnTplDefinedInHeader(int) is...*fn_def_args-i2.h
+  CallFnTplDefinedInHeader<int>();
+
   // IWYU: operator new(unsigned long, :0, int) is...*-i1.h
   new ('a', 1) int;
   // IWYU: operator new(unsigned long, :0, int) is...*-i1.h
   new ('a') int;
+
+  // Use a separate overload to cover a source-file template redeclaration.
+  new ('a', short{}, 1L) int;
+  // IWYU: operator new(unsigned long, :0, short, long) is...*-i2.h
+  new ('a', short{}) int;
 }
 
 /**** IWYU_SUMMARY
@@ -86,7 +123,7 @@ tests/cxx/fn_def_args.cc should remove these lines:
 The full include-list for tests/cxx/fn_def_args.cc:
 #include "tests/cxx/fn_def_args-d1.h"  // for FnWithSmearedDefArgs, Struct, operator new
 #include "tests/cxx/fn_def_args-i1.h"  // for FnTplWithDefArg, FnWithSmearedDefArgs2, FnWithSmearedDefArgs3, operator new
-#include "tests/cxx/fn_def_args-i2.h"  // for FnWithDefArg, FnWithSmearedDefArgs, FnWithSmearedDefArgs2, operator new
+#include "tests/cxx/fn_def_args-i2.h"  // for FnTplDefinedInHeader, FnTplSourceDefault, FnWithDefArg, FnWithSmearedDefArgs, FnWithSmearedDefArgs2, operator new
 #include "tests/cxx/fn_def_args-i3.h"  // for FnWithSmearedDefArgs2
 
 ***** IWYU_SUMMARY */

--- a/tests/cxx/fn_def_args_tpl_redecl-d1.h
+++ b/tests/cxx/fn_def_args_tpl_redecl-d1.h
@@ -1,0 +1,12 @@
+//===--- fn_def_args_tpl_redecl-d1.h - iwyu test --------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/fn_def_args_tpl_redecl-i1.h"
+#include "tests/cxx/fn_def_args_tpl_redecl-i2.h"
+#include "tests/cxx/fn_def_args_tpl_redecl-i3.h"

--- a/tests/cxx/fn_def_args_tpl_redecl-i1.h
+++ b/tests/cxx/fn_def_args_tpl_redecl-i1.h
@@ -1,4 +1,4 @@
-//===--- 1942.h - iwyu test -----------------------------------------------===//
+//===--- fn_def_args_tpl_redecl-i1.h - iwyu test --------------------------===//
 //
 //                     The LLVM Compiler Infrastructure
 //
@@ -7,13 +7,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "f-def_arg.h"
+template <typename T>
+typename T::Internal FnTplDeclOnly(int = 0, int = 0, int = 0);
 
-template <typename>
-void f(int);
-
-/**** IWYU_SUMMARY
-
-(tests/bugs/1942/1942.h has correct #includes/fwd-decls)
-
-***** IWYU_SUMMARY */
+template <typename T>
+void FnTplNotCalled(int = 0);

--- a/tests/cxx/fn_def_args_tpl_redecl-i2.h
+++ b/tests/cxx/fn_def_args_tpl_redecl-i2.h
@@ -1,4 +1,4 @@
-//===--- 1942.cc - iwyu test ----------------------------------------------===//
+//===--- fn_def_args_tpl_redecl-i2.h - iwyu test --------------------------===//
 //
 //                     The LLVM Compiler Infrastructure
 //
@@ -7,16 +7,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// IWYU_XFAIL
+template <typename T>
+typename T::Internal FnTplDeclOnly(int, int, int);
 
-#include "1942.h"
-
-int main() {
-  f<char>();
-}
-
-/**** IWYU_SUMMARY
-
-(tests/bugs/1942/1942.cc has correct #includes/fwd-decls)
-
-***** IWYU_SUMMARY */
+template <typename T>
+void FnTplNotCalled(int);

--- a/tests/cxx/fn_def_args_tpl_redecl-i3.h
+++ b/tests/cxx/fn_def_args_tpl_redecl-i3.h
@@ -1,4 +1,4 @@
-//===--- f-def_arg.h - iwyu test ------------------------------------------===//
+//===--- fn_def_args_tpl_redecl-i3.h - iwyu test --------------------------===//
 //
 //                     The LLVM Compiler Infrastructure
 //
@@ -7,5 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-template <typename>
-void f(int = 0);
+struct TemplateArgument {
+  using Internal = int;
+};

--- a/tests/cxx/fn_def_args_tpl_redecl.cc
+++ b/tests/cxx/fn_def_args_tpl_redecl.cc
@@ -1,0 +1,31 @@
+//===--- fn_def_args_tpl_redecl.cc - iwyu test ----------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU_ARGS: -I .
+
+#include "tests/cxx/fn_def_args_tpl_redecl.h"
+
+int main() {
+  // IWYU: TemplateArgument needs a declaration
+  // IWYU: TemplateArgument is...*fn_def_args_tpl_redecl-i3.h
+  FnTplDeclOnly<TemplateArgument>();
+}
+
+/**** IWYU_SUMMARY
+
+tests/cxx/fn_def_args_tpl_redecl.cc should add these lines:
+#include "tests/cxx/fn_def_args_tpl_redecl-i3.h"
+
+tests/cxx/fn_def_args_tpl_redecl.cc should remove these lines:
+
+The full include-list for tests/cxx/fn_def_args_tpl_redecl.cc:
+#include "tests/cxx/fn_def_args_tpl_redecl.h"
+#include "tests/cxx/fn_def_args_tpl_redecl-i3.h"  // for TemplateArgument
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/fn_def_args_tpl_redecl.h
+++ b/tests/cxx/fn_def_args_tpl_redecl.h
@@ -1,0 +1,31 @@
+//===--- fn_def_args_tpl_redecl.h - iwyu test -----------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/fn_def_args_tpl_redecl-d1.h"
+
+template <typename T>
+// IWYU: FnTplDeclOnly(int, int, int) is...*fn_def_args_tpl_redecl-i1.h
+typename T::Internal FnTplDeclOnly(int, int, int);
+
+template <typename T>
+// IWYU: FnTplNotCalled(int) is...*fn_def_args_tpl_redecl-i1.h
+void FnTplNotCalled(int);
+
+/**** IWYU_SUMMARY
+
+tests/cxx/fn_def_args_tpl_redecl.h should add these lines:
+#include "tests/cxx/fn_def_args_tpl_redecl-i1.h"
+
+tests/cxx/fn_def_args_tpl_redecl.h should remove these lines:
+- #include "tests/cxx/fn_def_args_tpl_redecl-d1.h"  // lines XX-XX
+
+The full include-list for tests/cxx/fn_def_args_tpl_redecl.h:
+#include "tests/cxx/fn_def_args_tpl_redecl-i1.h"  // for FnTplDeclOnly, FnTplNotCalled
+
+***** IWYU_SUMMARY */


### PR DESCRIPTION
## Summary

- preserve the exact declaration that provides a default argument when an ordinary call, placement-new expression, or function-template specialization uses it
- keep source-file function-template redeclarations independent, while making header redeclarations retain inherited-default providers through their reusable header boundary
- unify default-provider lookup in `IwyuBaseAstVisitor` and keep the original specialization for instantiated-function analysis
- add focused regressions for issue #1942, placement new, and dependent calls resolved during nested template instantiation

## Testing

- clean LLVM 24/Ninja configure and build
- targeted `cxx.test_fn_def_args` and `cxx.test_fn_def_args_tpl_redecl` tests (2/2)
- full CTest suite (240/240)
- known-bugs suite (60 expected failures)
- stdin tests (3/3), mapping export (7 files), install smoke, and license-header check (958 files)
- clang-format on edited code lines, `git diff --check`, and IWYU dogfood (IWYU 0, fix-includes 0, zero diff)

Fixes #1942