### PR TITLE
Report fwd-decl used by qualified class-head-name

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -1600,7 +1600,8 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
   // with the warning message that iwyu emits.
   virtual void ReportDeclForwardDeclareUse(SourceLocation used_loc,
                                            const NamedDecl* used_decl,
-                                           const char* comment = nullptr) {
+                                           const char* comment = nullptr,
+                                           UseFlags extra_use_flags = 0) {
     const NamedDecl* target_decl = used_decl;
 
     // Sometimes a shadow decl comes between us and the 'real' decl.
@@ -1614,7 +1615,7 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
     if (CanIgnoreDecl(target_decl))
       return;
 
-    UseFlags use_flags = ComputeUseFlags(current_ast_node());
+    UseFlags use_flags = ComputeUseFlags(current_ast_node()) | extra_use_flags;
 
     // Canonicalize the use location and report the use.
     used_loc = GetCanonicalUseLocation(used_loc, target_decl);
@@ -4035,8 +4036,10 @@ class InstantiatedTemplateVisitor
     }
   }
 
-  void ReportDeclForwardDeclareUse(SourceLocation, const NamedDecl*,
-                                   const char* /*comment*/ = nullptr) override {
+  void ReportDeclForwardDeclareUse(SourceLocation,
+                                   const NamedDecl*,
+                                   const char* /*comment*/ = nullptr,
+                                   UseFlags /*extra_use_flags*/ = 0) override {
     // Forward declarations make sense only when a type is explicitly written.
     // But 'InstantiatedTemplateVisitor' is to traverse implicit template
     // specializations, actually. (Template definitions and explicit
@@ -5141,6 +5144,13 @@ class IwyuAstConsumer
       preprocessor_info().FileInfoFor(CurrentFileEntry())->AddForwardDeclare(
           decl_to_fwd_declare, definitely_keep_fwd_decl);
     }
+    // If class-head-name of the definition has a nested-name-specifier, like
+    // 'class ns::C {};', IWYU should report that a forward-declaration is
+    // required before such definition. At least one should already be present
+    // somewhere, otherwise the code would not compile.
+    if (decl->getQualifier())
+      ReportDeclForwardDeclareUse(CurrentLoc(), decl->getPreviousDecl(),
+                                  nullptr, UF_RedeclUse);
     return Base::VisitTagDecl(decl);
   }
 

--- a/iwyu_output.cc
+++ b/iwyu_output.cc
@@ -884,6 +884,11 @@ bool DeclCanBeForwardDeclared(const Decl* decl) {
   return DeclCanBeForwardDeclared(decl, &reason);
 }
 
+bool SameClassDeclUsedInMethod(const Decl* decl, const OneUse& use) {
+  return DeclsAreInSameClass(decl, use.decl()) && !decl->isOutOfLine() &&
+         (use.flags() & UF_InCxxMethodBody);
+}
+
 // Helper to tell whether a forward-declare use is 'preceded' by a
 // declaration inside the same file.  'Preceded' is in quotes, because
 // it's actually ok if the declaration follows the use, inside a
@@ -901,8 +906,7 @@ bool DeclIsVisibleToUseInSameFile(const Decl* decl, const OneUse& use) {
   // method.
   return (IsBeforeInSameFile(decl, use.use_loc()) ||
           GetLocation(decl) == use.use_loc() ||
-          (DeclsAreInSameClass(decl, use.decl()) && !decl->isOutOfLine() &&
-           (use.flags() & UF_InCxxMethodBody)));
+          SameClassDeclUsedInMethod(decl, use));
 }
 
 // This makes a best-effort attempt to find the smallest set of
@@ -1279,17 +1283,19 @@ void ProcessForwardDeclare(OneUse* use,
   // (A6) If a definition exists earlier in this file, discard this use.
   // Note: for the 'earlier' checks, what matters is the *instantiation*
   // location.
-  const set<const NamedDecl*> redecls = GetTagRedecls(tag_decl);
-  for (const NamedDecl* redecl : redecls) {
-    CHECK_(isa<TagDecl>(redecl) && "GetTagRedecls has redecls of wrong type");
-    const SourceLocation defined_loc = GetLocation(redecl);
-    if (cast<TagDecl>(redecl)->isCompleteDefinition() &&
-        DeclIsVisibleToUseInSameFile(redecl, *use)) {
-      VERRS(6) << "Ignoring fwd-decl use of " << use->symbol_name() << " ("
-               << use->PrintableUseLoc()
-               << "): dfn is present: " << PrintableLoc(defined_loc) << "\n";
-      use->set_ignore_use();
-      return;
+  if (!(use->flags() & UF_RedeclUse)) {
+    const set<const NamedDecl*> redecls = GetTagRedecls(tag_decl);
+    for (const NamedDecl* redecl : redecls) {
+      CHECK_(isa<TagDecl>(redecl) && "GetTagRedecls has redecls of wrong type");
+      const SourceLocation defined_loc = GetLocation(redecl);
+      if (cast<TagDecl>(redecl)->isCompleteDefinition() &&
+          DeclIsVisibleToUseInSameFile(redecl, *use)) {
+        VERRS(6) << "Ignoring fwd-decl use of " << use->symbol_name() << " ("
+                 << use->PrintableUseLoc()
+                 << "): dfn is present: " << PrintableLoc(defined_loc) << "\n";
+        use->set_ignore_use();
+        return;
+      }
     }
   }
 
@@ -1682,7 +1688,8 @@ void CalculateIwyuForForwardDeclareUse(
   // in the same file as the use (and before it).
   const set<const NamedDecl*>& redecls = GetTagRedecls(tag_decl);
   for (const NamedDecl* redecl : redecls) {
-    if (DeclIsVisibleToUseInSameFile(redecl, *use)) {
+    if (IsBeforeInSameFile(redecl, use->use_loc()) ||
+        SameClassDeclUsedInMethod(redecl, *use)) {
       same_file_decl = redecl;
       break;
     }

--- a/tests/cxx/defn_is_use-namespace.h
+++ b/tests/cxx/defn_is_use-namespace.h
@@ -13,6 +13,9 @@
 namespace ns1 {
 namespace ns2 {
   void Foo();
+
+  class ClassInNs2;
+  class Class2InNs2;
 }
 }
 

--- a/tests/cxx/defn_is_use.cc
+++ b/tests/cxx/defn_is_use.cc
@@ -7,6 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "defn_is_use.h"
 #include "defn_is_use-decl.h"
 #include "defn_is_use-namespace.h"
 
@@ -16,8 +17,36 @@ void ns1::ns2::Foo() {
 void SomeFunction() {
 }
 
+// IWYU should keep these forward-declarations because they are needed
+// to compile the definitions below.
+namespace ns1 {
+class ClassInNs1;
+enum class EnumInNs1;
+}  // namespace ns1
+
+class ns1::ClassInNs1 {};
+enum class ns1::EnumInNs1 {};
+
+// IWYU should suggest adding a forward-declaration of ClassInNs2.
+// IWYU: ns1::ns2::ClassInNs2 needs a declaration
+class ns1::ns2::ClassInNs2 {};
+
+// The associated header already has a fwd-decl. No need in another one here.
+class ns1::ns2::Class2InNs2 {};
+
 /**** IWYU_SUMMARY
 
-(tests/cxx/defn_is_use.cc has correct #includes/fwd-decls)
+tests/cxx/defn_is_use.cc should add these lines:
+namespace ns1 { namespace ns2 { class ClassInNs2; } }
+
+tests/cxx/defn_is_use.cc should remove these lines:
+
+The full include-list for tests/cxx/defn_is_use.cc:
+#include "defn_is_use.h"
+#include "defn_is_use-decl.h"  // for SomeFunction
+#include "defn_is_use-namespace.h"  // for Foo
+namespace ns1 { class ClassInNs1; }  // lines XX-XX
+namespace ns1 { enum class EnumInNs1; }  // lines XX-XX
+namespace ns1 { namespace ns2 { class ClassInNs2; } }
 
 ***** IWYU_SUMMARY */

--- a/tests/cxx/defn_is_use.h
+++ b/tests/cxx/defn_is_use.h
@@ -1,4 +1,4 @@
-//===--- 1573.cc - iwyu test ----------------------------------------------===//
+//===--- defn_is_use.h - test input file for iwyu -------------------------===//
 //
 //                     The LLVM Compiler Infrastructure
 //
@@ -7,18 +7,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-// IWYU_XFAIL
-
-namespace foo {
-struct Bar;
+namespace ns1::ns2 {
+class Class2InNs2;
 }
 
-struct foo::Bar {
-  void frombulate();
-};
+extern ns1::ns2::Class2InNs2 c2ns2;
 
 /**** IWYU_SUMMARY
 
-(tests/bugs/1573/1573.cc has correct #includes/fwd-decls)
+(tests/cxx/defn_is_use.h has correct #includes/fwd-decls)
 
 ***** IWYU_SUMMARY */

--- a/tests/cxx/fwd_decl_nested_class.cc
+++ b/tests/cxx/fwd_decl_nested_class.cc
@@ -35,6 +35,7 @@ class Foo {
   // declaration/definition is needed.
   void Bar1() {
     UsedAsPtrInMethod* x;
+    FwdDeclAfterUsage* y;
   }
   void Bar2() {
     UsedFullyInMethod x;
@@ -66,6 +67,7 @@ class Foo {
   class UsedAsPtrMember { };
   struct UsedFullyInMethodNotForwardDeclared { };
   class UsedAsFriend { };
+  class FwdDeclAfterUsage;
 
   UsedFullyInInitializer init_;
   UsedImplicitlyInInitializer implicit_;
@@ -100,6 +102,7 @@ class Outer {
   // declaration/definition is needed.
   void Bar1() {
     UsedAsPtrInMethod<int>* x;
+    FwdDeclAfterUsage<int>* y;
   }
   void Bar2() {
     UsedFullyInMethod<int> x;
@@ -129,6 +132,7 @@ class Outer {
   template<typename T> class UsedAsPtrMember { };
   template<typename T> class UsedFullyInMethodNotForwardDeclared { };
   template<typename T> class UsedAsFriend { };
+  template<typename T> class FwdDeclAfterUsage;
 
   UsedFullyInInitializer<int> init_;
   UsedImplicitlyInInitializer<int> implicit_;
@@ -163,6 +167,7 @@ class Container {
   // declaration/definition is needed.
   void Bar1() {
     UsedAsPtrInMethod* x;
+    FwdDeclAfterUsage* y;
   }
   void Bar2() {
     UsedFullyInMethod x;
@@ -192,6 +197,7 @@ class Container {
   class UsedAsPtrMember { };
   class UsedFullyInMethodNotForwardDeclared { };
   class UsedAsFriend { };
+  class FwdDeclAfterUsage;
 
   UsedFullyInInitializer init_;
   UsedImplicitlyInInitializer implicit_;
@@ -222,17 +228,20 @@ tests/cxx/fwd_decl_nested_class.cc should remove these lines:
 - template <typename T> class Outer::UsedImplicitlyInInitializer;  // lines XX-XX
 
 The full include-list for tests/cxx/fwd_decl_nested_class.cc:
+class Container::FwdDeclAfterUsage;  // lines XX-XX
 class Container::UsedAsFriend;  // lines XX-XX
 class Container::UsedAsPtrArg;  // lines XX-XX
 class Container::UsedAsPtrMember;  // lines XX-XX
 class Container::UsedAsPtrReturn;  // lines XX-XX
 class Container::UsedInTypedef;  // lines XX-XX
+class Foo::FwdDeclAfterUsage;  // lines XX-XX
 class Foo::NoUsageDefinedOutOfLine;  // lines XX-XX
 class Foo::UsedAsFriend;  // lines XX-XX
 class Foo::UsedAsPtrArg;  // lines XX-XX
 class Foo::UsedAsPtrMember;  // lines XX-XX
 class Foo::UsedAsPtrReturn;  // lines XX-XX
 class Foo::UsedInTypedef;  // lines XX-XX
+template <typename T> class Outer::FwdDeclAfterUsage;  // lines XX-XX
 template <typename T> class Outer::NoUsageDefinedOutOfLine;  // lines XX-XX
 template <typename T> class Outer::UsedAsFriend;  // lines XX-XX
 template <typename T> class Outer::UsedAsPtrArg;  // lines XX-XX


### PR DESCRIPTION
Constructs like
```cpp
namespace ns {
class C;
}
class ns::C {};
```
require the forward-declaration prior to the definition.

A6 step should be skipped because `DeclIsVisibleToUseInSameFile` returns true not only when the definition is before the use but also when their locations coincide, and that is the case here.

This fixes #1573.