### PR TITLE
Avoid re-export policy for decls in source files

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -1522,8 +1522,6 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
               GetFileEntry(call_expr), GetFileEntry(*fn_redecl))) {
         continue;
       }
-      if (fn_redecl->isThisDeclarationADefinition() && !IsInHeader(*fn_redecl))
-        continue;
       for (const Type* type : autocast_types) {
         const set<const Type*> components =
             GetProvidedTypes(type, GetLocation(*fn_redecl));
@@ -3473,6 +3471,9 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
           continue;
         }
       }
+      // Source file declarations should not provide more than actually needed.
+      if (!IsInHeader(loc))
+        continue;
       const Type* canonical = GetCanonicalType(component);
       if (!CodeAuthorWantsJustAForwardDeclare(canonical, loc))
         retval.insert(canonical);
@@ -5337,7 +5338,9 @@ class IwyuAstConsumer
   // This is called from Traverse*() because Visit*()
   // can't call HandleFunctionCall().
   bool HandleAliasedClassMethods(TypedefNameDecl* decl) {
-    if (CanIgnoreCurrentASTNode())
+    // If a typedef is defined in a source file (as opposed to headers), it is
+    // already known how it is used. Providing more than needed makes no sense.
+    if (CanIgnoreCurrentASTNode() || !IsInHeader(decl))
       return true;
 
     const Type* underlying_type = decl->getUnderlyingType().getTypePtr();
@@ -5920,6 +5923,11 @@ class IwyuAstConsumer
 
   void CollectProvidedByDefaultTplArg(SourceLocation template_loc,
                                       TemplateInstantiationData* data) const {
+    // Only declarations in headers can provide. In source files, it is already
+    // known how the template is used, hence default arguments should be
+    // reported at instantiation sites if actually needed.
+    if (!IsInHeader(template_loc))
+      return;
     for (auto [canonical, sugared] : data->resugar_map) {
       if (!sugared) {  // This designates a default argument.
         if (const NamedDecl* decl =
@@ -6004,15 +6012,18 @@ class IwyuAstConsumer
 
   pair<bool, const char*> CanBeProvidedTypeComponent(
       const ASTNode* node) const {
+    // No point in author-intent analysis in source files or for builtins.
+    if (!IsInHeader(node->GetLocation()))
+      return pair(false, nullptr);
+
     if (node->HasAncestorOfType<TypedefNameDecl>() ||
         node->HasAncestorOfType<TemplateTypeParmDecl>()) {
       return pair(true, nullptr);
     }
 
     if (const FunctionDecl* decl = node->GetAncestorAs<FunctionDecl>()) {
-      // No point in author-intent analysis of function definitions
-      // in source files, or for builtins, or for friend declarations.
-      if (!IsInHeader(decl) || IsFriendDecl(decl))
+      // No point in author-intent analysis for friend function declarations.
+      if (IsFriendDecl(decl))
         return pair(false, nullptr);
       if (const auto* method = dyn_cast<CXXMethodDecl>(decl)) {
         // Only the primary (least derived) declaration can provide types.

--- a/tests/c/elaborated_struct-d2.h
+++ b/tests/c/elaborated_struct-d2.h
@@ -9,6 +9,13 @@
 
 typedef struct Struct Typedef;
 
+// Similar to LocalStructAlias.
+typedef struct HeaderStruct HeaderStructAlias;
+struct HeaderStruct {
+  int x;
+  HeaderStructAlias* next;
+};
+
 /**** IWYU_SUMMARY
 
 (tests/c/elaborated_struct-d2.h has correct #includes/fwd-decls)

--- a/tests/cxx/alias_template.cc
+++ b/tests/cxx/alias_template.cc
@@ -11,6 +11,7 @@
 
 // Tests alias templates.  Does not test type aliases.
 
+#include "tests/cxx/alias_template.h"
 #include "tests/cxx/direct.h"
 
 template <typename T>
@@ -24,10 +25,17 @@ constexpr auto s = sizeof(ic);
 // IWYU: IndirectClass needs a declaration
 Identity<IndirectClass>* pic = nullptr;
 
-// IWYU: IndirectClass is...*indirect.h
-using Providing = IndirectClass;
+Identity<Providing> type_is_provided_by_arg_1;
 
-Identity<Providing> type_is_provided_by_arg;
+// IWYU: IndirectClass needs a declaration
+// IWYU: IndirectClass is...*indirect.h
+HeaderIdentity<IndirectClass> hic;
+// IWYU: IndirectClass is...*indirect.h
+constexpr auto hs = sizeof(hic);
+// IWYU: IndirectClass needs a declaration
+HeaderIdentity<IndirectClass>* hpic = nullptr;
+
+HeaderIdentity<Providing> type_is_provided_by_arg_2;
 
 template<class T> struct FullUseTemplateArgInSizeof {
   char argument[sizeof(T)];
@@ -39,6 +47,9 @@ template<class T> using Alias = FullUseTemplateArgInSizeof<T>;
 // IWYU: IndirectClass needs a declaration
 // IWYU: IndirectClass is...*indirect.h
 Alias<IndirectClass> alias;
+// IWYU: IndirectClass needs a declaration
+// IWYU: IndirectClass is...*indirect.h
+HeaderAlias<IndirectClass> headerAlias;
 
 // Test following through entire chain of aliases.
 template<class T> using AliasChain1 = FullUseTemplateArgInSizeof<T>;
@@ -46,10 +57,14 @@ template<class T> using AliasChain2 = AliasChain1<T>;
 // IWYU: IndirectClass needs a declaration
 // IWYU: IndirectClass is...*indirect.h
 AliasChain2<IndirectClass> aliasChain;
+// IWYU: IndirectClass needs a declaration
+// IWYU: IndirectClass is...*indirect.h
+HeaderAliasChain2<IndirectClass> headerAliasChain;
 
 // Test the case when aliased type isn't a template specialization.
 template<class T> using Pointer = T*;
 Pointer<int> intPtr;
+HeaderPointer<int> headerIntPtr;
 
 template <class T>
 struct FullUseTemplateArgAsVar {
@@ -64,11 +79,18 @@ using AliasNested = FullUseTemplateArgAsVar<FullUseTemplateArgAsVar<T>>;
 // IWYU: IndirectClass is...*indirect.h
 AliasNested<IndirectClass> aliasNested;
 
+// IWYU: IndirectClass needs a declaration
+// IWYU: IndirectClass is...*indirect.h
+HeaderAliasNested<IndirectClass> headerAliasNested;
+
 template <typename T>
 using AliasNested2 = FullUseTemplateArgInSizeof<FullUseTemplateArgInSizeof<T>>;
 // IWYU: IndirectClass needs a declaration
 // IWYU: IndirectClass is...*indirect.h
 AliasNested2<IndirectClass> aliasNested2;
+// IWYU: IndirectClass needs a declaration
+// IWYU: IndirectClass is...*indirect.h
+HeaderAliasNested2<IndirectClass> headerAliasNested2;
 
 template <typename T>
 using UsingArgInternals = decltype(T::a);
@@ -81,6 +103,14 @@ UsingArgInternals<IndirectClass> aliased_int;
 // IWYU: IndirectClass is...*indirect.h
 UsingArgInternals<IndirectClass>* p_int = nullptr;
 
+// IWYU: IndirectClass needs a declaration
+// IWYU: IndirectClass is...*indirect.h
+HeaderUsingArgInternals<IndirectClass> header_aliased_int;
+// Full type is needed even in fwd-decl context.
+// IWYU: IndirectClass needs a declaration
+// IWYU: IndirectClass is...*indirect.h
+HeaderUsingArgInternals<IndirectClass>* header_p_int = nullptr;
+
 template <typename T>
 struct TplWithUsingArgInternals {
   UsingArgInternals<T>* p = nullptr;
@@ -91,6 +121,15 @@ struct TplWithUsingArgInternals {
 TplWithUsingArgInternals<IndirectClass> twuai;
 
 template <typename T>
+struct TplWithHeaderUsingArgInternals {
+  HeaderUsingArgInternals<T>* p = nullptr;
+};
+
+// IWYU: IndirectClass needs a declaration
+// IWYU: IndirectClass is...*indirect.h
+TplWithHeaderUsingArgInternals<IndirectClass> twhuai;
+
+template <typename T>
 void TakeByCopyInTplFn(T);
 
 void TestProvisionByTplArg() {
@@ -99,21 +138,27 @@ void TestProvisionByTplArg() {
   Identity<IndirectClass> iic;
   // IWYU: IndirectClass is...*indirect.h
   TakeByCopyInTplFn(iic);
+  // IWYU: IndirectClass needs a declaration
+  // IWYU: IndirectClass is...*indirect.h
+  HeaderIdentity<IndirectClass> hiic;
+  // IWYU: IndirectClass is...*indirect.h
+  TakeByCopyInTplFn(hiic);
 
-  Identity<Providing> ip;
   // Test collecting provided types for SourceOrTargetTypeIsProvided function.
+  Identity<Providing> ip;
   TakeByCopyInTplFn(ip);
+  HeaderIdentity<Providing> hip;
+  TakeByCopyInTplFn(hip);
 }
 
 /**** IWYU_SUMMARY
 
 tests/cxx/alias_template.cc should add these lines:
-#include "tests/cxx/indirect.h"
 
 tests/cxx/alias_template.cc should remove these lines:
 - #include "tests/cxx/direct.h"  // lines XX-XX
 
 The full include-list for tests/cxx/alias_template.cc:
-#include "tests/cxx/indirect.h"  // for IndirectClass
+#include "tests/cxx/alias_template.h"
 
 ***** IWYU_SUMMARY */

--- a/tests/cxx/alias_template.h
+++ b/tests/cxx/alias_template.h
@@ -1,0 +1,70 @@
+//===--- alias_template.h - test input file for iwyu ----------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/direct.h"
+
+// Some declarations from alias_template.cc have been duplicated here to test
+// alias templates with a different provision policy (only header declarations
+// can provide).
+
+template <typename T>
+using HeaderIdentity = T;
+
+// IWYU: IndirectClass is...*indirect.h
+using Providing = IndirectClass;
+
+template <class T>
+struct HeaderFullUseTemplateArgInSizeof {
+  char argument[sizeof(T)];
+};
+
+// Test that we go through alias template and handle aliased template
+// specialization.
+template <class T>
+using HeaderAlias = HeaderFullUseTemplateArgInSizeof<T>;
+
+// Test following through entire chain of aliases.
+template <class T>
+using HeaderAliasChain1 = HeaderFullUseTemplateArgInSizeof<T>;
+template <class T>
+using HeaderAliasChain2 = HeaderAliasChain1<T>;
+
+// Test the case when aliased type isn't a template specialization.
+template <class T>
+using HeaderPointer = T*;
+
+template <class T>
+struct HeaderFullUseTemplateArgAsVar {
+  T t;
+};
+
+// Test the used class being nested deeper in the alias
+template <typename T>
+using HeaderAliasNested =
+    HeaderFullUseTemplateArgAsVar<HeaderFullUseTemplateArgAsVar<T>>;
+
+template <typename T>
+using HeaderAliasNested2 =
+    HeaderFullUseTemplateArgInSizeof<HeaderFullUseTemplateArgInSizeof<T>>;
+
+template <typename T>
+using HeaderUsingArgInternals = decltype(T::a);
+
+/**** IWYU_SUMMARY
+
+tests/cxx/alias_template.h should add these lines:
+#include "tests/cxx/indirect.h"
+
+tests/cxx/alias_template.h should remove these lines:
+- #include "tests/cxx/direct.h"  // lines XX-XX
+
+The full include-list for tests/cxx/alias_template.h:
+#include "tests/cxx/indirect.h"  // for IndirectClass
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/anonymous_struct.cc
+++ b/tests/cxx/anonymous_struct.cc
@@ -7,7 +7,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+// IWYU_ARGS: -I .
+
 // Tests that anonymous structs, unions, and enums don't cause iwyu problems.
+
+#include "tests/cxx/anonymous_struct.h"
 
 union {
   int x;
@@ -71,6 +75,11 @@ typedef_union tu;
 typedef_struct ts;
 typedef_struct_with_label tswl;
 typedef_enum te;
+
+header_typedef_union htu;
+header_typedef_struct hts;
+header_typedef_struct_with_label htswl;
+header_typedef_enum hte;
 
 // Unnamed struct field should not cause a warning.
 

--- a/tests/cxx/anonymous_struct.h
+++ b/tests/cxx/anonymous_struct.h
@@ -1,0 +1,31 @@
+//===--- anonymous_struct.h - test input file for iwyu --------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+typedef union {
+  int tu;
+  int ty;
+} header_typedef_union;
+
+typedef struct {
+  int ta;
+  int tb;
+} header_typedef_struct;
+
+typedef struct header_typedef_struct_with_label {
+  int td1;
+  int td2;
+} header_typedef_struct_with_label;
+
+typedef enum { TA_Header, TB_Header } header_typedef_enum;
+
+/**** IWYU_SUMMARY
+
+(tests/cxx/anonymous_struct.h has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/avoids_double_specialization.cc
+++ b/tests/cxx/avoids_double_specialization.cc
@@ -7,6 +7,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+// IWYU_ARGS: -I .
+
 // This tests a bug I had that was causing a class to get explicitly
 // instantiated twice.  iwyu explicitly instantiates typedefed
 // classes, but it's supposed to have a check that avoids doing it
@@ -14,6 +16,8 @@
 // before: the instantiated visitor and the normal visitor were each
 // keeping separate values.  Hence this test tests two typedefs of the
 // same thing: one in a template and one outside it.
+
+#include "tests/cxx/avoids_double_specialization.h"
 
 template<class T> struct Foo {
   static int statici;

--- a/tests/cxx/avoids_double_specialization.h
+++ b/tests/cxx/avoids_double_specialization.h
@@ -1,0 +1,34 @@
+//===--- avoids_double_specialization.h - test input file for iwyu --------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// The same as in the associated .cc-file. Typedefs may behave differently in
+// source and header files.
+
+template <class T>
+struct HeaderFoo {
+  static int statici;
+};
+template <class T>
+int HeaderFoo<T>::statici = 0;
+
+template <class T>
+struct HeaderBar {
+  typedef HeaderFoo<T> value;
+};
+
+inline HeaderFoo<float> implicit_header_foo;
+typedef HeaderFoo<float> HeaderBaz;
+
+inline HeaderBar<float> implicit_header_bar;
+
+/**** IWYU_SUMMARY
+
+(tests/cxx/avoids_double_specialization.h has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/badinc-d5.h
+++ b/tests/cxx/badinc-d5.h
@@ -1,0 +1,131 @@
+//===--- badinc-d5.h - test input file for iwyu ---------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_BADINC_D5_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_BADINC_D5_H_
+
+#include "tests/cxx/badinc-d1.h"
+#include "tests/cxx/badinc-d2.h"
+#include <string>
+
+// Some declarations from badinc.cc have been duplicated here to test them with
+// a different provision policy (only header declarations can provide).
+
+// The generic D5_OperateOn, but each specialization needs to define its own.
+template <class T>
+class D5_OperateOn {};
+
+// D5_OperateOn isn't checked for IWYU violations until it's instantiated.
+template <class T, class Functor = D5_OperateOn<T> >
+class D5_TemplateStructHelper {
+ public:
+  void a() {
+    Functor f;
+    (void)f;
+  }
+};
+
+// To make this example as much like hash_set<> as possible, the outer
+// class is really just a container around the class that does work.
+template <class T, class Functor = D5_OperateOn<T> >
+class D5_TemplateStruct {
+ private:
+  typedef D5_TemplateStructHelper<T, Functor> _TS;
+  _TS ts;
+
+ public:
+  void a() {
+    return ts.a();
+  }
+};
+
+typedef std::string D5_string;  // Nobody should use this.
+// IWYU: I1_Class is...*badinc-i1.h
+typedef I1_Class D5_typedef;
+// IWYU: kI1ConstInt is...*badinc-i1.h
+// IWYU: I1_Class is...*badinc-i1.h
+typedef I1_Class D5_typedef_array[kI1ConstInt];
+// We need the full definition of template types (I1_TemplateClass in
+// this case) since we're re-exporting them.  Note we need a full
+// definition even of I2_Class, since we don't know if clients will be
+// using the no-arg Cc_tpl_typedef ctor, which requires the full
+// definition of I2_Class.
+// IWYU: I1_TemplateClass is...*badinc-i1.h...*#included.
+// IWYU: I1_Class is...*badinc-i1.h
+// IWYU: I2_Class is...*badinc-i2.h
+// IWYU: I2_Class::~I2_Class() is...*badinc-i2-inl.h
+typedef I1_TemplateClass<I1_TemplateClass<I1_Class, I2_Class> > D5_tpl_typedef;
+inline void Instantiate_I1_TemplateClass() {
+  // TODO(csilvers): it would be nice to be able to take this line out and
+  // still have the above tests pass:
+  // TODO(bolshakov): figure out how to determine at the use site that a typedef
+  // provides not only the types but also the member functions.
+  // IWYU: I2_Class::~I2_Class() is...*badinc-i2-inl.h
+  D5_tpl_typedef d5_tpl_typedef;
+}
+// IWYU: I2_Class is...*badinc-i2.h
+// IWYU: I2_Class::I2_Class({{.*}}) is...*badinc-i2-inl.h
+// IWYU: I2_Class::~I2_Class() is...*badinc-i2-inl.h
+// IWYU: I2_Class::InlFileFn({{.*}}) is...*badinc-i2-inl.h
+// IWYU: I2_Class::InlFileTemplateFn({{.*}}) is...*badinc-i2-inl.h
+// IWYU: I2_Class::InlFileStaticFn({{.*}}) is...*badinc-i2-inl.h
+typedef I2_Class D5_I2_Class_Typedef;
+// I1_Struct isn't really used by any possible operation with H_TemplateStruct,
+// but '#include' is required as a common rule, as long as I1_Struct
+// isn't forward-declared.
+// IWYU: I1_Struct is...*badinc-i1.h
+// IWYU: D5_OperateOn<I1_Struct> is...*badinc-i1.h
+typedef D5_TemplateStruct<I1_Struct> D5_TemplateStruct_I1Struct_Typedef;
+inline void Instantiate_D5_TemplateStruct() {
+  D5_TemplateStruct_I1Struct_Typedef x;
+  // IWYU: D5_OperateOn<I1_Struct> is...*badinc-i1.h
+  x.a();
+}
+
+// IWYU: I2_TemplateClass needs a declaration
+// IWYU: I2_TemplateClass is...*badinc-i2.h
+// IWYU: I2_TemplateClass::I2_TemplateClass<{{.*}}>({{.*}}) is...*badinc-i2-inl.h
+// IWYU: I2_TemplateClass::~I2_TemplateClass<{{.*}}>() is...*badinc-i2-inl.h
+// IWYU: I2_TemplateClass::InlFileTemplateClassFn({{.*}}) is...*badinc-i2-inl.h
+typedef I2_TemplateClass<int> D5_typedef_implicit_instantiation;
+// Make sure we can do the same typedef multiple times.
+// IWYU: I2_TemplateClass needs a declaration
+// IWYU: I2_TemplateClass is...*badinc-i2.h
+// IWYU: I2_TemplateClass::I2_TemplateClass<{{.*}}>({{.*}}) is...*badinc-i2-inl.h
+// IWYU: I2_TemplateClass::~I2_TemplateClass<{{.*}}>() is...*badinc-i2-inl.h
+// IWYU: I2_TemplateClass::InlFileTemplateClassFn({{.*}}) is...*badinc-i2-inl.h
+typedef I2_TemplateClass<int> D5_typedef_implicit_instantiation2;
+
+// TODO(csilvers): I1_Class is technically forward-declarable.
+// IWYU: I1_Class is...*badinc-i1.h
+// IWYU: I1_Enum is...*badinc-i1.h
+template <class T = I1_Class, I1_Enum E = I11>
+class D5_DeclareOnlyTemplateClass;
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_BADINC_D5_H_
+
+/**** IWYU_SUMMARY
+
+tests/cxx/badinc-d5.h should add these lines:
+#include "tests/cxx/badinc-i1.h"
+#include "tests/cxx/badinc-i2-inl.h"
+#include "tests/cxx/badinc-i2.h"
+
+tests/cxx/badinc-d5.h should remove these lines:
+- #include "tests/cxx/badinc-d1.h"  // lines XX-XX
+- #include "tests/cxx/badinc-d2.h"  // lines XX-XX
+- template <class T = I1_Class, I1_Enum E = I11> class D5_DeclareOnlyTemplateClass;  // lines XX-XX+1
+
+The full include-list for tests/cxx/badinc-d5.h:
+#include <string>  // for string
+#include "tests/cxx/badinc-i1.h"  // for D5_OperateOn, I1_Class, I1_Enum, I1_Struct, I1_TemplateClass, kI1ConstInt
+#include "tests/cxx/badinc-i2-inl.h"  // for I2_Class::I2_Class, I2_Class::InlFileFn, I2_Class::InlFileStaticFn, I2_Class::InlFileTemplateFn, I2_Class::~I2_Class, I2_TemplateClass::I2_TemplateClass<FOO>, I2_TemplateClass::InlFileTemplateClassFn, I2_TemplateClass::~I2_TemplateClass<FOO>
+#include "tests/cxx/badinc-i2.h"  // for I2_Class, I2_TemplateClass
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/badinc-i1.h
+++ b/tests/cxx/badinc-i1.h
@@ -186,6 +186,12 @@ template<class T> class OperateOn;   // forward declare, from badinc.h
 template<> class OperateOn<I1_Struct> { };
 template<class T> class OperateOn<I1_TemplateClass<T> > { };
 
+// This is needed by D5_TemplateStruct.
+template <class T>
+class D5_OperateOn;  // forward declare, from badinc-d5.h
+template <>
+class D5_OperateOn<I1_Struct> {};
+
 typedef I2_Class I1_I2_Class_Typedef;
 typedef I1_Class* I1_ClassPtr;
 

--- a/tests/cxx/badinc.cc
+++ b/tests/cxx/badinc.cc
@@ -7,7 +7,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// IWYU_ARGS: -Xiwyu --mapping_file=tests/cxx/badinc.imp -std=gnu++98 -I .
+// IWYU_ARGS: -Xiwyu --mapping_file=tests/cxx/badinc.imp -std=gnu++98 -I . \
+//            -Xiwyu --check_also=tests/cxx/*-d5.h
 
 // This is a unittest for include-what-you-use.
 //
@@ -62,6 +63,7 @@
 #include  "tests/cxx/badinc.h"
 #include   "tests/cxx/badinc-d1.h"
 #include "tests/cxx/badinc-d2.h"
+#include "tests/cxx/badinc-d5.h"
 #include  USED_INC    // testing computed #includes
 #include  <string>    // not sorted properly (before the #include ""'s).
 // The following line is needed, but use a 'keep' pragma anyway.
@@ -177,39 +179,20 @@ struct Cc_C_Struct* cc_c_struct_ptr = NULL;
 
 // The types.
 typedef std::string Cc_string;   // Nobody should use this.
-// IWYU: I1_Class is...*badinc-i1.h
+// IWYU: I1_Class needs a declaration
 typedef I1_Class Cc_typedef;
 // IWYU: kI1ConstInt is...*badinc-i1.h
-// IWYU: I1_Class is...*badinc-i1.h
+// IWYU: I1_Class needs a declaration
 typedef I1_Class Cc_typedef_array[kI1ConstInt];
-// We need the full definition of template types (I1_TemplateClass in
-// this case) since we're re-exporting them.  Note we need a full
-// definition even of I2_Class, since we don't know if clients will be
-// using the no-arg Cc_tpl_typedef ctor, which requires the full
-// definition of I2_Class.
+// We need the full definition of template type I1_TemplateClass
+// since we're making use of the default template argument.
 // IWYU: I1_TemplateClass is...*badinc-i1.h...*#included.
-// IWYU: I1_Class is...*badinc-i1.h
-// IWYU: I2_Class is...*badinc-i2.h
-// IWYU: I2_Class::~I2_Class() is...*badinc-i2-inl.h
+// IWYU: I1_Class needs a declaration
+// IWYU: I2_Class needs a declaration
 typedef I1_TemplateClass<I1_TemplateClass<I1_Class,I2_Class> > Cc_tpl_typedef;
-// TODO(csilvers): it would be nice to be able to take this line out and
-// still have the above tests pass:
-// TODO(bolshakov): figure out how to determine at the use site that a typedef
-// provides not only the types but also the member functions.
-// IWYU: I2_Class::~I2_Class() is...*badinc-i2-inl.h
-Cc_tpl_typedef cc_tpl_typedef;
-// IWYU: I2_Class is...*badinc-i2.h
-// IWYU: I2_Class::I2_Class({{.*}}) is...*badinc-i2-inl.h
-// IWYU: I2_Class::~I2_Class() is...*badinc-i2-inl.h
-// IWYU: I2_Class::InlFileFn({{.*}}) is...*badinc-i2-inl.h
-// IWYU: I2_Class::InlFileTemplateFn({{.*}}) is...*badinc-i2-inl.h
-// IWYU: I2_Class::InlFileStaticFn({{.*}}) is...*badinc-i2-inl.h
+// IWYU: I2_Class needs a declaration
 typedef I2_Class Cc_I2_Class_Typedef;
-// I1_Struct isn't really used by any possible operation with H_TemplateStruct,
-// but '#include' is required as a common rule, as long as I1_Struct
-// isn't forward-declared.
-// IWYU: I1_Struct is...*badinc-i1.h
-// IWYU: OperateOn<I1_Struct> is...*badinc-i1.h
+// IWYU: I1_Struct needs a declaration
 typedef H_TemplateStruct<I1_Struct> Cc_H_TemplateStruct_I1Class_Typedef;
 
 // IWYU: kI1ConstInt is...*badinc-i1.h
@@ -297,8 +280,7 @@ template<I1_Enum E> struct Cc_TemplateStruct<I1_Class, E> { I1_Class i; };
 // IWYU: I1_Class needs a declaration
 // IWYU: I1_Enum is...*badinc-i1.h
 template<> struct Cc_TemplateStruct<I1_Class, I12> { I1_Class* i; };
-// TODO(csilvers): I1_Class is technically forward-declarable.
-// IWYU: I1_Class is...*badinc-i1.h
+// IWYU: I1_Class needs a declaration
 // IWYU: I1_Enum is...*badinc-i1.h
 template<class T = I1_Class, I1_Enum E = I11> class Cc_DeclareOnlyTemplateClass;
 
@@ -945,17 +927,9 @@ template class I1_TemplateClass<I1_ClassPtr>;
 // IWYU: I2_TemplateClass is...*badinc-i2.h
 int i2_tpl_class_a = i2_template_class_with_inl_constructor.a();
 // IWYU: I2_TemplateClass needs a declaration
-// IWYU: I2_TemplateClass is...*badinc-i2.h
-// IWYU: I2_TemplateClass::I2_TemplateClass<{{.*}}>({{.*}}) is...*badinc-i2-inl.h
-// IWYU: I2_TemplateClass::~I2_TemplateClass<{{.*}}>() is...*badinc-i2-inl.h
-// IWYU: I2_TemplateClass::InlFileTemplateClassFn({{.*}}) is...*badinc-i2-inl.h
 typedef I2_TemplateClass<int> Cc_typedef_implicit_instantiation;
 // Make sure we can do the same typedef multiple times.
 // IWYU: I2_TemplateClass needs a declaration
-// IWYU: I2_TemplateClass is...*badinc-i2.h
-// IWYU: I2_TemplateClass::I2_TemplateClass<{{.*}}>({{.*}}) is...*badinc-i2-inl.h
-// IWYU: I2_TemplateClass::~I2_TemplateClass<{{.*}}>() is...*badinc-i2-inl.h
-// IWYU: I2_TemplateClass::InlFileTemplateClassFn({{.*}}) is...*badinc-i2-inl.h
 typedef I2_TemplateClass<int> Cc_typedef_implicit_instantiation2;
 // IWYU: I1_ClassPtr is...*badinc-i1.h
 // IWYU: I1_TemplateClass is...*badinc-i1.h
@@ -1016,10 +990,7 @@ class CC_Class2 {
   struct CC_TemplateStruct2<int> x;
 };
 
-// We require full type info for default template parameters, even
-// when it's not strictly necessary, just to avoid potential trouble.
-// (Users shouldn't have to worry about instantiating default params.)
-// IWYU: I1_Class is...*badinc-i1.h
+// IWYU: I1_Class needs a declaration
 template <class A, class B = I1_Class>
 class CC_TemplateClass {
  public:
@@ -1104,12 +1075,23 @@ int main() {
   fprintf(stdout, "%d", local_cc_struct.a);  // test a global in stdio.h too
   // IWYU: printf({{.*}}) is...*<cstdio>
   printf("%d", local_cc_struct.a);
+  // IWYU: I1_Class is...*badinc-i1.h
   (void)Cc_typedef(4);
-  // Not an iwyu violation, because Cc_typedef is responsible for its members.
+  // Only header-defined typedefs may provide underlying types.
+  // IWYU: I1_Class is...*badinc-i1.h
   Cc_typedef::s();
+  // IWYU: I1_Class is...*badinc-i1.h
   Cc_typedef::I1_Class_int Cc_typedef_int = 0;
+  // IWYU: I1_Class is...*badinc-i1.h
   Cc_typedef::NestedStruct Cc_typedef_struct;
+  // IWYU: I1_Class is...*badinc-i1.h
   Cc_typedef::NestedStruct::NestedStructTypedef Cc_typedef_nested_int = 0;
+  (void)D5_typedef(4);
+  // Not an iwyu violation, because D5_typedef is responsible for its members.
+  D5_typedef::s();
+  D5_typedef::I1_Class_int D5_typedef_int = 0;
+  D5_typedef::NestedStruct D5_typedef_struct;
+  D5_typedef::NestedStruct::NestedStructTypedef D5_typedef_nested_int = 0;
   local_h_class.a();
   // a() returns a FOO, which in this case is I2_Enum.
   local_d1_template_class.a();
@@ -1217,12 +1199,21 @@ int main() {
   I1_TemplateMethodOnlyClass<I2_Class>::tt<I1_TemplateClass>();
   // Try the static calls again, but this time with a typedef tpl arg.
   // IWYU: I1_TemplateMethodOnlyClass is...*badinc-i1.h
+  // IWYU: I1_Class is...*badinc-i1.h
   // IWYU: I2_Class is...*badinc-i2.h
   I1_TemplateMethodOnlyClass<Cc_typedef>::s(local_i2_class_ptr);
   // IWYU: I1_TemplateMethodOnlyClass is...*badinc-i1.h
+  // IWYU: I1_Class is...*badinc-i1.h
   // IWYU: I2_Class needs a declaration
   // IWYU: I2_Class is...*badinc-i2.h
   I1_TemplateMethodOnlyClass<Cc_typedef>::s<I2_Class*>(local_i2_class_ptr);
+  // IWYU: I1_TemplateMethodOnlyClass is...*badinc-i1.h
+  // IWYU: I2_Class is...*badinc-i2.h
+  I1_TemplateMethodOnlyClass<D5_typedef>::s(local_i2_class_ptr);
+  // IWYU: I1_TemplateMethodOnlyClass is...*badinc-i1.h
+  // IWYU: I2_Class needs a declaration
+  // IWYU: I2_Class is...*badinc-i2.h
+  I1_TemplateMethodOnlyClass<D5_typedef>::s<I2_Class*>(local_i2_class_ptr);
 
   // The result of static_cast depends on the relation between the
   // source and target type, and thus requires the full target type
@@ -1780,13 +1771,24 @@ int main() {
   // IWYU: I1_Class needs a declaration
   I1_TemplateFunction<I1_Class*>(i1_class_ptr);
   // Try again, but with a typedef
+  // IWYU: I1_Class is...*badinc-i1.h
   Cc_typedef cc_typedef;
   // IWYU: I1_TemplateFunction(:0) is...*badinc-i1.h
+  // IWYU: I1_Class is...*badinc-i1.h
   I1_TemplateFunction(cc_typedef);
   // IWYU: I1_TemplateFunction(:0) is...*badinc-i1.h
+  // IWYU: I1_Class is...*badinc-i1.h
   I1_TemplateFunction<Cc_typedef>(cc_typedef);
   // IWYU: I1_TemplateFunction(:0) is...*badinc-i1.h
+  // IWYU: I1_Class is...*badinc-i1.h
   I1_TemplateFunction<Cc_typedef>(i1_class);
+  D5_typedef d5_typedef;
+  // IWYU: I1_TemplateFunction(:0) is...*badinc-i1.h
+  I1_TemplateFunction(d5_typedef);
+  // IWYU: I1_TemplateFunction(:0) is...*badinc-i1.h
+  I1_TemplateFunction<D5_typedef>(d5_typedef);
+  // IWYU: I1_TemplateFunction(:0) is...*badinc-i1.h
+  I1_TemplateFunction<D5_typedef>(i1_class);
 
   // IWYU: I1_Class is...*badinc-i1.h
   i1_class.I1_ClassTemplateFunction(&i1_struct);
@@ -1862,6 +1864,7 @@ The full include-list for tests/cxx/badinc.cc:
 #include <typeinfo>  // for type_info
 #include "tests/cxx/badinc-d1.h"  // for D1CopyClassFn, D1Function, D1_Class, D1_CopyClass, D1_Enum, D1_I1_Typedef, D1_StructPtr, D1_Subclass, D1_TemplateClass, D1_TemplateStructWithDefaultParam, MACRO_CALLING_I4_FUNCTION
 #include "tests/cxx/badinc-d4.h"  // for D4_ClassForOperator, operator<<
+#include "tests/cxx/badinc-d5.h"  // for D5_typedef
 #include "tests/cxx/badinc-i1.h"  // for EmptyDestructorClass, H_Class::H_Class_DefinedInI1, I1_And_I2_OverloadedFunction, I1_Base, I1_Class, I1_ClassPtr, I1_Enum, I1_Function, I1_FunctionPtr, I1_I2_Class_Typedef, I1_MACRO_LOGGING_CLASS, I1_MACRO_SYMBOL_WITHOUT_VALUE, I1_MACRO_SYMBOL_WITH_VALUE, I1_MACRO_SYMBOL_WITH_VALUE0, I1_MACRO_SYMBOL_WITH_VALUE2, I1_ManyPtrStruct (ptr only), I1_MemberPtr, I1_NamespaceClass, I1_NamespaceStruct, I1_NamespaceTemplateFn, I1_OverloadedFunction, I1_PtrAndUseOnSameLine, I1_PtrDereferenceClass, I1_PtrDereferenceStatic, I1_PtrDereferenceStruct, I1_SiblingClass, I1_StaticMethod, I1_Struct, I1_Subclass, I1_SubclassesI2Class, I1_TemplateClass, I1_TemplateClassFwdDeclaredInD2 (ptr only), I1_TemplateFunction, I1_TemplateMethodOnlyClass, I1_TemplateSubclass, I1_Typedef, I1_TypedefOnly_Class, I1_Union, I1_UnnamedStruct, I1_UnusedNamespaceStruct (ptr only), I1_const_ptr, I2_OperatorDefinedInI1Class::operator<<, MACRO_CALLING_I6_FUNCTION, OperateOn, i1_GlobalFunction, i1_int, i1_int_global, i1_int_global2, i1_int_global2sub, i1_int_global3, i1_int_global3sub, i1_int_global4, i1_int_global4sub, i1_int_globalsub, i1_ns5, kI1ConstInt, operator==
 #include "tests/cxx/badinc2.c"
 class D2_Class;

--- a/tests/cxx/comment_pragmas.cc
+++ b/tests/cxx/comment_pragmas.cc
@@ -68,10 +68,10 @@
 // 20. "no_forward_declare" pragma: cpd19 is used in a forward-declarable
 //      way, but is forward declared anyway even though inhibited.
 // 21. "no_forward_declare" pragma: Test21a is defined after a typedef,
-//     which requires a forward declaration. This case is different because
-//     internally IWYU wants a full-use which it downgrades to a forward-decl.
+//     which requires a forward declaration.
 // 22. "no_forward_declare" pragma: cpd20a and cpd20b are defined inside an
 //     anonymous namespace.
+#include "tests/cxx/comment_pragmas.h"
 #include "tests/cxx/comment_pragmas-d1.h"
 #include "tests/cxx/comment_pragmas-d10.h"
 #include "tests/cxx/comment_pragmas-d11.h"
@@ -192,11 +192,6 @@ CommentPragmasD19* cpd19;
 CommentPragmasD20a* cpd20a;
 Foo::CommentPragmasD20b* cpd20b;
 CommentPragmasD20c* cpd20c;
-// This is a case where IWYU wants the full definition of
-// CommentPragmasTest21a due to the typedef, but then downgrades to
-// requiring a forward declaration since the definition appears later
-// in the same file. This forward declaration is inhibited due to a
-// no_forward_declare pragma at the top of this file.
 typedef CommentPragmasTest21a CommentPragmasTest21b;
 class CommentPragmasTest21a {};
 
@@ -224,6 +219,7 @@ tests/cxx/comment_pragmas.cc should remove these lines:
 - class CommentPragmasTest21a;  // lines XX-XX
 
 The full include-list for tests/cxx/comment_pragmas.cc:
+#include "tests/cxx/comment_pragmas.h"
 #include "some_public_header_file"  // for CommentPragmasD8, CommentPragmasD9
 #include "tests/cxx/comment_pragmas-d11.h"  // for CommentPragmasD11
 #include "tests/cxx/comment_pragmas-d12.h"  // for CommentPragmasD12

--- a/tests/cxx/comment_pragmas.h
+++ b/tests/cxx/comment_pragmas.h
@@ -1,0 +1,32 @@
+//===--- comment_pragmas.h - test input file for iwyu ---------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// IWYU pragma: no_forward_declare CommentPragmasTest21aHeader
+
+class CommentPragmasTest21aHeader;  // Needed but removed due to
+                                    // no_forward_declare.
+
+// This is a case where IWYU wants the full definition of
+// CommentPragmasTest21aHeader due to the typedef, but then downgrades to
+// requiring a forward declaration since the definition appears later
+// in the same file. This forward declaration is inhibited due to a
+// no_forward_declare pragma at the top of this file.
+typedef CommentPragmasTest21aHeader CommentPragmasTest21bHeader;
+class CommentPragmasTest21aHeader {};
+
+/**** IWYU_SUMMARY
+
+tests/cxx/comment_pragmas.h should add these lines:
+
+tests/cxx/comment_pragmas.h should remove these lines:
+- class CommentPragmasTest21aHeader;  // lines XX-XX
+
+The full include-list for tests/cxx/comment_pragmas.h:
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/default_tpl_arg-d4.h
+++ b/tests/cxx/default_tpl_arg-d4.h
@@ -1,0 +1,62 @@
+//===--- default_tpl_arg-d4.h - test input file for iwyu ------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/default_tpl_arg-d1.h"
+#include "tests/cxx/direct.h"
+
+// Some cases from default_tpl_arg.cc have been duplicated here to test them
+// with a different provision policy (only template declarations from headers
+// can provide their default arguments).
+
+// IWYU: UninstantiatedTpl needs a declaration
+// IWYU: UninstantiatedTpl is...*default_tpl_arg-i1.h
+template <typename = UninstantiatedTpl<int>>
+struct HeaderTpl {};
+
+template <typename T>
+struct HeaderOuter1 {
+  // IWYU: UninstantiatedTpl needs a declaration
+  // IWYU: UninstantiatedTpl is...*default_tpl_arg-i1.h
+  template <typename = UninstantiatedTpl<T>>
+  struct Inner {};
+};
+
+inline HeaderOuter1<int> ho1;
+
+template <typename T1, typename T2>
+struct HeaderOuter2 {
+  // IWYU: IndirectTemplate needs a declaration
+  // IWYU: IndirectTemplate is...*indirect.h
+  template <typename = IndirectTemplate<T1>>
+  struct Inner {};
+};
+
+// Test that IWYU should not suggest to provide default template argument
+// of an internal template on instantiation side.
+// IWYU: IndirectTemplate needs a declaration
+inline HeaderOuter2<int, IndirectTemplate<int>> ho2;
+
+// IWYU: IndirectClass is...*indirect.h
+using ProvidingAlias = IndirectClass;
+
+/**** IWYU_SUMMARY
+
+tests/cxx/default_tpl_arg-d4.h should add these lines:
+#include "tests/cxx/default_tpl_arg-i1.h"
+#include "tests/cxx/indirect.h"
+
+tests/cxx/default_tpl_arg-d4.h should remove these lines:
+- #include "tests/cxx/default_tpl_arg-d1.h"  // lines XX-XX
+- #include "tests/cxx/direct.h"  // lines XX-XX
+
+The full include-list for tests/cxx/default_tpl_arg-d4.h:
+#include "tests/cxx/default_tpl_arg-i1.h"  // for UninstantiatedTpl
+#include "tests/cxx/indirect.h"  // for IndirectClass, IndirectTemplate
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/default_tpl_arg.cc
+++ b/tests/cxx/default_tpl_arg.cc
@@ -7,7 +7,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// IWYU_ARGS: -I . -Xiwyu --check_also="tests/cxx/*-d2.h"
+// IWYU_ARGS: -I . -Xiwyu --check_also="tests/cxx/*-d2.h" \
+//                 -Xiwyu --check_also="tests/cxx/*-d4.h"
 
 // Tests handling default template arguments. In particular, that IWYU
 // doesn't crash when they refer to uninstantiated template specializations.
@@ -15,17 +16,16 @@
 #include "tests/cxx/default_tpl_arg-d1.h"
 #include "tests/cxx/default_tpl_arg-d2.h"
 #include "tests/cxx/default_tpl_arg-d3.h"
+#include "tests/cxx/default_tpl_arg-d4.h"
 #include "tests/cxx/direct.h"
 
 // IWYU: UninstantiatedTpl needs a declaration
-// IWYU: UninstantiatedTpl is...*default_tpl_arg-i1.h
 template <typename = UninstantiatedTpl<int>>
 struct Tpl {};
 
 template <typename T>
 struct Outer1 {
   // IWYU: UninstantiatedTpl needs a declaration
-  // IWYU: UninstantiatedTpl is...*default_tpl_arg-i1.h
   template <typename = UninstantiatedTpl<T>>
   struct Inner {};
 };
@@ -35,7 +35,6 @@ Outer1<int> o1;
 template <typename T1, typename T2>
 struct Outer2 {
   // IWYU: IndirectTemplate needs a declaration
-  // IWYU: IndirectTemplate is...*indirect.h
   template <typename = IndirectTemplate<T1>>
   struct Inner {};
 };
@@ -219,8 +218,6 @@ void Fn() {
   (void)&FnWithProvidedDefaultTplArg<>;
   FnWithProvidedDefaultTplArg();
 
-  // IWYU: IndirectClass is...*indirect.h
-  using ProvidingAlias = IndirectClass;
   ProvidingAlias* p = 0;
   // IWYU: NonProvidingAlias is...*default_tpl_arg-i1.h
   NonProvidingAlias* n = 0;
@@ -298,9 +295,10 @@ tests/cxx/default_tpl_arg.cc should remove these lines:
 The full include-list for tests/cxx/default_tpl_arg.cc:
 #include "tests/cxx/default_tpl_arg-d2.h"  // for AliasTpl5, DerivedFromProvidedDefArg, DerivedTplProvidingDefArg, FnWithProvidedDefaultTplArg, FnWithProvidedDefaultTplArgAndDefaultCallArg1, FnWithProvidedDefaultTplArgAndDefaultCallArg2, FnWithProvidedDefaultTplArgAndDefaultCallArg3, GetClassTpl2Ref, TplProvidingDefArg, TplProvidingDefArg2, TplProvidingDefArg3, TplProvidingDefArg4
 #include "tests/cxx/default_tpl_arg-d3.h"  // for TplProvidingDefArg5Alias
-#include "tests/cxx/default_tpl_arg-i1.h"  // for AliasTpl1, AliasTpl2, AliasTpl3, AliasTpl4, AliasTpl7, ClassTpl, ClassTpl2, ClassTplNoDefinition, ClassTplWithDefinition, ClassTplWithDefinition2, FnWithNonProvidedDefaultTplArg, FnWithNonProvidedDefaultTplArgAndDefaultCallArg, NonProvidingAlias, SomeTpl, SpecializedClassTpl, TplProvidingDefArg4, UninstantiatedTpl, VarTpl
+#include "tests/cxx/default_tpl_arg-d4.h"  // for ProvidingAlias
+#include "tests/cxx/default_tpl_arg-i1.h"  // for AliasTpl1, AliasTpl2, AliasTpl3, AliasTpl4, AliasTpl7, ClassTpl, ClassTpl2, ClassTplNoDefinition, ClassTplWithDefinition, ClassTplWithDefinition2, FnWithNonProvidedDefaultTplArg, FnWithNonProvidedDefaultTplArgAndDefaultCallArg, NonProvidingAlias, SomeTpl, SpecializedClassTpl, TplProvidingDefArg4, UninstantiatedTpl (ptr only), VarTpl
 #include "tests/cxx/default_tpl_arg-i2.h"  // for AliasTpl7, ClassTpl2, ClassTplWithDefinition2, ClassTplWithDefinition3, ClassTplWithDefinition7
-#include "tests/cxx/indirect.h"  // for IndirectClass, IndirectTemplate
+#include "tests/cxx/indirect.h"  // for IndirectClass, IndirectTemplate (ptr only)
 template <typename = int, typename> class ClassTpl;  // lines XX-XX+2
 template <typename = int> class ClassTpl3;  // lines XX-XX+1
 template <typename = int> class ClassTplWithDefinition3;  // lines XX-XX+1

--- a/tests/cxx/dependent_tpl_crash.cc
+++ b/tests/cxx/dependent_tpl_crash.cc
@@ -7,9 +7,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+// IWYU_ARGS: -I .
+
 // Tests that we don't trigger an assertion failure for dependent template
 // aliases. We avoid reporting uses of template names without an underlying
 // template decl to ensure we don't hit this.
+
+#include "tests/cxx/dependent_tpl_crash.h"
 
 template <int value, typename Type>
 struct ClassValueType {};
@@ -61,6 +65,7 @@ struct DependentFnReturn {
 int main() {
   test<0>();
   Tpl<int> t;
+  HeaderTpl<int> ht;
 }
 
 /**** IWYU_SUMMARY

--- a/tests/cxx/dependent_tpl_crash.h
+++ b/tests/cxx/dependent_tpl_crash.h
@@ -1,0 +1,33 @@
+//===--- dependent_tpl_crash.h - test input file for iwyu -----------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// Some cases from dependent_tpl_crash.cc have been duplicated here to test them
+// with a different provision policy (only typedefs from headers can provide
+// their underlying types).
+
+template <typename>
+struct HeaderTpl {
+  template <typename U>
+  using Alias = typename U::template Nested<int>::Type;
+};
+
+struct HeaderDependentFnReturn {
+  template <typename T>
+  static typename T::template NestedTpl<T> GetNestedTpl() {
+    return {};
+  }
+
+  using ThisType = HeaderDependentFnReturn;
+};
+
+/**** IWYU_SUMMARY
+
+(tests/cxx/dependent_tpl_crash.h has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/derived_function_tpl_args-i1.h
+++ b/tests/cxx/derived_function_tpl_args-i1.h
@@ -14,3 +14,6 @@ class NsClass { };
 }
 
 template<typename T, typename U=ns::NsClass> class IndirectTplClass { };
+
+typedef IndirectClass ProvidingTypedef;
+typedef IndirectClass* ProvidingPtrTypedef;

--- a/tests/cxx/derived_function_tpl_args.cc
+++ b/tests/cxx/derived_function_tpl_args.cc
@@ -74,21 +74,41 @@ int main() {
   FnWithForwardingReference(ic_ptr);
 
   // Now try again, but with a typedef.
-  // IWYU: IndirectClass is...*derived_function_tpl_args-i1.h
+  // IWYU: IndirectClass needs a declaration
   typedef IndirectClass LocalClass;
-  // IWYU: IndirectClass is...*derived_function_tpl_args-i1.h
+  // IWYU: IndirectClass needs a declaration
   typedef IndirectClass* LocalClassPtr;
+  // IWYU: IndirectClass is...*derived_function_tpl_args-i1.h
   LocalClass lc;
   LocalClass* lc_ptr = 0;
   LocalClassPtr lc_ptr2 = 0;
+  // IWYU: IndirectClass is...*derived_function_tpl_args-i1.h
   Fn(lc);
   Fn(lc_ptr);
+  // IWYU: IndirectClass is...*derived_function_tpl_args-i1.h
   FnWithPtr(lc_ptr);
+  // IWYU: IndirectClass is...*derived_function_tpl_args-i1.h
   FnWithPtr(lc_ptr2);
+  // IWYU: IndirectClass is...*derived_function_tpl_args-i1.h
   FnWithReference(lc);
   FnWithReference(lc_ptr);
+  // IWYU: IndirectClass is...*derived_function_tpl_args-i1.h
   FnWithForwardingReference(lc);
   FnWithForwardingReference(lc_ptr);
+  // IWYU: ProvidingTypedef is...*derived_function_tpl_args-i1.h
+  ProvidingTypedef pt;
+  // IWYU: ProvidingTypedef is...*derived_function_tpl_args-i1.h
+  ProvidingTypedef* pt_ptr = 0;
+  // IWYU: ProvidingPtrTypedef is...*derived_function_tpl_args-i1.h
+  ProvidingPtrTypedef pt_ptr2 = 0;
+  Fn(pt);
+  Fn(pt_ptr);
+  FnWithPtr(pt_ptr);
+  FnWithPtr(pt_ptr2);
+  FnWithReference(pt);
+  FnWithReference(pt_ptr);
+  FnWithForwardingReference(pt);
+  FnWithForwardingReference(pt_ptr);
 
   // And try again, but with namespaces.  This makes sure we don't
   // get tripped up by ElaboratedType's.
@@ -151,8 +171,14 @@ int main() {
   FnWithForwardingReference(itc2_ptr);
 
   // If we specify explicit template args, those should override everything.
+  // IWYU: IndirectClass is...*derived_function_tpl_args-i1.h
   FnWithPtr<LocalClass>(ic_ptr);
+  // IWYU: IndirectClass is...*derived_function_tpl_args-i1.h
   FnWithReference<LocalClass>(ic);
+  // IWYU: ProvidingTypedef is...*derived_function_tpl_args-i1.h
+  FnWithPtr<ProvidingTypedef>(ic_ptr);
+  // IWYU: ProvidingTypedef is...*derived_function_tpl_args-i1.h
+  FnWithReference<ProvidingTypedef>(ic);
 }
 
 /**** IWYU_SUMMARY
@@ -164,6 +190,6 @@ tests/cxx/derived_function_tpl_args.cc should remove these lines:
 - #include "tests/cxx/derived_function_tpl_args-d1.h"  // lines XX-XX
 
 The full include-list for tests/cxx/derived_function_tpl_args.cc:
-#include "tests/cxx/derived_function_tpl_args-i1.h"  // for IndirectClass, IndirectTplClass, NsClass
+#include "tests/cxx/derived_function_tpl_args-i1.h"  // for IndirectClass, IndirectTplClass, NsClass, ProvidingPtrTypedef, ProvidingTypedef
 
 ***** IWYU_SUMMARY */

--- a/tests/cxx/expl_inst_args-i1.h
+++ b/tests/cxx/expl_inst_args-i1.h
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+template <typename>
+struct S2;
+
 struct Struct1 {};
 struct Struct2 {};
 struct Struct3 {};
@@ -15,3 +18,7 @@ template <typename T = Struct1>
 void body5() {
   T x;
 }
+
+using Struct3Providing = Struct3;
+using Struct3ProvidingPtr = Struct3*;
+using S2Struct3Providing = S2<Struct3>;

--- a/tests/cxx/expl_inst_args.cc
+++ b/tests/cxx/expl_inst_args.cc
@@ -66,13 +66,6 @@ struct S2 {
   }
 };
 
-// IWYU: Struct3 is...*expl_inst_args-i1.h
-using Struct3Providing = Struct3;
-// IWYU: Struct3 is...*expl_inst_args-i1.h
-using Struct3ProvidingPtr = Struct3*;
-// IWYU: Struct3 is...*expl_inst_args-i1.h
-using S2Struct3Providing = S2<Struct3>;
-
 // Part 1: add explicit instantiation declarations for these template kinds.
 
 // IWYU: Struct1 needs a declaration
@@ -151,6 +144,7 @@ template void body1<Struct1>();                   // (h)
 // IWYU: Struct2NonProviding is...*expl_inst_args-i2.h
 // IWYU: Struct2 is...*expl_inst_args-i1.h
 template void body1<Struct2NonProviding>();
+// IWYU: Struct3Providing is...*expl_inst_args-i1.h
 template void body1<Struct3Providing>();
 // IWYU: Struct1 needs a declaration
 // IWYU: Struct1 is...*expl_inst_args-i1.h
@@ -158,6 +152,7 @@ template void body2(Struct1*);
 // IWYU: Struct2NonProvidingPtr is...*expl_inst_args-i2.h
 // IWYU: Struct2 is...*expl_inst_args-i1.h
 template void body2(Struct2NonProvidingPtr);
+// IWYU: Struct3ProvidingPtr is...*expl_inst_args-i1.h
 template void body2(Struct3ProvidingPtr);
 // IWYU: Struct1 needs a declaration
 // IWYU: Struct1 is...*expl_inst_args-i1.h
@@ -165,6 +160,7 @@ template void body3<Struct1*>();
 // IWYU: Struct2NonProvidingPtr is...*expl_inst_args-i2.h
 // IWYU: Struct2 is...*expl_inst_args-i1.h
 template void body3<Struct2NonProvidingPtr>();
+// IWYU: Struct3ProvidingPtr is...*expl_inst_args-i1.h
 template void body3<Struct3ProvidingPtr>();
 // body4 doesn't provide its default template argument.
 // IWYU: body4() is...*expl_inst_args-i2.h
@@ -179,6 +175,7 @@ template void S2<Struct1>::method();              // (j)
 // IWYU: Struct2 is...*expl_inst_args-i1.h
 // IWYU: S2Struct2NonProviding is...*expl_inst_args-i2.h
 template void S2Struct2NonProviding::method();
+// IWYU: S2Struct3Providing is...*expl_inst_args-i1.h
 template void S2Struct3Providing::method();
 
 /**** IWYU_SUMMARY
@@ -191,7 +188,7 @@ tests/cxx/expl_inst_args.cc should remove these lines:
 - #include "tests/cxx/expl_inst_args-d1.h"  // lines XX-XX
 
 The full include-list for tests/cxx/expl_inst_args.cc:
-#include "tests/cxx/expl_inst_args-i1.h"  // for Struct1, Struct2, Struct3, body5
+#include "tests/cxx/expl_inst_args-i1.h"  // for S2Struct3Providing, Struct1, Struct2, Struct3Providing, Struct3ProvidingPtr, body5
 #include "tests/cxx/expl_inst_args-i2.h"  // for S2Struct2NonProviding, Struct2NonProviding, Struct2NonProvidingPtr, body4
 
 ***** IWYU_SUMMARY */

--- a/tests/cxx/explicit_instantiation-template2.h
+++ b/tests/cxx/explicit_instantiation-template2.h
@@ -28,3 +28,5 @@ template <typename T = IndirectClass>
 class TplWithProvidedDefArg {
   T t;
 };
+
+typedef IndirectTemplate<char> ProvidingTypedef;

--- a/tests/cxx/explicit_instantiation.cc
+++ b/tests/cxx/explicit_instantiation.cc
@@ -85,9 +85,6 @@ template class ClassWithUsingMethod<IndirectClass>;
 template class ClassWithUsingMethod<IndirectTemplate<int>>;
 
 // The template argument is considered to be provided with type alias.
-// IWYU: IndirectTemplate needs a declaration
-// IWYU: IndirectTemplate is...*indirect.h
-typedef IndirectTemplate<char> ProvidingTypedef;
 // IWYU: ClassWithUsingMethod is...*explicit_instantiation-template.h
 template class ClassWithUsingMethod<ProvidingTypedef>;
 
@@ -273,7 +270,7 @@ The full include-list for tests/cxx/explicit_instantiation.cc:
 #include "tests/cxx/explicit_instantiation-spec-i1.h"  // for Template
 #include "tests/cxx/explicit_instantiation-spec-i2.h"  // for TplFn, var_tpl
 #include "tests/cxx/explicit_instantiation-template.h"  // for ClassWithMethodUsingPtr, ClassWithUsingMethod, Host, Template, TplFn, TplFnWithRedecl, TplFnWithRedecl2, TplWithDefArg, TplWithNotProvidedDefArg, getInt, var_tpl, var_tpl_with_redecl, var_tpl_with_redecl2
-#include "tests/cxx/explicit_instantiation-template2.h"  // for ClassWithUsingMethod2, TplWithProvidedDefArg
+#include "tests/cxx/explicit_instantiation-template2.h"  // for ClassWithUsingMethod2, ProvidingTypedef, TplWithProvidedDefArg
 #include "tests/cxx/indirect.h"  // for IndirectClass, IndirectTemplate
 
 ***** IWYU_SUMMARY */

--- a/tests/cxx/fullinfo_for_templates.cc
+++ b/tests/cxx/fullinfo_for_templates.cc
@@ -12,11 +12,14 @@
 // Test that when a template is typedef'd that the location of the definition, not
 // any forward declaration, is included.
 
+#include "tests/cxx/fullinfo_for_templates.h"
 // First include the file containing the definition of TemplateClass.
 #include "tests/cxx/fullinfo_for_templates-d1.h"
 // Then include a file containing a forward declaration of TemplateClass.
 #include "tests/cxx/fullinfo_for_templates-d2.h"
-// IWYU requires full info when typedefing a template.
+// A forward-declaration is sufficient here because the typedef is in a source
+// file. See fullinfo_for_templates.h for the test case with a providing
+// typedef.
 typedef TemplateClass<int> tc_int;
 
 /**** IWYU_SUMMARY
@@ -27,6 +30,7 @@ tests/cxx/fullinfo_for_templates.cc should remove these lines:
 - #include "tests/cxx/fullinfo_for_templates-d2.h"  // lines XX-XX
 
 The full include-list for tests/cxx/fullinfo_for_templates.cc:
-#include "tests/cxx/fullinfo_for_templates-d1.h"  // for TemplateClass
+#include "tests/cxx/fullinfo_for_templates.h"
+#include "tests/cxx/fullinfo_for_templates-d1.h"  // for TemplateClass (ptr only)
 
 ***** IWYU_SUMMARY */

--- a/tests/cxx/fullinfo_for_templates.h
+++ b/tests/cxx/fullinfo_for_templates.h
@@ -1,0 +1,27 @@
+//===--- fullinfo_for_templates.h - test input file for iwyu --------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// First include the file containing the definition of TemplateClass.
+#include "tests/cxx/fullinfo_for_templates-d1.h"
+// Then include a file containing a forward declaration of TemplateClass.
+#include "tests/cxx/fullinfo_for_templates-d2.h"
+// IWYU requires full info when typedefing a template.
+typedef TemplateClass<int> tc_int;
+
+/**** IWYU_SUMMARY
+
+tests/cxx/fullinfo_for_templates.h should add these lines:
+
+tests/cxx/fullinfo_for_templates.h should remove these lines:
+- #include "tests/cxx/fullinfo_for_templates-d2.h"  // lines XX-XX
+
+The full include-list for tests/cxx/fullinfo_for_templates.h:
+#include "tests/cxx/fullinfo_for_templates-d1.h"  // for TemplateClass
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/fwd_decl_nested_class.cc
+++ b/tests/cxx/fwd_decl_nested_class.cc
@@ -7,9 +7,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+// IWYU_ARGS: -I .
+
 // Various tests of the handling of the forward declaration of nested
 // classes. For some uses the forward declaration is needed, for
 // others it isn't.
+
+#include "tests/cxx/fwd_decl_nested_class.h"
 
 template<typename T> void TplFn() { T t; (void)t; }
 
@@ -228,6 +232,7 @@ tests/cxx/fwd_decl_nested_class.cc should remove these lines:
 - template <typename T> class Outer::UsedImplicitlyInInitializer;  // lines XX-XX
 
 The full include-list for tests/cxx/fwd_decl_nested_class.cc:
+#include "tests/cxx/fwd_decl_nested_class.h"
 class Container::FwdDeclAfterUsage;  // lines XX-XX
 class Container::UsedAsFriend;  // lines XX-XX
 class Container::UsedAsPtrArg;  // lines XX-XX

--- a/tests/cxx/fwd_decl_nested_class.h
+++ b/tests/cxx/fwd_decl_nested_class.h
@@ -1,0 +1,44 @@
+//===--- fwd_decl_nested_class.h - test input file for iwyu ---------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// Some cases from fwd_decl_nested_class.cc have been duplicated here to test
+// them with a different provision policy (only typedefs from headers can
+// provide their underlying types).
+
+class HeaderFoo {
+  class UsedInTypedef;
+
+  // If a nested class is used in a typedef, a preceding declaration
+  // is needed.
+  typedef UsedInTypedef UsedInTypedefType;
+};
+
+class HeaderOuter {
+  template <typename T>
+  class UsedInTypedef;  // Necessary.
+
+  // If a nested class is used in a typedef, a preceding declaration
+  // is needed.
+  typedef UsedInTypedef<int> UsedInTypedefType;
+};
+
+template <class T>
+class HeaderContainer {
+  class UsedInTypedef;  // Necessary.
+
+  // If a nested class is used in a typedef, a preceding declaration
+  // is needed.
+  typedef UsedInTypedef UsedInTypedefType;
+};
+
+/**** IWYU_SUMMARY
+
+(tests/cxx/fwd_decl_nested_class.h has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/fwd_decl_then_dfn.cc
+++ b/tests/cxx/fwd_decl_then_dfn.cc
@@ -7,12 +7,16 @@
 //
 //===----------------------------------------------------------------------===//
 
+// IWYU_ARGS: -I .
+
 // There are a few situations where the language allows a type to be
 // forward-declared, but iwyu requires the definition: templates and
 // dependent template types, for instance.  In those cases, we run the
 // risk that iwyu might not realize a forward-declaration is actually
 // needed, if the definition comes after the relevant use.  This tests
 // to make sure iwyu does the right thing in those situations.
+
+#include "tests/cxx/fwd_decl_then_dfn.h"
 
 template<class T> struct Foo;
 template<class T> struct SubFoo : public Foo<T> { };

--- a/tests/cxx/fwd_decl_then_dfn.h
+++ b/tests/cxx/fwd_decl_then_dfn.h
@@ -1,0 +1,47 @@
+//===--- fwd_decl_then_dfn.h - test input file for iwyu -------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// fwd_decl_then_dfn.cc content has been duplicated here to test it with
+// a different provision policy (header files may provide stuff not strictly
+// required to compile them, whereas source files should not).
+
+template <class T>
+struct HeaderFoo;
+template <class T>
+struct HeaderSubFoo : public HeaderFoo<T> {};
+
+template <class T>
+struct HeaderBar;
+template <class T>
+struct HeaderSubBar : public HeaderFoo<typename HeaderBar<T>::type> {};
+
+template <class T>
+struct HeaderBaz;
+typedef HeaderBaz<int> HeaderBazTypedef;
+
+struct HeaderBang;
+typedef HeaderBang HeaderBangTypedef;
+
+// Now come the definitions, way at the end.
+
+template <class T>
+struct HeaderFoo {};
+template <class T>
+struct HeaderBar {
+  typedef const T type;
+};
+template <class T>
+struct HeaderBaz {};
+struct HeaderBang {};
+
+/**** IWYU_SUMMARY
+
+(tests/cxx/fwd_decl_then_dfn.h has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/implicit_ctor-d1.h
+++ b/tests/cxx/implicit_ctor-d1.h
@@ -56,6 +56,11 @@ void TakeMultipleRedeclStruct(MultipleRedeclStruct);
 // IWYU: OuterAggregate1 is...*implicit_ctor-i2.h
 using ProvidingOuterAggregate1 = OuterAggregate1;
 
+// IWYU: NoAutocastCtor is...*implicit_ctor-i2.h
+using Providing = NoAutocastCtor;
+// IWYU: NoTrivialCtorDtor is...*implicit_ctor-i2.h
+using NoTrivialCtorDtorProvidingAlias = NoTrivialCtorDtor;
+
 /**** IWYU_SUMMARY
 
 tests/cxx/implicit_ctor-d1.h should add these lines:
@@ -67,7 +72,7 @@ tests/cxx/implicit_ctor-d1.h should remove these lines:
 - #include "tests/cxx/implicit_ctor-i1.h"  // lines XX-XX
 
 The full include-list for tests/cxx/implicit_ctor-d1.h:
-#include "tests/cxx/implicit_ctor-i2.h"  // for ImplicitCtorInPartial, IndirectWithImplicitCtor, MultipleRedeclStruct, OuterAggregate1
+#include "tests/cxx/implicit_ctor-i2.h"  // for ImplicitCtorInPartial, IndirectWithImplicitCtor, MultipleRedeclStruct, NoAutocastCtor, NoTrivialCtorDtor, OuterAggregate1
 class IndirectClass;
 
 ***** IWYU_SUMMARY */

--- a/tests/cxx/implicit_ctor.cc
+++ b/tests/cxx/implicit_ctor.cc
@@ -64,11 +64,6 @@ IndirectWithImplicitCtor indirect
     // IWYU: IndirectWithImplicitCtor is...*implicit_ctor-i2.h
     = 1;
 
-// IWYU: NoAutocastCtor is...*implicit_ctor-i2.h
-using Providing = NoAutocastCtor;
-// IWYU: NoTrivialCtorDtor is...*implicit_ctor-i2.h
-using NoTrivialCtorDtorProvidingAlias = NoTrivialCtorDtor;
-
 // IWYU: NoAutocastCtor needs a declaration
 void FnTakingDirectly(NoAutocastCtor);
 void FnTakingByProvidingAlias(Providing);
@@ -220,7 +215,7 @@ tests/cxx/implicit_ctor.cc should add these lines:
 tests/cxx/implicit_ctor.cc should remove these lines:
 
 The full include-list for tests/cxx/implicit_ctor.cc:
-#include "tests/cxx/implicit_ctor-d1.h"  // for ImplicitCtorFn, ImplicitCtorInPartialFn, ImplicitCtorRefFn, InlineImplicitCtorRefFn, ProvidingOuterAggregate1, TakeMultipleRedeclStruct
+#include "tests/cxx/implicit_ctor-d1.h"  // for ImplicitCtorFn, ImplicitCtorInPartialFn, ImplicitCtorRefFn, InlineImplicitCtorRefFn, NoTrivialCtorDtorProvidingAlias, Providing, ProvidingOuterAggregate1, TakeMultipleRedeclStruct
 #include "tests/cxx/implicit_ctor-d2.h"  // for NoTrivialCtorDtorNonProvidingAlias, NonProviding, NonProvidingOuterAggregate1
 #include "tests/cxx/implicit_ctor-i2.h"  // for AggregateWithNonAggregate, I2NonAggregate, IndirectWithImplicitCtor, InnerAggregate1, InnerAggregate2, NoAutocastCtor, NoTrivialCtorDtor, OuterAggregate1, OuterAggregate2, OuterAggregateWithRef
 

--- a/tests/cxx/iwyu_stricter_than_cpp-d5.h
+++ b/tests/cxx/iwyu_stricter_than_cpp-d5.h
@@ -12,3 +12,7 @@
 // No forward-declaration of 'IndirectClass' here.
 
 IndirectStruct4::IndirectClassNonProvidingTypedef RetNonProvidingTypedef();
+
+// DirectStruct7 should be used only in LocalTplWithDefaultArgs testing.
+struct DirectStruct7 {};
+struct DirectStruct8 {};

--- a/tests/cxx/iwyu_stricter_than_cpp-i2.h
+++ b/tests/cxx/iwyu_stricter_than_cpp-i2.h
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_IWYU_STRICTER_THAN_CPP_I2_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_IWYU_STRICTER_THAN_CPP_I2_H_
+
 struct IndirectStruct2 {
   IndirectStruct2(int) {}
   int a;
@@ -16,3 +19,5 @@ template <typename T> struct TplIndirectStruct2 { TplIndirectStruct2(int) {} };
 
 // We also use a specialization for float.
 template <> struct TplIndirectStruct2<float> { TplIndirectStruct2(float) {} };
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_IWYU_STRICTER_THAN_CPP_I2_H_

--- a/tests/cxx/iwyu_stricter_than_cpp-i5.h
+++ b/tests/cxx/iwyu_stricter_than_cpp-i5.h
@@ -7,6 +7,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "tests/cxx/iwyu_stricter_than_cpp-i2.h"
+
 template <typename T1, typename T2>
 struct TplIndirectStruct3 {
   TplIndirectStruct3() = default;
@@ -19,6 +21,9 @@ struct TplIndirectStruct3 {
   static constexpr auto s = sizeof(T1);
   T2* t2;
 };
+
+using TplAllForwardDeclaredFnRetTypeProviding =
+    TplIndirectStruct3<IndirectStruct2, IndirectStruct2>;
 
 template <typename, typename>
 struct TplDirectStruct7;

--- a/tests/cxx/iwyu_stricter_than_cpp-type_alias.h
+++ b/tests/cxx/iwyu_stricter_than_cpp-type_alias.h
@@ -40,6 +40,8 @@ using DoesNotForwardDeclareAndIncludesAl = DirectStruct2;
 struct IndirectStruct2;
 using DoesEverythingRightAl = IndirectStruct2;
 
+using HeaderDoubleAl = DoesEverythingRightAl;
+
 // --- Now do it all again, with templates!
 
 // IWYU: TplIndirectStruct1 needs a declaration

--- a/tests/cxx/iwyu_stricter_than_cpp-typedefs.h
+++ b/tests/cxx/iwyu_stricter_than_cpp-typedefs.h
@@ -44,6 +44,8 @@ typedef DirectStruct2 DoesNotForwardDeclareAndIncludes;
 struct IndirectStruct2;
 typedef IndirectStruct2 DoesEverythingRight;
 
+typedef DoesEverythingRight HeaderDoubleTypedef;
+
 // --- Now do it all again, with templates!
 
 // IWYU: IndirectStruct1 needs a declaration
@@ -95,6 +97,21 @@ typedef IndirectStruct3 IndirectStruct3NonProvidingTypedef;
 struct IndirectStruct4;
 typedef IndirectStruct4 IndirectStruct4NonProvidingTypedef;
 
+// ---
+
+template <typename T1, typename T2>
+struct WithAlias {
+  // IWYU: TplIndirectStruct1 needs a declaration
+  // IWYU: TplIndirectStruct1 is...*iwyu_stricter_than_cpp-i1.h
+  using Type = TplIndirectStruct1<T1>;
+};
+
+inline void TestInstantiationDoesntProvide() {
+  // Test that IWYU should not suggest to provide underlying type of template
+  // internal type alias on instantiation side.
+  // IWYU: TplIndirectStruct1 needs a declaration
+  WithAlias<int, TplIndirectStruct1<int>> wa;
+}
 
 /**** IWYU_SUMMARY
 

--- a/tests/cxx/iwyu_stricter_than_cpp.cc
+++ b/tests/cxx/iwyu_stricter_than_cpp.cc
@@ -71,14 +71,18 @@ struct NonUsingType {
   T* t = nullptr;
 };
 
-template <typename T1, typename T2>
-struct WithAlias {
-  // IWYU: TplIndirectStruct2 needs a declaration
-  // IWYU: TplIndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
-  using Type = TplIndirectStruct2<T1>;
-};
-
 typedef DoesEverythingRight DoubleTypedef;
+
+// Source file typedefs don't provide anything.
+// IWYU: IndirectClass needs a declaration
+typedef IndirectClass NotFullyUsedLocalTypedef;
+// IWYU: IndirectClass needs a declaration
+typedef IndirectClass FullyUsedLocalTypedef;
+// IWYU: TplIndirectStruct3 needs a declaration
+// IWYU: IndirectStruct2 needs a declaration
+// IWYU: IndirectStruct1 needs a declaration
+typedef TplIndirectStruct3<IndirectStruct2, IndirectStruct1>
+    TplIndirectStruct3LocalTypedef;
 
 // If the typedef in -typedefs.h requires the full type, then users of
 // that typedef (here) do not.  Otherwise, they do.
@@ -95,6 +99,8 @@ void TestTypedefs() {
   // same things DoesEverythingRight does.
   // IWYU: IndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
   DoubleTypedef dt(6);
+  // IWYU: IndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
+  HeaderDoubleTypedef hdt(6);
 
   // ...and with templates.
   TplDoesNotForwardDeclare tdnfd(7);
@@ -163,9 +169,28 @@ void TestTypedefs() {
   // IWYU: IndirectStruct4 is...*iwyu_stricter_than_cpp-i4.h
   // IWYU: IndirectClass is...*indirect.h
   IndirectStruct4NonProvidingTypedef::IndirectClassNonProvidingTypedef nn;
+
+  // Test that typedefs from .cc-file don't provide.
+  NotFullyUsedLocalTypedef* pnfult;
+  // IWYU: IndirectClass is...*indirect.h
+  FullyUsedLocalTypedef fult;
+  // IWYU: TplIndirectStruct3 is...*iwyu_stricter_than_cpp-i5.h
+  // IWYU: IndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
+  TplIndirectStruct3LocalTypedef tis3lt;
 }
 
 using DoubleTypedefAl = DoesEverythingRightAl;
+
+// Source file type aliases don't provide anything.
+// IWYU: IndirectClass needs a declaration
+using NotFullyUsedLocalAl = IndirectClass;
+// IWYU: IndirectClass needs a declaration
+using FullyUsedLocalAl = IndirectClass;
+using TplIndirectStruct3LocalAl =
+    // IWYU: TplIndirectStruct3 needs a declaration
+    // IWYU: IndirectStruct2 needs a declaration
+    // IWYU: IndirectStruct1 needs a declaration
+    TplIndirectStruct3<IndirectStruct2, IndirectStruct1>;
 
 void TestTypeAliases() {
   DoesNotForwardDeclareAl dnfd(1);
@@ -179,6 +204,8 @@ void TestTypeAliases() {
   // same things DoesEverythingRightAl does.
   // IWYU: IndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
   DoubleTypedefAl dt(6);
+  // IWYU: IndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
+  HeaderDoubleAl hda(6);
 
   // ...and with templates.
   TplDoesNotForwardDeclareAl tdnfd(7);
@@ -248,11 +275,26 @@ void TestTypeAliases() {
   // IWYU: IndirectClass is...*indirect.h
   IndirectStruct4NonProvidingAl::IndirectClassNonProvidingAl nn;
 
-  // Test that IWYU should not suggest to provide underlying type of template
-  // internal type alias on instantiation side.
-  // IWYU: TplIndirectStruct2 needs a declaration
-  WithAlias<int, TplIndirectStruct2<int>> wa;
+  // Test that aliases from .cc-file don't provide.
+  NotFullyUsedLocalAl* pnfula;
+  // IWYU: IndirectClass is...*indirect.h
+  FullyUsedLocalAl fula;
+  // IWYU: TplIndirectStruct3 is...*iwyu_stricter_than_cpp-i5.h
+  // IWYU: IndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
+  TplIndirectStruct3LocalAl tis3la;
 }
+
+// Source file alias templates don't provide anything.
+template <typename>
+// IWYU: IndirectClass needs a declaration
+using NotFullyUsedLocalAlTpl = IndirectClass;
+template <typename>
+// IWYU: IndirectClass needs a declaration
+using FullyUsedLocalAlTpl = IndirectClass;
+template <typename T>
+// IWYU: TplIndirectStruct3 needs a declaration
+// IWYU: IndirectStruct2 needs a declaration
+using TplIndirectStruct3LocalAlTpl = TplIndirectStruct3<IndirectStruct2, T>;
 
 void TestAliasTemplates() {
   DoesNotForwardDeclareAlTpl<int> dnfd(1);
@@ -282,6 +324,15 @@ void TestAliasTemplates() {
       argument_provided;
   // IWYU: IndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
   TemplateProvidedArgumentUsed<DoesEverythingRight> argument_not_provided;
+
+  // Test that alias templates from .cc-file don't provide.
+  NotFullyUsedLocalAlTpl<int>* pnfulat;
+  // IWYU: IndirectClass is...*indirect.h
+  FullyUsedLocalAlTpl<int> fulat;
+  // IWYU: TplIndirectStruct3 is...*iwyu_stricter_than_cpp-i5.h
+  // IWYU: IndirectStruct1 needs a declaration
+  // IWYU: IndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
+  TplIndirectStruct3LocalAlTpl<IndirectStruct1> tis3lat;
 }
 
 void TestAutocast() {
@@ -345,6 +396,10 @@ template <typename Ret, Ret Fn()>
 void Call() {
   Fn();
 }
+
+// A function declared in a source file doesn't provide its return type.
+// IWYU: IndirectStruct2 needs a declaration
+IndirectStruct2 LocalGetIndirectStruct2();
 
 void TestFunctionReturn() {
   // In each of these cases, we bind the return value to a reference,
@@ -445,17 +500,33 @@ void TestFunctionReturn() {
        TplOnlyTemplateProvidedFn>();
 
   // -- Call from a template with "providing" alias as a template argument.
-
-  // IWYU: TplIndirectStruct3 needs a declaration
-  // IWYU: TplIndirectStruct3 is...*iwyu_stricter_than_cpp-i5.h
-  // IWYU: IndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
-  using Alias = TplIndirectStruct3<IndirectStruct2, IndirectStruct2>;
-
-  Call<Alias, TplAllForwardDeclaredFn>();
+  // IWYU: TplAllForwardDeclaredFnRetTypeProviding is...*-i5.h
+  Call<TplAllForwardDeclaredFnRetTypeProviding, TplAllForwardDeclaredFn>();
 
   // IWYU: IndirectClass is...*indirect.h
   RetNonProvidingTypedef();
+
+  // IWYU: IndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
+  LocalGetIndirectStruct2();
 }
+
+// Source file templates don't provide their default arguments.
+// IWYU: IndirectStruct2 needs a declaration
+template <typename T1 = IndirectStruct2,
+          typename T2 = DirectStruct7,
+          typename T3 = DirectStruct8>
+struct LocalTplWithDefaultArgs {
+  LocalTplWithDefaultArgs();
+
+  T1 t1;
+  T2 t2;
+  T3* pt3;
+};
+
+template <typename T = DirectStruct8>
+struct UnusedLocalTplWithDefaultArg {
+  T t;
+};
 
 void TestDefaultTplArgs() {
   // There is currently some difference between default type template arguments
@@ -471,6 +542,11 @@ void TestDefaultTplArgs() {
   // which means it is considered as provided in template instantiation context.
   // IWYU: IndirectStruct3 is...*iwyu_stricter_than_cpp-i3.h
   TplWithDefaultArgs<> t;
+
+  // IWYU should also report the full use of directly included DirectStruct7:
+  // IWYU_SUMMARY should not contain "(ptr only)" comment for it.
+  // IWYU: IndirectStruct2 is...*iwyu_stricter_than_cpp-i2.h
+  LocalTplWithDefaultArgs<> lt;
 }
 
 /**** IWYU_SUMMARY
@@ -500,15 +576,15 @@ The full include-list for tests/cxx/iwyu_stricter_than_cpp.cc:
 #include "tests/cxx/indirect.h"  // for IndirectClass
 #include "tests/cxx/iwyu_stricter_than_cpp-autocast.h"  // for FnRefs, FnValues, HeaderDefinedFnRefs, HeaderDefinedTplFnRefs, TplFnRefs, TplFnValues
 #include "tests/cxx/iwyu_stricter_than_cpp-d3.h"  // for IndirectStruct3ProvidingAl, IndirectStruct3ProvidingTypedef, IndirectStruct4ProvidingAl, IndirectStruct4ProvidingTypedef
-#include "tests/cxx/iwyu_stricter_than_cpp-d5.h"  // for RetNonProvidingTypedef
+#include "tests/cxx/iwyu_stricter_than_cpp-d5.h"  // for DirectStruct7, DirectStruct8 (ptr only), RetNonProvidingTypedef
 #include "tests/cxx/iwyu_stricter_than_cpp-def_tpl_arg.h"  // for TplWithDefaultArgs
 #include "tests/cxx/iwyu_stricter_than_cpp-fnreturn.h"  // for DoesEverythingRightFn, DoesNotForwardDeclareAndIncludesFn, DoesNotForwardDeclareFn, DoesNotForwardDeclareProperlyFn, IncludesFn, TplAllForwardDeclaredFn, TplAllNeededTypesProvidedFn, TplDoesEverythingRightAgainFn, TplDoesEverythingRightFn, TplDoesNotForwardDeclareAndIncludesFn, TplDoesNotForwardDeclareFn, TplDoesNotForwardDeclareProperlyFn, TplIncludesFn, TplOnlyArgumentTypeProvidedFn, TplOnlyTemplateProvidedFn
 #include "tests/cxx/iwyu_stricter_than_cpp-i2.h"  // for IndirectStruct2, TplIndirectStruct2
 #include "tests/cxx/iwyu_stricter_than_cpp-i3.h"  // for IndirectStruct3
 #include "tests/cxx/iwyu_stricter_than_cpp-i4.h"  // for IndirectStruct4
-#include "tests/cxx/iwyu_stricter_than_cpp-i5.h"  // for TplIndirectStruct3
-#include "tests/cxx/iwyu_stricter_than_cpp-type_alias.h"  // for DoesEverythingRightAl, DoesEverythingRightAlTpl, DoesNotForwardDeclareAl, DoesNotForwardDeclareAlTpl, DoesNotForwardDeclareAndIncludesAl, DoesNotForwardDeclareAndIncludesAlTpl, DoesNotForwardDeclareProperlyAl, IncludesAl, IncludesAlTpl, IncludesElaboratedAl, IndirectStruct3NonProvidingAl, IndirectStruct4NonProvidingAl, TemplateNotProvidedArgumentNotUsed, TemplateNotProvidedArgumentUsed, TemplateProvidedArgumentNotUsed, TemplateProvidedArgumentUsed, TplAllForwardDeclaredAl, TplAllNeededTypesProvidedAl, TplDoesEverythingRightAgainAl, TplDoesEverythingRightAl, TplDoesNotForwardDeclareAl, TplDoesNotForwardDeclareAndIncludesAl, TplDoesNotForwardDeclareProperlyAl, TplIncludesAl, TplOnlyArgumentTypeProvidedAl, TplOnlyTemplateProvidedAl
-#include "tests/cxx/iwyu_stricter_than_cpp-typedefs.h"  // for DoesEverythingRight, DoesNotForwardDeclare, DoesNotForwardDeclareAndIncludes, DoesNotForwardDeclareProperly, Includes, IncludesElaborated, IncludesPublicHeader, IndirectStruct3NonProvidingTypedef, IndirectStruct4NonProvidingTypedef, TplAllForwardDeclared, TplAllNeededTypesProvided, TplDoesEverythingRight, TplDoesEverythingRightAgain, TplDoesNotForwardDeclare, TplDoesNotForwardDeclareAndIncludes, TplDoesNotForwardDeclareProperly, TplIncludes, TplOnlyArgumentTypeProvided, TplOnlyTemplateProvided
+#include "tests/cxx/iwyu_stricter_than_cpp-i5.h"  // for TplAllForwardDeclaredFnRetTypeProviding, TplIndirectStruct3
+#include "tests/cxx/iwyu_stricter_than_cpp-type_alias.h"  // for DoesEverythingRightAl, DoesEverythingRightAlTpl, DoesNotForwardDeclareAl, DoesNotForwardDeclareAlTpl, DoesNotForwardDeclareAndIncludesAl, DoesNotForwardDeclareAndIncludesAlTpl, DoesNotForwardDeclareProperlyAl, HeaderDoubleAl, IncludesAl, IncludesAlTpl, IncludesElaboratedAl, IndirectStruct3NonProvidingAl, IndirectStruct4NonProvidingAl, TemplateNotProvidedArgumentNotUsed, TemplateNotProvidedArgumentUsed, TemplateProvidedArgumentNotUsed, TemplateProvidedArgumentUsed, TplAllForwardDeclaredAl, TplAllNeededTypesProvidedAl, TplDoesEverythingRightAgainAl, TplDoesEverythingRightAl, TplDoesNotForwardDeclareAl, TplDoesNotForwardDeclareAndIncludesAl, TplDoesNotForwardDeclareProperlyAl, TplIncludesAl, TplOnlyArgumentTypeProvidedAl, TplOnlyTemplateProvidedAl
+#include "tests/cxx/iwyu_stricter_than_cpp-typedefs.h"  // for DoesEverythingRight, DoesNotForwardDeclare, DoesNotForwardDeclareAndIncludes, DoesNotForwardDeclareProperly, HeaderDoubleTypedef, Includes, IncludesElaborated, IncludesPublicHeader, IndirectStruct3NonProvidingTypedef, IndirectStruct4NonProvidingTypedef, TplAllForwardDeclared, TplAllNeededTypesProvided, TplDoesEverythingRight, TplDoesEverythingRightAgain, TplDoesNotForwardDeclare, TplDoesNotForwardDeclareAndIncludes, TplDoesNotForwardDeclareProperly, TplIncludes, TplOnlyArgumentTypeProvided, TplOnlyTemplateProvided
 struct DirectStruct1;
 struct DirectStruct2;
 struct IndirectStruct1;

--- a/tests/cxx/precomputed_tpl_args.cc
+++ b/tests/cxx/precomputed_tpl_args.cc
@@ -19,6 +19,7 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <bitset>
+#include "tests/cxx/precomputed_tpl_args.h"
 #include "tests/cxx/precomputed_tpl_args-d1.h"
 
 template <typename T> struct Identity {
@@ -139,6 +140,7 @@ tests/cxx/precomputed_tpl_args.cc should add these lines:
 tests/cxx/precomputed_tpl_args.cc should remove these lines:
 
 The full include-list for tests/cxx/precomputed_tpl_args.cc:
+#include "tests/cxx/precomputed_tpl_args.h"
 #include <bitset>  // for bitset
 #include <forward_list>  // for forward_list
 #include <list>  // for list

--- a/tests/cxx/precomputed_tpl_args.h
+++ b/tests/cxx/precomputed_tpl_args.h
@@ -1,0 +1,19 @@
+//===--- precomputed_tpl_args.h - test input file for iwyu ----------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include <set>
+
+// Same as IntSet in .cc-file, but the typedef is handled as providing.
+typedef std::set<int> HeaderIntSet;
+
+/**** IWYU_SUMMARY
+
+(tests/cxx/precomputed_tpl_args.h has correct #includes/fwd-decls)
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/template_args-d3.h
+++ b/tests/cxx/template_args-d3.h
@@ -1,0 +1,53 @@
+//===--- template_args-d3.h - test input file for iwyu --------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/direct.h"
+
+template <typename>
+struct TplWithMethodWithoutDef;
+
+template <typename>
+struct Host;
+
+// The type aliases below provide IndirectClass.
+
+// IWYU: IndirectClass is...*indirect.h
+using IndirectClassProviding = IndirectClass;
+
+// IWYU: IndirectClass is...*indirect.h
+using ProvidingFunctionAlias = IndirectClass(IndirectClass);
+
+// IWYU: IndirectClass is...*indirect.h
+using TplWithMethodWithoutDefProviding = TplWithMethodWithoutDef<IndirectClass>;
+
+template <int>
+// IWYU: IndirectClass is...*indirect.h
+using ProvidingPtrAlias = IndirectClass*;
+
+// IWYU: IndirectClass is...*indirect.h
+using HostProvidingAlias = Host<IndirectClass>;
+
+template <typename>
+// IWYU: IndirectClass is...*indirect.h
+using HostProvidingAliasTpl = Host<IndirectClass>;
+
+/**** IWYU_SUMMARY
+
+tests/cxx/template_args-d3.h should add these lines:
+#include "tests/cxx/indirect.h"
+
+tests/cxx/template_args-d3.h should remove these lines:
+- #include "tests/cxx/direct.h"  // lines XX-XX
+
+The full include-list for tests/cxx/template_args-d3.h:
+#include "tests/cxx/indirect.h"  // for IndirectClass
+template <typename> struct Host;  // lines XX-XX+1
+template <typename> struct TplWithMethodWithoutDef;  // lines XX-XX+1
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/template_args.cc
+++ b/tests/cxx/template_args.cc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// IWYU_ARGS: -I .
+// IWYU_ARGS: -I . -Xiwyu --check_also=tests/cxx/*-d3.h
 
 // Tests unusual and complex use of template arguments, such as
 // function-proto template arguments, for both classes and functions.
@@ -15,11 +15,7 @@
 #include "tests/cxx/direct.h"
 #include "tests/cxx/template_args-d1.h"
 #include "tests/cxx/template_args-d2.h"
-
-// IWYU: IndirectClass is...*indirect.h
-using IndirectClassProviding = IndirectClass;
-
-// ---------------------------------------------------------------
+#include "tests/cxx/template_args-d3.h"
 
 // IWYU: IndirectClass needs a declaration
 char Foo(IndirectClass ic);
@@ -41,8 +37,6 @@ void FunctionProtoClassArguments() {
   FunctionStruct<IndirectClass(char)> f2;
   (void)f2;
 
-  // IWYU: IndirectClass is...*indirect.h
-  using ProvidingFunctionAlias = IndirectClass(IndirectClass);
   FunctionStruct<ProvidingFunctionAlias> f3;
   // IWYU: IndirectClass is...*indirect.h
   FunctionStruct<NonProvidingFunctionAlias1> f4;
@@ -204,24 +198,47 @@ void TestCreateTemporary() {
 
 // ---------------------------------------------------------------
 
-// IWYU: IndirectClass is...*indirect.h
+// IWYU: IndirectClass needs a declaration
 typedef IndirectClass LocalClass;
 
 void TestResugaringOfTypedefs() {
+  // IWYU: IndirectClass is...*indirect.h
   FunctionStruct<char(LocalClass&)> f1;
   (void)f1;
 
   LocalClass* lc = 0;
+  // IWYU: IndirectClass is...*indirect.h
   PointerStruct<LocalClass*>::a(lc);
+  // IWYU: IndirectClass is...*indirect.h
   DoublePointerStruct<LocalClass**>::a(&lc);
+  // IWYU: IndirectClass is...*indirect.h
   PointerStruct2<LocalClass>::a(lc);
+  // IWYU: IndirectClass is...*indirect.h
   DoublePointerStruct2<LocalClass>::a(&lc);
 
+  // IWYU: IndirectClass is...*indirect.h
   Outer<Inner<LocalClass> > oi;
   (void)oi;
 
+  // IWYU: IndirectClass is...*indirect.h
   CreateTemporary<LocalClass>::a();
+  // IWYU: IndirectClass is...*indirect.h
   CreateTemporary<int>::b<LocalClass>();
+
+  FunctionStruct<char(IndirectClassProviding&)> f1_icp;
+  (void)f1_icp;
+
+  IndirectClassProviding* icp = 0;
+  PointerStruct<IndirectClassProviding*>::a(icp);
+  DoublePointerStruct<IndirectClassProviding**>::a(&icp);
+  PointerStruct2<IndirectClassProviding>::a(icp);
+  DoublePointerStruct2<IndirectClassProviding>::a(&icp);
+
+  Outer<Inner<IndirectClassProviding>> oi_icp;
+  (void)oi_icp;
+
+  CreateTemporary<IndirectClassProviding>::a();
+  CreateTemporary<int>::b<IndirectClassProviding>();
 }
 
 // ---------------------------------------------------------------
@@ -261,9 +278,6 @@ template <typename T>
 struct TplWithMethodWithoutDef {
   static T GetT();
 };
-
-// IWYU: IndirectClass is...*indirect.h
-using TplWithMethodWithoutDefProviding = TplWithMethodWithoutDef<IndirectClass>;
 
 // IWYU: IndirectClass needs a declaration
 // IWYU: IndirectClass is...*indirect.h
@@ -365,7 +379,7 @@ TplStructWithParameterPack2<IndirectClass, IndirectTemplate<int>> tswpp22;
 // IWYU: IndirectClass is...*indirect.h
 TplStructWithParameterPack2<IndirectClass> tswpp23;
 
-// IWYU: IndirectClass is...*indirect.h
+// IWYU: IndirectClass needs a declaration
 template <typename T = IndirectClass, typename... Args>
 struct TplStructWithParameterPackAndDefArg : T, Args... {};
 
@@ -387,8 +401,6 @@ TplStructWithParameterPackAndDefArg<IndirectClass> tswppda2;
 // IWYU: IndirectClass needs a declaration
 TplStructWithParameterPackAndDefArg<IndirectClass>* ptswppda2;
 
-// TODO: probably, no need of IndirectClass here, because it is reported
-// at template declaration.
 // IWYU: IndirectClass is...*indirect.h
 TplStructWithParameterPackAndDefArg<> tswppda3;
 
@@ -405,10 +417,6 @@ constexpr auto inner_tpl_size = sizeof(inner_tpl);
 // instantiation scan. The class template uses dereferenced parameter type so
 // that there is no directly corresponding argument type for resugar_map, and
 // the type provision info should be obtained by GetProvidedTypeComponents.
-
-template <int>
-// IWYU: IndirectClass is...*indirect.h
-using ProvidingPtrAlias = IndirectClass*;
 
 template <typename T>
 struct UsingDereferenced {
@@ -477,13 +485,6 @@ struct Derived : Host<IndirectClass> {
   // IWYU: IndirectClass needs a declaration
   using Host<IndirectClass>::NestedNonTemplate;
 };
-
-// IWYU: IndirectClass is...*indirect.h
-using HostProvidingAlias = Host<IndirectClass>;
-
-template <typename>
-// IWYU: IndirectClass is...*indirect.h
-using HostProvidingAliasTpl = Host<IndirectClass>;
 
 using NestedWithClass = Host<Class>::Intermediate1;
 
@@ -632,6 +633,7 @@ The full include-list for tests/cxx/template_args.cc:
 #include "tests/cxx/indirect.h"  // for IndirectClass, IndirectTemplate
 #include "tests/cxx/template_args-d1.h"  // for ProvidingAlias
 #include "tests/cxx/template_args-d2.h"  // for HostNonProvidingAlias, HostNonProvidingAliasTpl, IndirectClassNonProviding, NonProvidingAlias, NonProvidingFunctionAlias1, NonProvidingFunctionAlias2, NonProvidingPtrAlias, TplWithMethodWithoutDefNonProviding
+#include "tests/cxx/template_args-d3.h"  // for HostProvidingAlias, HostProvidingAliasTpl, IndirectClassProviding, ProvidingFunctionAlias, ProvidingPtrAlias, TplWithMethodWithoutDefProviding
 #include "tests/cxx/template_args-i1.h"  // for Class, GetInt, TplHost, TplInI1
 template <typename F> struct FunctionStruct;  // lines XX-XX
 

--- a/tests/cxx/template_specialization.cc
+++ b/tests/cxx/template_specialization.cc
@@ -12,9 +12,8 @@
 // Tests that when we instantiate a specialized template, we attribute
 // it to the right location.
 
+#include "tests/cxx/template_specialization.h"
 #include "tests/cxx/template_specialization-d1.h"
-#include "tests/cxx/template_specialization-d2.h"
-#include "tests/cxx/template_specialization-d3.h"
 #include "tests/cxx/direct.h"
 
 template<typename T> class Foo;
@@ -50,44 +49,23 @@ template<>
 // IWYU: IndirectClass is...*indirect.h
 struct Specialized<int> : IndirectClass {};
 
-// When a specialization requires a forward-declaration of the primary template,
-// a fwd-decl in the current file should be preferred to one in the
-// otherwise-unused include -d2.h.
-// The type alias is needed to trigger a full-use report because there is no
-// forward-declaration in the alias-defining file. That full use is then
-// recategorized to fwd-decl use because the defn is actually after the alias.
-// IWYU: FwdDeclaredTpl needs a declaration
-using FwdDeclaredTplSpecAlias = FwdDeclaredTpl<1>;
-// IWYU: FwdDeclaredTpl needs a declaration
-template <> class FwdDeclaredTpl<1> {};
-
-// IWYU: DefinedBeforeSpec needs a declaration
-using DefinedBeforeSpecAlias = DefinedBeforeSpec<1>;
-// Define the primary template; no diagnostic here.
-template <int> class DefinedBeforeSpec {};
-
 /**** IWYU_SUMMARY
 
 tests/cxx/template_specialization.cc should add these lines:
 #include "tests/cxx/indirect.h"
 #include "tests/cxx/template_specialization-i1.h"
 #include "tests/cxx/template_specialization-i2.h"
-template <int> class DefinedBeforeSpec;
-template <int> class FwdDeclaredTpl;
 
 tests/cxx/template_specialization.cc should remove these lines:
 - #include "tests/cxx/direct.h"  // lines XX-XX
 - #include "tests/cxx/template_specialization-d1.h"  // lines XX-XX
-- #include "tests/cxx/template_specialization-d2.h"  // lines XX-XX
-- #include "tests/cxx/template_specialization-d3.h"  // lines XX-XX
 - template <typename T> class Foo;  // lines XX-XX
 
 The full include-list for tests/cxx/template_specialization.cc:
+#include "tests/cxx/template_specialization.h"
 #include "tests/cxx/indirect.h"  // for IndirectClass
 #include "tests/cxx/template_specialization-i1.h"  // for Foo
 #include "tests/cxx/template_specialization-i2.h"  // for Foo
-template <int> class DefinedBeforeSpec;
-template <int> class FwdDeclaredTpl;
 template <typename T> struct Specialized;  // lines XX-XX+1
 
 ***** IWYU_SUMMARY */

--- a/tests/cxx/template_specialization.h
+++ b/tests/cxx/template_specialization.h
@@ -1,0 +1,45 @@
+//===--- template_specialization.h - test input file for iwyu -------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/template_specialization-d2.h"
+#include "tests/cxx/template_specialization-d3.h"
+
+// When a specialization requires a forward-declaration of the primary template,
+// a fwd-decl in the current file should be preferred to one in the
+// otherwise-unused include -d2.h.
+// The type alias is needed to trigger a full-use report because there is no
+// forward-declaration in the alias-defining file. That full use is then
+// recategorized to fwd-decl use because the defn is actually after the alias.
+// IWYU: FwdDeclaredTpl needs a declaration
+using FwdDeclaredTplSpecAlias = FwdDeclaredTpl<1>;
+template <>
+// IWYU: FwdDeclaredTpl needs a declaration
+class FwdDeclaredTpl<1> {};
+
+// IWYU: DefinedBeforeSpec needs a declaration
+using DefinedBeforeSpecAlias = DefinedBeforeSpec<1>;
+// Define the primary template; no diagnostic here.
+template <int>
+class DefinedBeforeSpec {};
+
+/**** IWYU_SUMMARY
+
+tests/cxx/template_specialization.h should add these lines:
+template <int> class DefinedBeforeSpec;
+template <int> class FwdDeclaredTpl;
+
+tests/cxx/template_specialization.h should remove these lines:
+- #include "tests/cxx/template_specialization-d2.h"  // lines XX-XX
+- #include "tests/cxx/template_specialization-d3.h"  // lines XX-XX
+
+The full include-list for tests/cxx/template_specialization.h:
+template <int> class DefinedBeforeSpec;
+template <int> class FwdDeclaredTpl;
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/type_pack_elem.cc
+++ b/tests/cxx/type_pack_elem.cc
@@ -12,6 +12,7 @@
 // Tests that __type_pack_element (used in standard library implementations of
 // std::tuple) types are recognized and reported.
 
+#include "tests/cxx/type_pack_elem.h"
 #include "tests/cxx/direct.h"
 
 // IWYU: IndirectClass needs a declaration
@@ -36,9 +37,6 @@ __type_pack_element<0, decltype(IndirectClass::a)>*
     member_expr_ptr;
 
 // Provided types
-// IWYU: IndirectClass is...*indirect.h
-using Providing = IndirectClass;
-
 __type_pack_element<0, Providing>
     type_is_provided_by_arg;
 
@@ -88,12 +86,11 @@ void Tuple1617() {
 /**** IWYU_SUMMARY
 
 tests/cxx/type_pack_elem.cc should add these lines:
-#include "tests/cxx/indirect.h"
 
 tests/cxx/type_pack_elem.cc should remove these lines:
 - #include "tests/cxx/direct.h"  // lines XX-XX
 
 The full include-list for tests/cxx/type_pack_elem.cc:
-#include "tests/cxx/indirect.h"  // for IndirectClass
+#include "tests/cxx/type_pack_elem.h"
 
 ***** IWYU_SUMMARY */

--- a/tests/cxx/type_pack_elem.h
+++ b/tests/cxx/type_pack_elem.h
@@ -1,0 +1,26 @@
+//===--- type_pack_elem.h - test input file for iwyu ----------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/direct.h"
+
+// IWYU: IndirectClass is...*indirect.h
+using Providing = IndirectClass;
+
+/**** IWYU_SUMMARY
+
+tests/cxx/type_pack_elem.h should add these lines:
+#include "tests/cxx/indirect.h"
+
+tests/cxx/type_pack_elem.h should remove these lines:
+- #include "tests/cxx/direct.h"  // lines XX-XX
+
+The full include-list for tests/cxx/type_pack_elem.h:
+#include "tests/cxx/indirect.h"  // for IndirectClass
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/typedef_in_template-d3.h
+++ b/tests/cxx/typedef_in_template-d3.h
@@ -1,0 +1,132 @@
+//===--- typedef_in_template-d3.h - test input file for iwyu --------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "tests/cxx/direct.h"
+#include "tests/cxx/typedef_in_template-d1.h"
+#include "tests/cxx/typedef_in_template-d2.h"
+
+template <typename T>
+struct Identity;
+
+// Some cases from typedef_in_template.cc have been duplicated here to test them
+// with a different provision policy (only typedefs from headers can provide
+// their underlying types).
+
+template <class T1, class T2>
+class HeaderContainer {
+ public:
+  // Should not be an iwyu violation for T1
+  typedef T1 value_type;
+
+  // C++11 alias declaration, should not be an iwyu violation for T1
+  using alias_type = T1;
+
+  // IWYU: Pair needs a declaration
+  // IWYU: Pair is...*typedef_in_template-i2.h
+  typedef Pair<T2, T2> pair_type;
+};
+
+template <typename T>
+struct Header_UsesAliasedParameter {
+  using TAlias = T;
+  TAlias t;
+};
+
+template <typename T>
+struct Header_IndirectlyUsesAliasedParameter {
+  using TAlias = typename Header_UsesAliasedParameter<T>::TAlias;
+  TAlias t;
+};
+
+template <typename T>
+struct Header_NestedUseOfAliasedParameter {
+  using UserAlias = Header_UsesAliasedParameter<T>;
+  UserAlias a;
+};
+
+template <typename T>
+struct Header_UsesAliasedSugaredParameter {
+  static T t1;
+  using TAlias = decltype(t1);
+  TAlias t2;
+};
+
+// IWYU: IndirectClass is...*indirect.h
+using Providing = IndirectClass;
+
+// This alias provides IndirectClass.
+// IWYU: IndirectClass is...*indirect.h
+using ProvidingNested = Identity<IndirectClass>;
+
+template <typename T>
+struct HeaderIdentity {
+  static T t;
+  using SugaredType = decltype(t);
+
+  template <int>
+  using AliasTemplate = T;
+};
+
+template <typename T>
+struct HeaderOuter {
+  template <typename U>
+  struct Inner {
+    // IWYU: Pair needs a declaration
+    // IWYU: Pair is...*typedef_in_template-i2.h
+    using AliasedTpl = Pair<T, U>;
+  };
+};
+
+template <typename T>
+struct UnaryTransformTypes {
+  using AddPointer = __add_pointer(T);
+  using RemoveAllExtents = __remove_all_extents(T);
+  using RemovePointer = __remove_pointer(T);
+  using RemoveReference = __remove_reference_t(T);
+  using Identity = __remove_reference_t(T&);
+  // IWYU: Pair needs a declaration
+  // IWYU: Pair is...*typedef_in_template-i2.h
+  // IWYU: Class1 is...*typedef_in_template-i1.h
+  using PairAlias1 = __remove_pointer(Pair<Class1, T>*);
+  // IWYU: Pair needs a declaration
+  // IWYU: Pair is...*typedef_in_template-i2.h
+  // IWYU: Class1 is...*typedef_in_template-i1.h
+  using PairAlias2 = __remove_pointer(Pair<Class1, T>);
+};
+
+struct NonDependentUnaryTransformTypes {
+  // IWYU: IndirectClass is...*indirect.h
+  using RemoveAllExtents = __remove_all_extents(IndirectClass[2][3]);
+  // IWYU: IndirectClass is...*indirect.h
+  using RemovePointer = __remove_pointer(IndirectClass*);
+  // IWYU: IndirectClass is...*indirect.h
+  using RemoveReference = __remove_reference_t(IndirectClass&);
+  // IWYU: IndirectClass is...*indirect.h
+  using DummyRemoveReference = __remove_reference_t(IndirectClass);
+};
+
+/**** IWYU_SUMMARY
+
+tests/cxx/typedef_in_template-d3.h should add these lines:
+#include "tests/cxx/indirect.h"
+#include "tests/cxx/typedef_in_template-i1.h"
+#include "tests/cxx/typedef_in_template-i2.h"
+
+tests/cxx/typedef_in_template-d3.h should remove these lines:
+- #include "tests/cxx/direct.h"  // lines XX-XX
+- #include "tests/cxx/typedef_in_template-d1.h"  // lines XX-XX
+- #include "tests/cxx/typedef_in_template-d2.h"  // lines XX-XX
+
+The full include-list for tests/cxx/typedef_in_template-d3.h:
+#include "tests/cxx/indirect.h"  // for IndirectClass
+#include "tests/cxx/typedef_in_template-i1.h"  // for Class1
+#include "tests/cxx/typedef_in_template-i2.h"  // for Pair
+template <typename T> struct Identity;  // lines XX-XX+1
+
+***** IWYU_SUMMARY */

--- a/tests/cxx/typedef_in_template.cc
+++ b/tests/cxx/typedef_in_template.cc
@@ -7,11 +7,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-// IWYU_ARGS: -std=c++11 -I .
+// IWYU_ARGS: -std=c++11 -I . \
+//            -Xiwyu --check_also=tests/cxx/typedef_in_template-d3.h
 
 #include "tests/cxx/direct.h"
 #include "tests/cxx/typedef_in_template-d1.h"
 #include "tests/cxx/typedef_in_template-d2.h"
+#include "tests/cxx/typedef_in_template-d3.h"
 
 template<class T1, class T2>
 class Container {
@@ -23,7 +25,6 @@ class Container {
   using alias_type = T1;
 
   // IWYU: Pair needs a declaration
-  // IWYU: Pair is...*typedef_in_template-i2.h
   typedef Pair<T2,T2> pair_type;
 };
 
@@ -47,12 +48,32 @@ void Declarations() {
   // IWYU: Class1 needs a declaration
   // IWYU: Class2 is...*typedef_in_template-i2.h
   // IWYU: Class2 needs a declaration
+  // IWYU: Pair is...*typedef_in_template-i2.h
   Container<Class1, Class2>::pair_type pt;
 
   // IWYU: Class1 is...*typedef_in_template-i1.h
   // IWYU: Class1 needs a declaration
   // IWYU: Class2 needs a declaration
   Container<Class1, Class2>::alias_type at;
+
+  // IWYU: Class1 needs a declaration
+  // IWYU: Class2 needs a declaration
+  HeaderContainer<Class1, Class2> hc;
+
+  // IWYU: Class1 is...*typedef_in_template-i1.h
+  // IWYU: Class1 needs a declaration
+  // IWYU: Class2 needs a declaration
+  HeaderContainer<Class1, Class2>::value_type hvt;
+
+  // IWYU: Class1 needs a declaration
+  // IWYU: Class2 is...*typedef_in_template-i2.h
+  // IWYU: Class2 needs a declaration
+  HeaderContainer<Class1, Class2>::pair_type hpt;
+
+  // IWYU: Class1 is...*typedef_in_template-i1.h
+  // IWYU: Class1 needs a declaration
+  // IWYU: Class2 needs a declaration
+  HeaderContainer<Class1, Class2>::alias_type hat;
 }
 
 // STL containers are often implemented via a complex web of type aliases and
@@ -81,6 +102,17 @@ constexpr auto s1 = sizeof(UsesAliasedParameter<IndirectClass>);
 // IWYU: IndirectClass needs a declaration
 UsesAliasedParameter<IndirectClass>::TAlias a2;
 
+// IWYU: IndirectClass is...*indirect.h
+// IWYU: IndirectClass needs a declaration
+Header_UsesAliasedParameter<IndirectClass> ha;
+// IWYU: IndirectClass is...*indirect.h
+// IWYU: IndirectClass needs a declaration
+constexpr auto hs1 = sizeof(Header_UsesAliasedParameter<IndirectClass>);
+
+// IWYU: IndirectClass is...*indirect.h
+// IWYU: IndirectClass needs a declaration
+Header_UsesAliasedParameter<IndirectClass>::TAlias ha2;
+
 // Try a more complex example, through an additional layer of indirection.
 template <typename T>
 struct IndirectlyUsesAliasedParameter {
@@ -92,6 +124,10 @@ struct IndirectlyUsesAliasedParameter {
 // IWYU: IndirectClass needs a declaration
 IndirectlyUsesAliasedParameter<IndirectClass> b;
 
+// IWYU: IndirectClass is...*indirect.h
+// IWYU: IndirectClass needs a declaration
+Header_IndirectlyUsesAliasedParameter<IndirectClass> hb;
+
 template <typename T>
 struct NestedUseOfAliasedParameter {
   using UserAlias = UsesAliasedParameter<T>;
@@ -101,6 +137,10 @@ struct NestedUseOfAliasedParameter {
 // IWYU: IndirectClass is...*indirect.h
 // IWYU: IndirectClass needs a declaration
 NestedUseOfAliasedParameter<IndirectClass> c;
+
+// IWYU: IndirectClass is...*indirect.h
+// IWYU: IndirectClass needs a declaration
+Header_NestedUseOfAliasedParameter<IndirectClass> hc;
 
 template <typename T>
 struct UsesAliasedSugaredParameter {
@@ -112,6 +152,10 @@ struct UsesAliasedSugaredParameter {
 // IWYU: IndirectClass is...*indirect.h
 // IWYU: IndirectClass needs a declaration
 constexpr auto s2 = sizeof(UsesAliasedSugaredParameter<IndirectClass>);
+
+// IWYU: IndirectClass is...*indirect.h
+// IWYU: IndirectClass needs a declaration
+constexpr auto hs2 = sizeof(Header_UsesAliasedSugaredParameter<IndirectClass>);
 
 // Passing aliased type as a template argument.
 
@@ -135,16 +179,9 @@ struct Outer {
   template <typename U>
   struct Inner {
     // IWYU: Pair needs a declaration
-    // IWYU: Pair is...*typedef_in_template-i2.h
     using AliasedTpl = Pair<T, U>;
   };
 };
-
-// IWYU: IndirectClass is...*indirect.h
-using Providing = IndirectClass;
-
-// IWYU: IndirectClass is...*indirect.h
-using ProvidingNested = Identity<IndirectClass>;
 
 struct ConstructionFromIndirectClass {
   // IWYU: IndirectClass needs a declaration
@@ -155,6 +192,10 @@ struct AggregateContainingIndirectClass {
   // IWYU: IndirectClass is...*indirect.h
   IndirectClass ic;
 };
+
+template <int>
+using ProvidingLocalAliasTpl = ProvidingNested;
+using ProvidingLocal = ProvidingLocalAliasTpl<1>;
 
 void ArgumentTypeProvision() {
   Identity<Providing>::Type p1;
@@ -191,12 +232,22 @@ void ArgumentTypeProvision() {
 
   Identity<Providing>::Inner::Type p3;
 
+  // IWYU: Pair is...*typedef_in_template-i2.h
   Outer<Providing>::Inner<Providing>::AliasedTpl pp;
 
   // IWYU: IndirectClass needs a declaration
+  // IWYU: Pair is...*typedef_in_template-i2.h
   Outer<Providing>::Inner<IndirectClass*>::AliasedTpl p_ptr;
   // IWYU: IndirectClass needs a declaration
+  // IWYU: Pair is...*typedef_in_template-i2.h
   Outer<IndirectClass*>::Inner<Providing>::AliasedTpl ptr_p;
+
+  HeaderOuter<Providing>::Inner<Providing>::AliasedTpl hpp;
+
+  // IWYU: IndirectClass needs a declaration
+  HeaderOuter<Providing>::Inner<IndirectClass*>::AliasedTpl hp_ptr;
+  // IWYU: IndirectClass needs a declaration
+  HeaderOuter<IndirectClass*>::Inner<Providing>::AliasedTpl hptr_p;
 
   Identity<Providing>::AliasTemplate<1> atp;
   (void)sizeof(Identity<Providing>::AliasTemplate<1>);
@@ -207,10 +258,20 @@ void ArgumentTypeProvision() {
   // IWYU: IndirectClass is...*indirect.h
   (void)sizeof(Identity<NonProviding>::AliasTemplate<1>);
 
+  HeaderIdentity<Providing>::AliasTemplate<1> hatp;
+  (void)sizeof(HeaderIdentity<Providing>::AliasTemplate<1>);
+  // IWYU: NonProviding is...*typedef_in_template-i1.h
+  // IWYU: IndirectClass is...*indirect.h
+  HeaderIdentity<NonProviding>::AliasTemplate<1> hatn;
+  // IWYU: NonProviding is...*typedef_in_template-i1.h
+  // IWYU: IndirectClass is...*indirect.h
+  (void)sizeof(HeaderIdentity<NonProviding>::AliasTemplate<1>);
+
   ProvidingNested::Type pnt;
   // IWYU: NonProvidingNested is...*typedef_in_template-i1.h
   // IWYU: IndirectClass is...*indirect.h
   NonProvidingNested::Type nnt;
+  ProvidingLocal::Type plt;
 
   TplProvidingDefArg<>::ArgType tpdaat;
 }
@@ -219,35 +280,11 @@ void ArgumentTypeProvision() {
 // IWYU: IndirectClass is...*indirect.h
 constexpr auto s3 = sizeof(Identity<IndirectClass>::SugaredType);
 
+// IWYU: IndirectClass needs a declaration
+// IWYU: IndirectClass is...*indirect.h
+constexpr auto hs3 = sizeof(HeaderIdentity<IndirectClass>::SugaredType);
+
 // Test handling some of builtin unary transforms in dependent typedefs.
-
-template <typename T>
-struct UnaryTransformTypes {
-  using AddPointer = __add_pointer(T);
-  using RemoveAllExtents = __remove_all_extents(T);
-  using RemovePointer = __remove_pointer(T);
-  using RemoveReference = __remove_reference_t(T);
-  using Identity = __remove_reference_t(T&);
-  // IWYU: Pair needs a declaration
-  // IWYU: Pair is...*typedef_in_template-i2.h
-  // IWYU: Class1 is...*typedef_in_template-i1.h
-  using PairAlias1 = __remove_pointer(Pair<Class1, T>*);
-  // IWYU: Pair needs a declaration
-  // IWYU: Pair is...*typedef_in_template-i2.h
-  // IWYU: Class1 is...*typedef_in_template-i1.h
-  using PairAlias2 = __remove_pointer(Pair<Class1, T>);
-};
-
-struct NonDependentUnaryTransformTypes {
-  // IWYU: IndirectClass is...*indirect.h
-  using RemoveAllExtents = __remove_all_extents(IndirectClass[2][3]);
-  // IWYU: IndirectClass is...*indirect.h
-  using RemovePointer = __remove_pointer(IndirectClass*);
-  // IWYU: IndirectClass is...*indirect.h
-  using RemoveReference = __remove_reference_t(IndirectClass&);
-  // IWYU: IndirectClass is...*indirect.h
-  using DummyRemoveReference = __remove_reference_t(IndirectClass);
-};
 
 void TestUnaryTransformTypes() {
   // IWYU: IndirectClass needs a declaration
@@ -293,6 +330,7 @@ tests/cxx/typedef_in_template.cc should remove these lines:
 The full include-list for tests/cxx/typedef_in_template.cc:
 #include "tests/cxx/indirect.h"  // for IndirectClass
 #include "tests/cxx/typedef_in_template-d1.h"  // for TplProvidingDefArg
+#include "tests/cxx/typedef_in_template-d3.h"  // for HeaderContainer, HeaderIdentity, HeaderOuter, Header_IndirectlyUsesAliasedParameter, Header_NestedUseOfAliasedParameter, Header_UsesAliasedParameter, Header_UsesAliasedSugaredParameter, NonDependentUnaryTransformTypes, Providing, ProvidingNested, UnaryTransformTypes
 #include "tests/cxx/typedef_in_template-i1.h"  // for Class1, NonProviding, NonProvidingNested
 #include "tests/cxx/typedef_in_template-i2.h"  // for Class2, Pair
 


### PR DESCRIPTION
Provision policies make sense only for header files, where IWYU cannot determine how a declaration is going to be used. As opposed to headers, source files are usually not intended to be included in other source files, so IWYU can analyze all the uses of a typedef, a function, or a template. Requiring to include more than needed in a source file for automatic re-export was just a bug.

IWYU already didn't suggest providing return and parameter types for function declarations in source files. This change extends this to typedefs, type aliases, alias templates, and default arguments of template type parameters. Moreover, this fixes an inconsistency in handling function return types in cases like
```cpp
#include "direct.h"

IndirectClass LocalGetIndirectClass();

void Use() {
  LocalGetIndirectClass();
}
```
In such cases, IWYU reported `IndirectClass` type neither at `LocalGetIndirectClass()` declaration nor at its call site, and wrongly suggested replacing `#include` with a forward-declaration.

The new test cases have been added into `iwyu_stricter_than_cpp` and `typedef_in_template` (look for `ProvidingLocal`). A lot of other tests have been changed to maintain their old behavior. In some of them, declarations intended to be providing have been moved into headers. In other tests, some test cases from source files have been duplicated in headers.