### PR TITLE
[ci] Install versioned variant of Clang snapshot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,15 +24,12 @@ jobs:
       - name: Install prerequisites
         run: |
           wget -O- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/llvm-snapshot.asc
-          sudo add-apt-repository "deb http://apt.llvm.org/noble/ llvm-toolchain-noble$LLVM_TAG main"
+          . /etc/os-release
+          REPO_NAME="deb http://apt.llvm.org/${VERSION_CODENAME} llvm-toolchain-${VERSION_CODENAME} main"
+          sudo add-apt-repository -y "${REPO_NAME}"
           sudo apt update
-          # Remove any base dist LLVM/Clang installations
-          sudo apt remove -y \
-               "libclang*" \
-               "clang*" \
-               "llvm*" \
-               "libc++*"
-          # Reinstall tagged versions
+          LLVM_TAG="${LLVM_TAG:--$(apt-cache search --names-only '^clang-[0-9]+$' | sort -V | tail -1 | cut -f1 -d" " | cut -f2 -d"-" )}"
+          echo "LLVM_TAG=${LLVM_TAG}" >> "$GITHUB_ENV"
           sudo apt install -y \
                ninja-build \
                llvm$LLVM_TAG-dev \

--- a/iwyu.cc
+++ b/iwyu.cc
@@ -123,7 +123,7 @@
 #include "clang/Basic/SourceLocation.h"
 #include "clang/Basic/SourceManager.h"
 #include "clang/Basic/Specifiers.h"
-#include "clang/Basic/TypeTraits.h"
+#include "clang/Basic/BuiltinTraits.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Lex/Preprocessor.h"
 #include "clang/Sema/Ownership.h"

--- a/iwyu.cc
+++ b/iwyu.cc
@@ -4035,10 +4035,6 @@ class InstantiatedTemplateVisitor
                           const Expr* calling_expr) {
     if (const Type* resugared_type = ResugarType(parent_type))
       parent_type = resugared_type;
-    if (callee) {
-      if (FunctionDecl* defn = callee->getDefinition())
-        callee = defn;
-    }
     if (!Base::HandleFunctionCall(callee, parent_type, calling_expr))
       return false;
     return TraverseFunctionIfInstantiatedTpl(callee, parent_type, calling_expr);

--- a/iwyu_ast_util.cc
+++ b/iwyu_ast_util.cc
@@ -98,7 +98,6 @@ using clang::EnumDecl;
 using clang::EnumType;
 using clang::ExplicitCastExpr;
 using clang::ExplicitInstantiationDecl;
-using clang::ExplicitInstantiationInfo;
 using clang::Expr;
 using clang::ExprResult;
 using clang::ExprValueKind;
@@ -1325,14 +1324,9 @@ bool IsExplicitInstantiationDefinitionAsWritten(
     const ClassTemplateSpecializationDecl* decl) {
   // When swithing instantiation declaration to definition, clang preserves
   // the 'extern' keyword location info.
-  if (decl->getSpecializationKind() ==
-      clang::TSK_ExplicitInstantiationDefinition) {
-    if (const ExplicitInstantiationInfo* info =
-            decl->getExplicitInstantiationInfo()) {
-      return info->ExternKeywordLoc.isInvalid();
-    }
-  }
-  return false;
+  return decl->getSpecializationKind() ==
+             clang::TSK_ExplicitInstantiationDefinition &&
+         decl->getExternKeywordLoc().isInvalid();
 }
 
 bool IsInInlineNamespace(const Decl* decl) {


### PR DESCRIPTION
This is an [alternative](https://github.com/include-what-you-use/include-what-you-use/pull/2085#issuecomment-5220118227) to https://github.com/include-what-you-use/include-what-you-use/pull/2085.

The unversioned snapshot metapackages on apt.llvm.org become uninstallable while the trunk major version rolls over (currently 23 -> 24; see #2085), which breaks CI on master.

Add the snapshot suite for the runner's actual codename, detect the newest clang-N available in the package index, and install the versioned packages instead. The detected `LLVM_TAG` is exported via `GITHUB_ENV` so that subsequent steps keep using it; a preset `LLVM_TAG` short-circuits the detection.

The versioned packages co-install cleanly with the toolchains shipped on the runner image, so removing the base-dist LLVM/Clang packages is no longer necessary.

As part of compatibility effort:
1.  The `TypeTraits.h` header is renamed to `BuiltinTraits.h`. See https://github.com/llvm/llvm-project/commit/6bb30c03650c9ebc816d089ea78b36a246116f07
2. The b8b7ad1aa1675d42e18cddc0cdfb881cc52497d1 commit is [reverted](https://github.com/include-what-you-use/include-what-you-use/pull/2071#issuecomment-5219444608). See https://github.com/llvm/llvm-project/commit/63e757382099c92c2f91d0f4acb7d74a84c09ef9.