### PR TITLE
Clarify logging slightly for satisfied uses

### DIFF
--- a/iwyu_output.cc
+++ b/iwyu_output.cc
@@ -1704,11 +1704,11 @@ void CalculateIwyuForForwardDeclareUse(
 
   // (D2) Mark iwyu violation unless defined in a current #include.
   if (dfn_from_actual_includes) {
-    VERRS(6) << "Ignoring fwd-decl use of " << use->symbol_name()
+    VERRS(6) << "Satisfied fwd-decl use of " << use->symbol_name()
              << " (" << use->PrintableUseLoc() << "): have definition at "
              << PrintableLoc(GetLocation(dfn_from_actual_includes)) << "\n";
   } else if (same_file_decl) {
-    VERRS(6) << "Ignoring fwd-decl use of " << use->symbol_name()
+    VERRS(6) << "Satisfied fwd-decl use of " << use->symbol_name()
              << " (" << use->PrintableUseLoc() << "): have earlier fwd-decl at "
              << PrintableLoc(GetLocation(same_file_decl)) << "\n";
   } else {
@@ -1776,7 +1776,7 @@ void CalculateIwyuForFullUse(OneUse* use,
 
   // (E3) Mark iwyu violation unless in a current #include.
   if (ContainsKey(actual_includes, use->suggested_header())) {
-    VERRS(6) << "Ignoring full use of " << use->symbol_name()
+    VERRS(6) << "Satisfied full use of " << use->symbol_name()
              << " (" << use->PrintableUseLoc() << "): #including dfn from "
              << use->suggested_header() << "\n";
   } else {


### PR DESCRIPTION
In cbded3f4a6c3a7b653f01560418a79b121d72a33, I went through and made inventory of all IWYU policy logs, classified them in a few groups and made the logging for each group consistent.

I overlooked that a few of the "Ignoring" logs actually do not have a corresponding use->set_ignore_use(), but instead mean the use is "ignored" because it doesn't cause an IWYU violation.

I think that really means the use is "satisfied" -- update the few instances of this to use that term to keep them separate from all the ways a use can be actually ignored.