### PR TITLE
Fix comment in `std_size_t` test

### DIFF
--- a/tests/cxx/std_size_t.cc
+++ b/tests/cxx/std_size_t.cc
@@ -7,15 +7,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// This tests a little quirk with the mappings for the new <cstd...> headers.
-// size_t is such a commonly-used type that it deserves a dedicated test to
-// demonstrate how this behaves in general. Note how the use of 'printf' is
-// attributed to <cstdio> and <stdio.h> is removed. This happens because
-// std::size_t is mapped to <cstdio> before 'printf' is seen and already-needed
-// includes take precedence if a symbol is available from multiple sources.
-//
-// (Note that if 'printf' was seen before std::size_t, <stdio.h> would still be
-// required.)
+// In this test, IWYU picks <cstdio> for printf and size_t although it is
+// not guaranteed that <c...> headers provide names from the global namespace.
 
 #include <cstdio>
 #include <stdio.h>


### PR DESCRIPTION
After 146292c5224f204166bb855ba8bf392685f92691, IWYU suggests removing `#include <stdio.h>` just because it is launched in the C++ mode.