### PR TITLE
Remove a couple of `no_include` pragmas

### DIFF
--- a/iwyu.cc
+++ b/iwyu.cc
@@ -125,6 +125,7 @@
 #include "clang/Basic/Specifiers.h"
 #include "clang/Basic/BuiltinTraits.h"
 #include "clang/Frontend/CompilerInstance.h"
+#include "clang/Lex/PPCallbacks.h"
 #include "clang/Lex/Preprocessor.h"
 #include "clang/Sema/Ownership.h"
 #include "clang/Sema/Sema.h"
@@ -149,13 +150,7 @@
 // IWYU pragma: no_include "clang/AST/Redeclarable.h"
 // IWYU pragma: no_include "clang/AST/StmtIterator.h"
 // IWYU pragma: no_include "clang/Basic/CustomizableOptional.h"
-// IWYU pragma: no_include "clang/Lex/PPCallbacks.h"
 // IWYU pragma: no_include "llvm/ADT/iterator.h"
-// IWYU pragma: begin_keep
-namespace clang {
-class PPCallbacks;
-}  // namespace clang
-// IWYU pragma: end_keep
 
 namespace clang {
 class FriendDecl;

--- a/iwyu_location_util.cc
+++ b/iwyu_location_util.cc
@@ -24,9 +24,6 @@
 #include "iwyu_ast_util.h"
 #include "iwyu_string_util.h"
 
-// TODO: Clean out pragmas as IWYU improves.
-// IWYU pragma: no_include "clang/Basic/CustomizableOptional.h"
-
 using clang::BinaryOperator;
 using clang::CXXDependentScopeMemberExpr;
 using clang::CXXMethodDecl;


### PR DESCRIPTION
Suppressing `PPCallbacks.h` was wrong: it is required for `std::unique_ptr<PPCallbacks>` destructor.