### PR TITLE
[ci] Pin llvm-24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
 
     env:
-      LLVM_TAG:
+      LLVM_TAG: -24
 
     steps:
       - name: Install prerequisites


### PR DESCRIPTION
The snapshot builds seem to be in an in-between state. Use llvm-24 explicitly for the master branch for now, to see if we can get builds through.