### PR TITLE
[ci] Include the LLVM_TAG in LLVM apt repo name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           wget -O- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/llvm-snapshot.asc
           . /etc/os-release
-          REPO_NAME="deb http://apt.llvm.org/${VERSION_CODENAME} llvm-toolchain-${VERSION_CODENAME} main"
+          REPO_NAME="deb http://apt.llvm.org/${VERSION_CODENAME} llvm-toolchain-${VERSION_CODENAME}${LLVM_TAG} main"
           sudo add-apt-repository -y "${REPO_NAME}"
           sudo apt update
           LLVM_TAG="${LLVM_TAG:--$(apt-cache search --names-only '^clang-[0-9]+$' | sort -V | tail -1 | cut -f1 -d" " | cut -f2 -d"-" )}"


### PR DESCRIPTION
The improvements in 632c921ceb7e6105fcb040488e4396b14324a082 accidentally removed the LLVM tag from the repo name. This breaks the procedure we use when taking a release branch: pin LLVM_TAG to the released LLVM version, and have everything expand correctly.

This should have no functional impact on the master branch, since LLVM_TAG is empty for snapshot builds.

This change was already applied on clang_23 in
cced1904e983d8d13ae7369bc4353a295501389d.