### PR TITLE
[ci] Disable LLVM CMake target checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Work around broken packaging
         run: |
           # Disable CMake target checks.
-          # sudo ./iwyu-fixup-llvm-target-checks.bash "$LLVM_PREFIX"
+          sudo ./iwyu-fixup-llvm-target-checks.bash "$LLVM_PREFIX"
 
       - name: Build include-what-you-use with LLVM ${{ env.LLVM_MAJOR }}
         run: |


### PR DESCRIPTION
The APT LLVM packages are getting ready for LLVM 23 release and LLVM 24 on mainline.

A new CAS library was added in
https://github.com/llvm/llvm-project/pull/213331, and it's not yet built as part of the APT LLVM packages, so the target checks fail.

Disable them for now.