### PR TITLE
Fix obtaining aliased template type location

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -5949,8 +5949,12 @@ class IwyuAstConsumer
     // Couldn't files containing other declarations (like primary template
     // redeclarations or explicit specializations or instantiations) provide
     // definitions for default args?
-    if (const Decl* defn = GetDefinitionAsWritten(TypeToDeclAsWritten(type)))
+    // 'type' may be a typedef, so GetCanonicalType is needed to get
+    // the class template.
+    if (const Decl* defn = GetDefinitionAsWritten(
+            TypeToDeclAsWritten(GetCanonicalType(type)))) {
       CollectProvidedByDefaultTplArg(defn->getLocation(), &ret);
+    }
     return ret;
   }
 

--- a/tests/cxx/default_tpl_arg-d2.h
+++ b/tests/cxx/default_tpl_arg-d2.h
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef INCLUDE_WHAT_YOU_USE_TESTS_CXX_DEFAULT_TPL_ARG_D2_H_
+#define INCLUDE_WHAT_YOU_USE_TESTS_CXX_DEFAULT_TPL_ARG_D2_H_
+
 #include "tests/cxx/default_tpl_arg-d1.h"
 #include "tests/cxx/indirect.h"
 
@@ -69,6 +72,13 @@ template <typename T>
 class TplProvidingDefArg4 {
   T t;
 };
+
+template <typename T = IndirectClass>
+class TplProvidingDefArg5 {
+  T t;
+};
+
+#endif  // INCLUDE_WHAT_YOU_USE_TESTS_CXX_DEFAULT_TPL_ARG_D2_H_
 
 /**** IWYU_SUMMARY
 

--- a/tests/cxx/default_tpl_arg-d3.h
+++ b/tests/cxx/default_tpl_arg-d3.h
@@ -1,0 +1,15 @@
+//===--- default_tpl_arg-d3.h - test input file for iwyu ------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// This file doesn't include "indirect.h" hence doesn't provide IndirectClass
+// directly.
+
+#include "tests/cxx/default_tpl_arg-d2.h"
+
+using TplProvidingDefArg5Alias = TplProvidingDefArg5<>;

--- a/tests/cxx/default_tpl_arg.cc
+++ b/tests/cxx/default_tpl_arg.cc
@@ -14,6 +14,7 @@
 
 #include "tests/cxx/default_tpl_arg-d1.h"
 #include "tests/cxx/default_tpl_arg-d2.h"
+#include "tests/cxx/default_tpl_arg-d3.h"
 #include "tests/cxx/direct.h"
 
 // IWYU: UninstantiatedTpl needs a declaration
@@ -275,6 +276,8 @@ void Fn() {
   // argument doesn't provide it (but the template definition does).
   // IWYU: TplProvidingDefArg4 is...*default_tpl_arg-i1.h
   TplProvidingDefArg4<> tpda41;
+
+  TplProvidingDefArg5Alias tpda5a;
 }
 
 /**** IWYU_SUMMARY
@@ -294,6 +297,7 @@ tests/cxx/default_tpl_arg.cc should remove these lines:
 
 The full include-list for tests/cxx/default_tpl_arg.cc:
 #include "tests/cxx/default_tpl_arg-d2.h"  // for AliasTpl5, DerivedFromProvidedDefArg, DerivedTplProvidingDefArg, FnWithProvidedDefaultTplArg, FnWithProvidedDefaultTplArgAndDefaultCallArg1, FnWithProvidedDefaultTplArgAndDefaultCallArg2, FnWithProvidedDefaultTplArgAndDefaultCallArg3, GetClassTpl2Ref, TplProvidingDefArg, TplProvidingDefArg2, TplProvidingDefArg3, TplProvidingDefArg4
+#include "tests/cxx/default_tpl_arg-d3.h"  // for TplProvidingDefArg5Alias
 #include "tests/cxx/default_tpl_arg-i1.h"  // for AliasTpl1, AliasTpl2, AliasTpl3, AliasTpl4, AliasTpl7, ClassTpl, ClassTpl2, ClassTplNoDefinition, ClassTplWithDefinition, ClassTplWithDefinition2, FnWithNonProvidedDefaultTplArg, FnWithNonProvidedDefaultTplArgAndDefaultCallArg, NonProvidingAlias, SomeTpl, SpecializedClassTpl, TplProvidingDefArg4, UninstantiatedTpl, VarTpl
 #include "tests/cxx/default_tpl_arg-i2.h"  // for AliasTpl7, ClassTpl2, ClassTplWithDefinition2, ClassTplWithDefinition3, ClassTplWithDefinition7
 #include "tests/cxx/indirect.h"  // for IndirectClass, IndirectTemplate


### PR DESCRIPTION
When an aliased type was passed to `GetTplInstData`, `TypeToDeclAsWritten` returned the alias declaration, not the class template declaration, so determination of default argument provision status didn't work correctly.