### PR TITLE
Fix fwd-decl mapping of types in inline namespaces

### DIFF
--- a/iwyu_output.cc
+++ b/iwyu_output.cc
@@ -1185,8 +1185,12 @@ void ProcessForwardDeclare(OneUse* use,
     return;
 
   // (A1) If not suitable for forward-declaration, recategorize as a full use.
+  // For classes in inline namespaces, DeclCanBeForwardDeclared returns false,
+  // but if there is a fwd-decl mapping, IWYU should report the mapped public
+  // header, so it should not recategorize the use to a full use.
   string reason;
-  if (!DeclCanBeForwardDeclared(use->decl(), &reason)) {
+  if (!DeclCanBeForwardDeclared(use->decl(), &reason) &&
+      use->public_headers().empty()) {
     VERRS(6) << "Moving " << use->symbol_name()
              << " from fwd-decl use to full use: " << reason << " ("
              << use->PrintableUseLoc() << ")\n";

--- a/tests/cxx/fwd_decl_mapping-i1.h
+++ b/tests/cxx/fwd_decl_mapping-i1.h
@@ -26,3 +26,7 @@ class MappedToD1 {};
 enum class EnumClass1 { A, B, C };
 
 enum class EnumClass2 { A, B, C };
+
+inline namespace inl {
+class ClassFromInlineNS {};
+}  // namespace inl

--- a/tests/cxx/fwd_decl_mapping.cc
+++ b/tests/cxx/fwd_decl_mapping.cc
@@ -47,12 +47,16 @@ EnumClass1 e1;
 // IWYU: EnumClass2 is...*-i14.h
 EnumClass2 e2 = EnumClass2::A;
 
+// IWYU: ClassFromInlineNS needs a declaration
+ClassFromInlineNS* cfins;
+
 /**** IWYU_SUMMARY
 
 tests/cxx/fwd_decl_mapping.cc should add these lines:
 #include "tests/cxx/fwd_decl_mapping-i10.h"
 #include "tests/cxx/fwd_decl_mapping-i12.h"
 #include "tests/cxx/fwd_decl_mapping-i14.h"
+#include "tests/cxx/fwd_decl_mapping-i16.h"
 #include "tests/cxx/fwd_decl_mapping-i2.h"
 #include "tests/cxx/fwd_decl_mapping-i4.h"
 #include "tests/cxx/fwd_decl_mapping-i6.h"
@@ -65,6 +69,7 @@ The full include-list for tests/cxx/fwd_decl_mapping.cc:
 #include "tests/cxx/fwd_decl_mapping-i10.h"  // for FwdDeclInTwoHeaders2 (ptr only)
 #include "tests/cxx/fwd_decl_mapping-i12.h"  // for EnumClass1 (ptr only)
 #include "tests/cxx/fwd_decl_mapping-i14.h"  // for EnumClass2
+#include "tests/cxx/fwd_decl_mapping-i16.h"  // for ClassFromInlineNS (ptr only)
 #include "tests/cxx/fwd_decl_mapping-i2.h"  // for OnlyFwdDeclUse (ptr only)
 #include "tests/cxx/fwd_decl_mapping-i4.h"  // for FwdDeclAndFullUse
 #include "tests/cxx/fwd_decl_mapping-i6.h"  // for FwdDeclInI6 (ptr only), FwdDeclInTwoHeaders1 (ptr only), HasIncludeMapping (ptr only)

--- a/tests/cxx/fwd_decl_mapping.imp
+++ b/tests/cxx/fwd_decl_mapping.imp
@@ -15,4 +15,6 @@
   { "symbol": ["EnumClass1", "fwd-decl", "\"tests/cxx/fwd_decl_mapping-i12.h\"", "public"] },
   { "symbol": ["EnumClass2", "fwd-decl", "\"tests/cxx/fwd_decl_mapping-i13.h\"", "public"] },
   { "symbol": ["EnumClass2", "full", "\"tests/cxx/fwd_decl_mapping-i14.h\"", "public"] },
+  { "symbol": ["ClassFromInlineNS", "full", "\"tests/cxx/fwd_decl_mapping-i15.h\"", "public"] },
+  { "symbol": ["ClassFromInlineNS", "fwd-decl", "\"tests/cxx/fwd_decl_mapping-i16.h\"", "public"] },
 ]


### PR DESCRIPTION
This fixes the issue described in https://github.com/include-what-you-use/include-what-you-use/issues/988#issuecomment-5184227261.

There still remains a bug that the export pragma doesn't work with forward-declarations in inline namespaces.