### PR TITLE
fix_includes.py: add --always_first_include flag

### DIFF
--- a/fix_includes.py
+++ b/fix_includes.py
@@ -1536,6 +1536,7 @@ def _GetNamespaceLevelReorderSpans(file_lines):
 
 
 # These are potential 'kind' arguments to _FirstReorderSpanWith.
+_ALWAYS_FIRST_INCLUDE_KIND = 0    # e.g. #include "config.h", via a flag
 _MAIN_CU_INCLUDE_KIND = 1         # e.g. #include "foo.h" when editing foo.cc
 _C_SYSTEM_INCLUDE_KIND = 2        # e.g. #include <stdio.h>
 _CXX_SYSTEM_INCLUDE_KIND = 3      # e.g. #include <vector>
@@ -1547,11 +1548,12 @@ _EOF_KIND = 7                     # used at eof
 # The span kinds are defined in default sort order, so generate a default
 # identity mapping.
 SORT_ORDER_DEFAULT = {
-  kind: kind for kind in range(_MAIN_CU_INCLUDE_KIND, _EOF_KIND + 1)
+  kind: kind for kind in range(_ALWAYS_FIRST_INCLUDE_KIND, _EOF_KIND + 1)
 }
 
 # In quoted-first mode, we sort all quoted kinds before system kinds.
 SORT_ORDER_QUOTED_FIRST = {
+  _ALWAYS_FIRST_INCLUDE_KIND: 0,
   _MAIN_CU_INCLUDE_KIND: 1,
   _NONSYSTEM_INCLUDE_KIND: 2,
   _PROJECT_INCLUDE_KIND: 3,
@@ -1565,6 +1567,26 @@ def _IsSystemInclude(line_info):
   """Given a line-info, return true iff the line is a <>-style #include."""
   # The key for #includes includes the <> or "", so this is easy. :-)
   return line_info.type == _INCLUDE_RE and line_info.key[0] == '<'
+
+
+def _IsAlwaysFirstInclude(line_info, always_first_includes):
+  """Given a line-info, return true iff its #include is always sorted first.
+
+  Arguments:
+    line_info: a LineInfo structure with .type and .key filled in.
+    always_first_includes: a sequence of #include basenames (as given by
+       the --always_first_include flag) that should always sort before
+       every other #include, in the order they're listed.
+
+  Returns:
+    True if line_info is an #include of one of the always_first_includes
+    basenames, False else.
+  """
+  if not always_first_includes or line_info.type != _INCLUDE_RE:
+    return False
+  # .key includes the surrounding <> or "" of the #include.
+  basename = os.path.basename(line_info.key[1:-1])
+  return basename in always_first_includes
 
 
 def _IsMainCUInclude(line_info, filename):
@@ -1665,13 +1687,16 @@ def _IsSameProject(line_info, edited_file, project):
   return (included_root and edited_root and included_root == edited_root)
 
 
-def _GetLineKind(file_line, filename, separate_project_includes):
+def _GetLineKind(file_line, filename, separate_project_includes,
+                 always_first_includes):
   """Given a file_line + file being edited, return best *_KIND value or None."""
   line_without_coments = _COMMENT_RE.sub('', file_line.line)
   if file_line.deleted:
     return None
   elif _IsMainCUInclude(file_line, filename):
     return _MAIN_CU_INCLUDE_KIND
+  elif _IsAlwaysFirstInclude(file_line, always_first_includes):
+    return _ALWAYS_FIRST_INCLUDE_KIND
   elif _IsSystemInclude(file_line) and '.' in line_without_coments:
     return _C_SYSTEM_INCLUDE_KIND
   elif _IsSystemInclude(file_line):
@@ -1712,6 +1737,7 @@ def _FirstReorderSpanWith(file_lines, good_reorder_spans, kind, filename,
   *before* the using line!
 
   kind is one of the following enums, with examples:
+     _ALWAYS_FIRST_INCLUDE_KIND: #include "a.h", via --always_first_include=a.h
      _MAIN_CU_INCLUDE_KIND:    #include "foo.h" when editing foo.cc
      _C_SYSTEM_INCLUDE_KIND:   #include <stdio.h>
      _CXX_SYSTEM_INCLUDE_KIND: #include <vector>
@@ -1730,15 +1756,18 @@ def _FirstReorderSpanWith(file_lines, good_reorder_spans, kind, filename,
        This is passed to _GetLineKind (are we a main-CU #include?)
     flags: commandline flags, as parsed by argparse.  We use
        flags.separate_project_includes to sort the #includes for the
-       current project separately from other #includes.
+       current project separately from other #includes, and
+       flags.always_first_include to identify #includes that should
+       always sort first.
 
   Returns:
     A pair of line numbers, [start_line, end_line), that is the 'best'
     reorder_span in file_lines for the given kind.
   """
-  assert kind in (_MAIN_CU_INCLUDE_KIND, _C_SYSTEM_INCLUDE_KIND,
-                  _CXX_SYSTEM_INCLUDE_KIND, _NONSYSTEM_INCLUDE_KIND,
-                  _PROJECT_INCLUDE_KIND, _FORWARD_DECLARE_KIND), kind
+  assert kind in (_ALWAYS_FIRST_INCLUDE_KIND, _MAIN_CU_INCLUDE_KIND,
+                  _C_SYSTEM_INCLUDE_KIND, _CXX_SYSTEM_INCLUDE_KIND,
+                  _NONSYSTEM_INCLUDE_KIND, _PROJECT_INCLUDE_KIND,
+                  _FORWARD_DECLARE_KIND), kind
   # Figure out where the first 'contentful' line is (after the first
   # 'good' span, so we skip past header guards and the like).  Basically,
   # the first contentful line is a line not in any reorder span.
@@ -1758,7 +1787,8 @@ def _FirstReorderSpanWith(file_lines, good_reorder_spans, kind, filename,
   for reorder_span in good_reorder_spans:
     for line_number in range(*reorder_span):
       line_kind = _GetLineKind(file_lines[line_number], filename,
-                               flags.separate_project_includes)
+                               flags.separate_project_includes,
+                               flags.always_first_include)
       # Ignore forward-declares that come after 'contentful' code; we
       # never want to insert new forward-declares there.
       if (line_kind == _FORWARD_DECLARE_KIND and
@@ -1773,7 +1803,7 @@ def _FirstReorderSpanWith(file_lines, good_reorder_spans, kind, filename,
     return first_reorder_spans[kind]
 
   # Second choice: last span of the kinds above us:
-  for backup_kind in range(kind - 1, _MAIN_CU_INCLUDE_KIND - 1, -1):
+  for backup_kind in range(kind - 1, _ALWAYS_FIRST_INCLUDE_KIND - 1, -1):
     if backup_kind in last_reorder_spans:
       return last_reorder_spans[backup_kind]
 
@@ -1893,7 +1923,9 @@ def _DecoratedMoveSpanLines(iwyu_record, file_lines, move_span_lines, flags):
       in, it will be a newly created list.
     flags: commandline flags, as parsed by argparse.  We use
       flags.separate_project_includes to sort the #includes for the
-      current project separately from other #includes.
+      current project separately from other #includes, and
+      flags.always_first_include to identify #includes that should
+      always sort first, in the order given.
 
   Returns:
     A tuple (reorder_span, kind, sort_key, all_lines_as_list)
@@ -1938,7 +1970,16 @@ def _DecoratedMoveSpanLines(iwyu_record, file_lines, move_span_lines, flags):
 
   # Next figure out the kind.
   kind = _GetLineKind(firstline, iwyu_record.filename,
-                      flags.separate_project_includes)
+                      flags.separate_project_includes,
+                      flags.always_first_include)
+
+  # If this #include is one of the --always_first_include basenames,
+  # sort it according to its position in that (user-specified) list,
+  # rather than alphabetically, so multiple always-first #includes keep
+  # the relative order the user asked for.
+  if kind == _ALWAYS_FIRST_INCLUDE_KIND:
+    basename = os.path.basename(firstline.key[1:-1])
+    sort_key = '%04d' % flags.always_first_include.index(basename)
 
   # All we're left to do is the reorder-span we're in.  Hopefully it's easy.
   reorder_span = firstline.reorder_span
@@ -2467,6 +2508,16 @@ def main(argv):
                       default=False,
                       help='When sorting includes, place quoted ones first')
 
+  parser.add_argument('--always_first_include', action='append', default=[],
+                      metavar='INCLUDE_BASENAME[,INCLUDE_BASENAME,...]',
+                      help=('Basename of an #include file, e.g. "config.h",'
+                            ' that should always be sorted before every other'
+                            ' #include, regardless of --reorder or'
+                            ' --quoted_includes_first.  May be given multiple'
+                            ' times, or as a comma-separated list; #includes'
+                            ' are placed first in the order given.  By'
+                            ' default, no #include is treated specially.'))
+
   parser.add_argument('files', nargs='*', metavar='FILES')
 
   flags = parser.parse_args(argv[1:])
@@ -2474,6 +2525,15 @@ def main(argv):
     files_to_modify = set(flags.files)
   else:
     files_to_modify = None
+
+  # Flatten --always_first_include, which may be repeated and/or
+  # comma-separated, into a single ordered list of basenames.
+  flags.always_first_include = [
+      basename.strip()
+      for value in flags.always_first_include
+      for basename in value.split(',')
+      if basename.strip()
+  ]
 
   if (flags.separate_project_includes and
       not flags.separate_project_includes.startswith('<') and  # 'special' vals

--- a/fix_includes.py
+++ b/fix_includes.py
@@ -1536,6 +1536,7 @@ def _GetNamespaceLevelReorderSpans(file_lines):
 
 
 # These are potential 'kind' arguments to _FirstReorderSpanWith.
+_ALWAYS_FIRST_INCLUDE_KIND = 0    # e.g. #include "config.h", via a flag
 _MAIN_CU_INCLUDE_KIND = 1         # e.g. #include "foo.h" when editing foo.cc
 _C_SYSTEM_INCLUDE_KIND = 2        # e.g. #include <stdio.h>
 _CXX_SYSTEM_INCLUDE_KIND = 3      # e.g. #include <vector>
@@ -1547,11 +1548,12 @@ _EOF_KIND = 7                     # used at eof
 # The span kinds are defined in default sort order, so generate a default
 # identity mapping.
 SORT_ORDER_DEFAULT = {
-  kind: kind for kind in range(_MAIN_CU_INCLUDE_KIND, _EOF_KIND + 1)
+  kind: kind for kind in range(_ALWAYS_FIRST_INCLUDE_KIND, _EOF_KIND + 1)
 }
 
 # In quoted-first mode, we sort all quoted kinds before system kinds.
 SORT_ORDER_QUOTED_FIRST = {
+  _ALWAYS_FIRST_INCLUDE_KIND: 0,
   _MAIN_CU_INCLUDE_KIND: 1,
   _NONSYSTEM_INCLUDE_KIND: 2,
   _PROJECT_INCLUDE_KIND: 3,
@@ -1565,6 +1567,26 @@ def _IsSystemInclude(line_info):
   """Given a line-info, return true iff the line is a <>-style #include."""
   # The key for #includes includes the <> or "", so this is easy. :-)
   return line_info.type == _INCLUDE_RE and line_info.key[0] == '<'
+
+
+def _IsAlwaysFirstInclude(line_info, always_first_includes):
+  """Given a line-info, return true iff its #include is always sorted first.
+
+  Arguments:
+    line_info: a LineInfo structure with .type and .key filled in.
+    always_first_includes: a sequence of #include basenames (as given by
+       the --always_first_include flag) that should always sort before
+       every other #include, in the order they're listed.
+
+  Returns:
+    True if line_info is an #include of one of the always_first_includes
+    basenames, False else.
+  """
+  if not always_first_includes or line_info.type != _INCLUDE_RE:
+    return False
+  # .key includes the surrounding <> or "" of the #include.
+  basename = os.path.basename(line_info.key[1:-1])
+  return basename in always_first_includes
 
 
 def _IsMainCUInclude(line_info, filename):
@@ -1665,13 +1687,16 @@ def _IsSameProject(line_info, edited_file, project):
   return (included_root and edited_root and included_root == edited_root)
 
 
-def _GetLineKind(file_line, filename, separate_project_includes):
+def _GetLineKind(file_line, filename, separate_project_includes,
+                 always_first_includes=()):
   """Given a file_line + file being edited, return best *_KIND value or None."""
   line_without_coments = _COMMENT_RE.sub('', file_line.line)
   if file_line.deleted:
     return None
   elif _IsMainCUInclude(file_line, filename):
     return _MAIN_CU_INCLUDE_KIND
+  elif _IsAlwaysFirstInclude(file_line, always_first_includes):
+    return _ALWAYS_FIRST_INCLUDE_KIND
   elif _IsSystemInclude(file_line) and '.' in line_without_coments:
     return _C_SYSTEM_INCLUDE_KIND
   elif _IsSystemInclude(file_line):
@@ -1712,6 +1737,7 @@ def _FirstReorderSpanWith(file_lines, good_reorder_spans, kind, filename,
   *before* the using line!
 
   kind is one of the following enums, with examples:
+     _ALWAYS_FIRST_INCLUDE_KIND: #include "config.h", via a commandline flag
      _MAIN_CU_INCLUDE_KIND:    #include "foo.h" when editing foo.cc
      _C_SYSTEM_INCLUDE_KIND:   #include <stdio.h>
      _CXX_SYSTEM_INCLUDE_KIND: #include <vector>
@@ -1730,15 +1756,18 @@ def _FirstReorderSpanWith(file_lines, good_reorder_spans, kind, filename,
        This is passed to _GetLineKind (are we a main-CU #include?)
     flags: commandline flags, as parsed by argparse.  We use
        flags.separate_project_includes to sort the #includes for the
-       current project separately from other #includes.
+       current project separately from other #includes, and
+       flags.always_first_include to identify #includes that should
+       always sort first.
 
   Returns:
     A pair of line numbers, [start_line, end_line), that is the 'best'
     reorder_span in file_lines for the given kind.
   """
-  assert kind in (_MAIN_CU_INCLUDE_KIND, _C_SYSTEM_INCLUDE_KIND,
-                  _CXX_SYSTEM_INCLUDE_KIND, _NONSYSTEM_INCLUDE_KIND,
-                  _PROJECT_INCLUDE_KIND, _FORWARD_DECLARE_KIND), kind
+  assert kind in (_ALWAYS_FIRST_INCLUDE_KIND, _MAIN_CU_INCLUDE_KIND,
+                  _C_SYSTEM_INCLUDE_KIND, _CXX_SYSTEM_INCLUDE_KIND,
+                  _NONSYSTEM_INCLUDE_KIND, _PROJECT_INCLUDE_KIND,
+                  _FORWARD_DECLARE_KIND), kind
   # Figure out where the first 'contentful' line is (after the first
   # 'good' span, so we skip past header guards and the like).  Basically,
   # the first contentful line is a line not in any reorder span.
@@ -1758,7 +1787,8 @@ def _FirstReorderSpanWith(file_lines, good_reorder_spans, kind, filename,
   for reorder_span in good_reorder_spans:
     for line_number in range(*reorder_span):
       line_kind = _GetLineKind(file_lines[line_number], filename,
-                               flags.separate_project_includes)
+                               flags.separate_project_includes,
+                               flags.always_first_include)
       # Ignore forward-declares that come after 'contentful' code; we
       # never want to insert new forward-declares there.
       if (line_kind == _FORWARD_DECLARE_KIND and
@@ -1773,7 +1803,7 @@ def _FirstReorderSpanWith(file_lines, good_reorder_spans, kind, filename,
     return first_reorder_spans[kind]
 
   # Second choice: last span of the kinds above us:
-  for backup_kind in range(kind - 1, _MAIN_CU_INCLUDE_KIND - 1, -1):
+  for backup_kind in range(kind - 1, _ALWAYS_FIRST_INCLUDE_KIND - 1, -1):
     if backup_kind in last_reorder_spans:
       return last_reorder_spans[backup_kind]
 
@@ -1893,7 +1923,9 @@ def _DecoratedMoveSpanLines(iwyu_record, file_lines, move_span_lines, flags):
       in, it will be a newly created list.
     flags: commandline flags, as parsed by argparse.  We use
       flags.separate_project_includes to sort the #includes for the
-      current project separately from other #includes.
+      current project separately from other #includes, and
+      flags.always_first_include to identify #includes that should
+      always sort first, in the order given.
 
   Returns:
     A tuple (reorder_span, kind, sort_key, all_lines_as_list)
@@ -1938,7 +1970,16 @@ def _DecoratedMoveSpanLines(iwyu_record, file_lines, move_span_lines, flags):
 
   # Next figure out the kind.
   kind = _GetLineKind(firstline, iwyu_record.filename,
-                      flags.separate_project_includes)
+                      flags.separate_project_includes,
+                      flags.always_first_include)
+
+  # If this #include is one of the --always_first_include basenames,
+  # sort it according to its position in that (user-specified) list,
+  # rather than alphabetically, so multiple always-first #includes keep
+  # the relative order the user asked for.
+  if kind == _ALWAYS_FIRST_INCLUDE_KIND:
+    basename = os.path.basename(firstline.key[1:-1])
+    sort_key = '%04d' % flags.always_first_include.index(basename)
 
   # All we're left to do is the reorder-span we're in.  Hopefully it's easy.
   reorder_span = firstline.reorder_span
@@ -2467,6 +2508,16 @@ def main(argv):
                       default=False,
                       help='When sorting includes, place quoted ones first')
 
+  parser.add_argument('--always_first_include', action='append', default=[],
+                      metavar='INCLUDE_BASENAME[,INCLUDE_BASENAME,...]',
+                      help=('Basename of an #include file, e.g. "config.h",'
+                            ' that should always be sorted before every other'
+                            ' #include, regardless of --reorder or'
+                            ' --quoted_includes_first.  May be given multiple'
+                            ' times, or as a comma-separated list; #includes'
+                            ' are placed first in the order given.  By'
+                            ' default, no #include is treated specially.'))
+
   parser.add_argument('files', nargs='*', metavar='FILES')
 
   flags = parser.parse_args(argv[1:])
@@ -2474,6 +2525,15 @@ def main(argv):
     files_to_modify = set(flags.files)
   else:
     files_to_modify = None
+
+  # Flatten --always_first_include, which may be repeated and/or
+  # comma-separated, into a single ordered list of basenames.
+  flags.always_first_include = [
+      basename.strip()
+      for value in flags.always_first_include
+      for basename in value.split(',')
+      if basename.strip()
+  ]
 
   if (flags.separate_project_includes and
       not flags.separate_project_includes.startswith('<') and  # 'special' vals

--- a/fix_includes_test.py
+++ b/fix_includes_test.py
@@ -44,6 +44,7 @@ class FakeFlags(object):
     self.reorder = True
     self.basedir = None
     self.quoted_includes_first = False
+    self.always_first_include = []
 
 
 class FixIncludesBase(unittest.TestCase):
@@ -4514,6 +4515,58 @@ The full include-list for simple:
     self.RegisterFileContents({'simple': infile})
     self.flags.quoted_includes_first = True
     self.ProcessAndTest(iwyu_output, expected_num_modified_files=1)
+
+  def testAlwaysFirstInclude(self):
+    # "zconfig.h" and "aplatform.h" are deliberately *not* in alphabetical
+    # order, to verify that --always_first_include preserves the order
+    # given on the commandline rather than sorting alphabetically.
+    infile = """\
+#include <notused.h>  ///-
+#include <foo>  ///-
+#include "zzz.h"  ///-
+#include "aplatform.h"  ///-
+#include "zconfig.h"  ///-
+///+#include "zconfig.h"
+///+#include "aplatform.h"
+///+#include <foo>
+///+#include "zzz.h"
+
+int main() { return 0; }
+"""
+    iwyu_output = """\
+simple should add these lines:
+
+simple should remove these lines:
+- #include <notused.h>  // lines 1-1
+
+The full include-list for simple:
+#include <foo>
+#include "zzz.h"
+#include "aplatform.h"
+#include "zconfig.h"
+---
+"""
+    self.RegisterFileContents({'simple': infile})
+    self.flags.always_first_include = ['zconfig.h', 'aplatform.h']
+    self.ProcessAndTest(iwyu_output, expected_num_modified_files=1)
+
+  def testMainAlwaysFirstIncludeFlagParsing(self):
+    """--always_first_include accepts commas and repeats, in given order."""
+    infile = """\
+#include "c.h"
+#include "a.h"
+#include "b.h"
+
+int main() { return 0; }
+"""
+    iwyu_output = "(simple.cc has correct #includes/fwd-decls)\n"
+    self.RegisterFileContents({'simple.cc': infile})
+    fix_includes.sys.stdin = StringIO(iwyu_output)
+    fix_includes.main(['fix_includes', '--sort_only', '--reorder',
+                       '--always_first_include=b.h,a.h', 'simple.cc', '--always_first_include=c.h'])
+    self.assertEqual(['#include "b.h"\n', '#include "a.h"\n', '#include "c.h"\n', '\n',
+                      'int main() { return 0; }\n'],
+                     self.actual_after_contents)
 
   def testMainReturnsZeroWhenNothingToFixDryRun(self):
     """Test that main returns 0 when --dry_run is passed and no fixes needed."""

--- a/fix_includes_test.py
+++ b/fix_includes_test.py
@@ -44,6 +44,7 @@ class FakeFlags(object):
     self.reorder = True
     self.basedir = None
     self.quoted_includes_first = False
+    self.always_first_include = []
 
 
 class FixIncludesBase(unittest.TestCase):
@@ -4514,6 +4515,57 @@ The full include-list for simple:
     self.RegisterFileContents({'simple': infile})
     self.flags.quoted_includes_first = True
     self.ProcessAndTest(iwyu_output, expected_num_modified_files=1)
+
+  def testAlwaysFirstInclude(self):
+    # "zconfig.h" and "aplatform.h" are deliberately *not* in alphabetical
+    # order, to verify that --always_first_include preserves the order
+    # given on the commandline rather than sorting alphabetically.
+    infile = """\
+#include <notused.h>  ///-
+#include <foo>  ///-
+#include "zzz.h"  ///-
+#include "aplatform.h"  ///-
+#include "zconfig.h"  ///-
+///+#include "zconfig.h"
+///+#include "aplatform.h"
+///+#include <foo>
+///+#include "zzz.h"
+
+int main() { return 0; }
+"""
+    iwyu_output = """\
+simple should add these lines:
+
+simple should remove these lines:
+- #include <notused.h>  // lines 1-1
+
+The full include-list for simple:
+#include <foo>
+#include "zzz.h"
+#include "aplatform.h"
+#include "zconfig.h"
+---
+"""
+    self.RegisterFileContents({'simple': infile})
+    self.flags.always_first_include = ['zconfig.h', 'aplatform.h']
+    self.ProcessAndTest(iwyu_output, expected_num_modified_files=1)
+
+  def testMainAlwaysFirstIncludeFlagParsing(self):
+    """--always_first_include accepts commas and repeats, in given order."""
+    infile = """\
+#include "a.h"
+#include "b.h"
+
+int main() { return 0; }
+"""
+    iwyu_output = "(simple.cc has correct #includes/fwd-decls)\n"
+    self.RegisterFileContents({'simple.cc': infile})
+    fix_includes.sys.stdin = StringIO(iwyu_output)
+    fix_includes.main(['fix_includes', '--sort_only', '--reorder',
+                       '--always_first_include=b.h,a.h', 'simple.cc'])
+    self.assertEqual(['#include "b.h"\n', '#include "a.h"\n', '\n',
+                      'int main() { return 0; }\n'],
+                     self.actual_after_contents)
 
   def testMainReturnsZeroWhenNothingToFixDryRun(self):
     """Test that main returns 0 when --dry_run is passed and no fixes needed."""


### PR DESCRIPTION
## Summary

Add a new `--always_first_include` commandline flag to `fix_includes.py`
that lets users designate one or more `#include` basenames (e.g.
`config.h`) that must always be sorted before every other `#include`
in a file, in the order given, regardless of `--reorder` or
`--quoted_includes_first`.

This is useful for projects that have a convention of always including
a specific project-wide header first (e.g. a compatibility/portability
header, or a header that must be included before any system headers
for correctness), a common pattern in several C++ codebases.

**The flag is opt-in and defaults to an empty list, so behavior is
unchanged from before this patch when the flag is not used.**

## Usage

```
# Always sort config.h first.
fix_includes.py --reorder --always_first_include=config.h < iwyu_out.txt

# Multiple basenames, sorted first in the order given (repeatable flag
# and/or comma-separated list are both supported).
fix_includes.py --reorder --always_first_include=config.h --always_first_include=platform.h < iwyu_out.txt
fix_includes.py --reorder --always_first_include=config.h,platform.h < iwyu_out.txt
```

## Implementation

* Introduced a new `_ALWAYS_FIRST_INCLUDE_KIND` (ordinal `0`, sorting
  before `_MAIN_CU_INCLUDE_KIND`) alongside the existing `*_KIND`
  constants used by `_FirstReorderSpanWith`/`_GetLineKind`, and wired it
  into both `SORT_ORDER_DEFAULT` and `SORT_ORDER_QUOTED_FIRST`.
* Added `_IsAlwaysFirstInclude()`, which matches an `#include` line's
  basename against the (ordered) list of basenames from
  `flags.always_first_include`.
* `_GetLineKind()` now accepts an optional `always_first_includes`
  parameter and returns `_ALWAYS_FIRST_INCLUDE_KIND` for matching
  `#include` lines (checked after the existing main-CU-include check).
* `_DecoratedMoveSpanLines()` overrides the `sort_key` for
  always-first `#include`s with a zero-padded index reflecting their
  position in `flags.always_first_include`, so that multiple
  always-first `#include`s keep the relative order the user asked for
  (rather than being sorted alphabetically amongst themselves).
* `_FirstReorderSpanWith()`'s assertion and "backup kind" search range
  were extended to include the new kind.
* `main()` gained the `--always_first_include` `argparse` option
  (`action='append'`, default `[]`). Its values are flattened (each
  occurrence may itself be a comma-separated list) into a single
  ordered list of basenames stored back onto `flags.always_first_include`.

No existing behavior changes when `--always_first_include` is not
passed: with an empty list, `_IsAlwaysFirstInclude()` always returns
`False`, so `_ALWAYS_FIRST_INCLUDE_KIND` is never assigned and sorting
proceeds exactly as before.

## Testing

Per `CONTRIBUTING.md`, added test coverage to `fix_includes_test.py`:

* `FakeFlags.always_first_include` (new attribute, defaults to `[]`) so
  existing tests are unaffected.
* `testAlwaysFirstInclude`: verifies that two always-first `#include`s
  given out of alphabetical order (`zconfig.h`, `aplatform.h`) are
  sorted first, and in the exact order specified, ahead of ordinary
  system and quoted `#include`s.
* `testMainAlwaysFirstIncludeFlagParsing`: verifies `main()`'s
  commandline parsing of a comma-separated `--always_first_include`
  value, run through `--sort_only --reorder`.

Ran the full existing suite locally:

```
$ python3.11 fix_includes_test.py
----------------------------------------------------------------------
Ran 148 tests in 0.056s

OK
```

(148 = 146 pre-existing tests + 2 new tests, all passing.)

## Checklist (per CONTRIBUTING.md)

- [x] Added a test case to `fix_includes_test.py` for this
      `fix_includes.py` change.
- [x] Ran `python3.11 fix_includes_test.py` — all tests pass.
- [x] No behavior change when the new flag is not used (verified via
      the full existing test suite passing unmodified).

This work was almost all done by copilot/Sonnet 5.0.

Hope this may be useful for others,

Eric
