### PR TITLE
Fix heap buffer overread in ExpandArgsFromBuf

### DIFF
--- a/iwyu_driver.cc
+++ b/iwyu_driver.cc
@@ -149,9 +149,10 @@ void ExpandArgsFromBuf(const char *Arg,
     }
 
     if (*P == '\\') {
-      ++P;
-      if (*P != '\0')
+      if (P[1] != '\0') {
+        ++P;
         CurArg.push_back(*P);
+      }
       continue;
     }
     CurArg.push_back(*P);


### PR DESCRIPTION
If a response file ends with a backslash, the escape-character detection would increment the pointer, then if it's NUL fall through to the next loop iteration which increments the pointer again, past the NUL terminator. It would keep processing until it hit another NUL character, which depends on random data following the response file buffer on the heap.

MemoryBuffer guarantees NUL-termination, so we don't need to consider buffer bounds.

Peek ahead instead, and only increment and store the character if it's non-NUL. This way we do controlled double-increment to skip the backslash, and avoid running over the buffer NUL terminator.

Co-authored-by: 360AlphaLab

Fixes #2105.